### PR TITLE
drag-to-create appointments by clicking and dragging on calendar slots

### DIFF
--- a/frontend/app/components/clinical/AppointmentCalendar.vue
+++ b/frontend/app/components/clinical/AppointmentCalendar.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'slot-click': [date: Date, time: string]
+  'slot-drag-create': [date: Date, startTime: string, endTime: string]
   'appointment-click': [appointment: Appointment]
   'week-change': [weekStart: Date]
   'appointment-move': [appointmentId: string, newDate: string, newStartTime: string, newEndTime: string]
@@ -55,6 +56,15 @@ const dragState = ref<{
   currentDayIndex: number
   currentTop: number
   currentHeight: number
+} | null>(null)
+
+// Create drag state (drag on empty slot to define duration)
+const createDragState = ref<{
+  date: Date
+  dayIndex: number
+  startSlot: number
+  currentSlot: number
+  startY: number
 } | null>(null)
 
 const calendarRef = ref<HTMLElement | null>(null)
@@ -255,10 +265,22 @@ function getStatusIcon(status: Appointment['status']): string {
   }
 }
 
-// Handle slot click
-function handleSlotClick(date: Date, timeSlot: string) {
-  if (dragState.value) return // Don't trigger click during drag
-  emit('slot-click', date, timeSlot)
+// Handle drag-to-create on empty slot
+function startCreateDrag(date: Date, timeSlot: string, dayIndex: number, event: MouseEvent) {
+  if (dragState.value) return
+  event.preventDefault()
+
+  const startSlot = getSlotIndex(timeSlot)
+  createDragState.value = {
+    date,
+    dayIndex,
+    startSlot,
+    currentSlot: startSlot,
+    startY: event.clientY
+  }
+
+  document.addEventListener('mousemove', handleDragMove)
+  document.addEventListener('mouseup', handleDragEnd)
 }
 
 // Handle appointment click
@@ -298,6 +320,17 @@ function startDrag(appointment: Appointment, event: MouseEvent, type: 'move' | '
 }
 
 function handleDragMove(event: MouseEvent) {
+  if (createDragState.value) {
+    const deltaY = event.clientY - createDragState.value.startY
+    const slotDelta = Math.floor(deltaY / SLOT_HEIGHT)
+    const maxSlot = (END_HOUR - START_HOUR) * SLOTS_PER_HOUR - 1
+    createDragState.value.currentSlot = Math.max(
+      createDragState.value.startSlot,
+      Math.min(maxSlot, createDragState.value.startSlot + slotDelta)
+    )
+    return
+  }
+
   if (!dragState.value) return
 
   const deltaY = event.clientY - dragState.value.startY
@@ -337,6 +370,18 @@ function handleDragMove(event: MouseEvent) {
 function handleDragEnd() {
   document.removeEventListener('mousemove', handleDragMove)
   document.removeEventListener('mouseup', handleDragEnd)
+
+  if (createDragState.value) {
+    const { date, startSlot, currentSlot } = createDragState.value
+    createDragState.value = null
+    const startTime = slotIndexToTime(startSlot)
+    if (currentSlot > startSlot) {
+      emit('slot-drag-create', date, startTime, slotIndexToTime(currentSlot + 1))
+    } else {
+      emit('slot-click', date, startTime)
+    }
+    return
+  }
 
   // Only set flag if there was actual movement
   if (hasMoved.value) {
@@ -629,14 +674,14 @@ const allAppointmentsWithDayIndex = computed(() => {
 
             <!-- Day columns -->
             <div
-              v-for="day in weekDays"
+              v-for="(day, dayIdx) in weekDays"
               :key="`${day.toISOString()}-${slot}`"
-              class="h-6 border-r border-gray-100 dark:border-gray-800 last:border-r-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors relative"
+              class="h-6 border-r border-gray-100 dark:border-gray-800 last:border-r-0 cursor-cell hover:bg-primary-50/40 dark:hover:bg-primary-900/10 transition-colors relative"
               :class="{
                 'bg-primary-50/30 dark:bg-primary-900/10': isToday(day),
                 'border-gray-200 dark:border-gray-700': slotIndex % SLOTS_PER_HOUR === 0
               }"
-              @click="handleSlotClick(day, slot)"
+              @mousedown="startCreateDrag(day, slot, dayIdx, $event)"
             />
           </div>
 
@@ -652,6 +697,24 @@ const allAppointmentsWithDayIndex = computed(() => {
                 :key="`appointments-${day.toISOString()}`"
                 class="relative border-r border-gray-100 dark:border-gray-800 last:border-r-0"
               >
+                <!-- Ghost block during drag-to-create -->
+                <div
+                  v-if="createDragState && createDragState.dayIndex === dayIndex"
+                  class="absolute left-1 right-1 rounded border-2 border-dashed border-primary-500 bg-primary-100/60 dark:bg-primary-900/30 pointer-events-none z-40 flex items-start p-1"
+                  :style="{
+                    top: `${createDragState.startSlot * SLOT_HEIGHT}px`,
+                    height: `${Math.max(1, createDragState.currentSlot - createDragState.startSlot + 1) * SLOT_HEIGHT}px`,
+                    minHeight: `${SLOT_HEIGHT}px`
+                  }"
+                >
+                  <span
+                    v-if="createDragState.currentSlot > createDragState.startSlot"
+                    class="text-xs text-primary-700 dark:text-primary-300 font-medium leading-none"
+                  >
+                    {{ slotIndexToTime(createDragState.startSlot) }} – {{ slotIndexToTime(createDragState.currentSlot + 1) }}
+                  </span>
+                </div>
+
                 <div
                   v-for="{ appointment } in allAppointmentsWithDayIndex.filter(a => a.dayIndex === dayIndex)"
                   :key="appointment.id"

--- a/frontend/app/components/clinical/AppointmentDailyView.vue
+++ b/frontend/app/components/clinical/AppointmentDailyView.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'slot-click': [professionalId: string, time: string]
+  'slot-drag-create': [professionalId: string, startTime: string, endTime: string]
   'appointment-click': [appointment: Appointment]
   'date-change': [date: Date]
   'appointment-move': [appointmentId: string, newProfessionalId: string, newStartTime: string, newEndTime: string]
@@ -49,6 +50,15 @@ const dragState = ref<{
   currentProfessionalIndex: number
   currentTop: number
   currentHeight: number
+} | null>(null)
+
+// Create drag state (drag on empty slot to define duration)
+const createDragState = ref<{
+  professionalId: string
+  professionalIndex: number
+  startSlot: number
+  currentSlot: number
+  startY: number
 } | null>(null)
 
 const calendarRef = ref<HTMLElement | null>(null)
@@ -183,10 +193,22 @@ function getStatusIcon(status: Appointment['status']): string {
   }
 }
 
-// Handle slot click
-function handleSlotClick(professionalId: string, timeSlot: string) {
+// Handle drag-to-create on empty slot
+function startCreateDrag(professionalId: string, timeSlot: string, profIndex: number, event: MouseEvent) {
   if (dragState.value) return
-  emit('slot-click', professionalId, timeSlot)
+  event.preventDefault()
+
+  const startSlot = getSlotIndex(timeSlot)
+  createDragState.value = {
+    professionalId,
+    professionalIndex: profIndex,
+    startSlot,
+    currentSlot: startSlot,
+    startY: event.clientY
+  }
+
+  document.addEventListener('mousemove', handleDragMove)
+  document.addEventListener('mouseup', handleDragEnd)
 }
 
 // Handle appointment click
@@ -225,6 +247,17 @@ function startDrag(appointment: Appointment, event: MouseEvent, type: 'move' | '
 }
 
 function handleDragMove(event: MouseEvent) {
+  if (createDragState.value) {
+    const deltaY = event.clientY - createDragState.value.startY
+    const slotDelta = Math.floor(deltaY / SLOT_HEIGHT)
+    const maxSlot = (END_HOUR - START_HOUR) * SLOTS_PER_HOUR - 1
+    createDragState.value.currentSlot = Math.max(
+      createDragState.value.startSlot,
+      Math.min(maxSlot, createDragState.value.startSlot + slotDelta)
+    )
+    return
+  }
+
   if (!dragState.value) return
 
   const deltaY = event.clientY - dragState.value.startY
@@ -258,6 +291,18 @@ function handleDragMove(event: MouseEvent) {
 function handleDragEnd() {
   document.removeEventListener('mousemove', handleDragMove)
   document.removeEventListener('mouseup', handleDragEnd)
+
+  if (createDragState.value) {
+    const { professionalId, startSlot, currentSlot } = createDragState.value
+    createDragState.value = null
+    const startTime = slotIndexToTime(startSlot)
+    if (currentSlot > startSlot) {
+      emit('slot-drag-create', professionalId, startTime, slotIndexToTime(currentSlot + 1))
+    } else {
+      emit('slot-click', professionalId, startTime)
+    }
+    return
+  }
 
   if (hasMoved.value) {
     wasDragging.value = true
@@ -546,11 +591,11 @@ const allAppointmentsWithProfIndex = computed(() => {
 
             <!-- Professional columns -->
             <div
-              v-for="prof in professionals"
+              v-for="(prof, profIdx) in professionals"
               :key="`${prof.id}-${slot}`"
-              class="h-6 border-r border-gray-100 dark:border-gray-800 last:border-r-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors relative"
+              class="h-6 border-r border-gray-100 dark:border-gray-800 last:border-r-0 cursor-cell hover:bg-primary-50/40 dark:hover:bg-primary-900/10 transition-colors relative"
               :class="{ 'border-gray-200 dark:border-gray-700': slotIndex % SLOTS_PER_HOUR === 0 }"
-              @click="handleSlotClick(prof.id, slot)"
+              @mousedown="startCreateDrag(prof.id, slot, profIdx, $event)"
             />
           </div>
 
@@ -569,6 +614,24 @@ const allAppointmentsWithProfIndex = computed(() => {
                 :key="`appointments-${prof.id}`"
                 class="relative border-r border-gray-100 dark:border-gray-800 last:border-r-0"
               >
+                <!-- Ghost block during drag-to-create -->
+                <div
+                  v-if="createDragState && createDragState.professionalIndex === profIndex"
+                  class="absolute left-1 right-1 rounded border-2 border-dashed border-primary-500 bg-primary-100/60 dark:bg-primary-900/30 pointer-events-none z-40 flex items-start p-1"
+                  :style="{
+                    top: `${createDragState.startSlot * SLOT_HEIGHT}px`,
+                    height: `${Math.max(1, createDragState.currentSlot - createDragState.startSlot + 1) * SLOT_HEIGHT}px`,
+                    minHeight: `${SLOT_HEIGHT}px`
+                  }"
+                >
+                  <span
+                    v-if="createDragState.currentSlot > createDragState.startSlot"
+                    class="text-xs text-primary-700 dark:text-primary-300 font-medium leading-none"
+                  >
+                    {{ slotIndexToTime(createDragState.startSlot) }} – {{ slotIndexToTime(createDragState.currentSlot + 1) }}
+                  </span>
+                </div>
+
                 <div
                   v-for="{ appointment } in allAppointmentsWithProfIndex.filter(a => a.profIndex === profIndex)"
                   :key="appointment.id"

--- a/frontend/app/components/clinical/AppointmentModal.vue
+++ b/frontend/app/components/clinical/AppointmentModal.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   appointment?: Appointment | null
   initialDate?: Date
   initialTime?: string
+  initialEndTime?: string
   initialProfessionalId?: string
   existingAppointments?: Appointment[]
 }>()
@@ -287,7 +288,19 @@ watch(() => props.open, async (isOpen) => {
 
       // Reset other fields
       selectedPatient.value = null
-      formData.duration = clinic.slotDuration.value || 30
+      if (props.initialEndTime) {
+        const startParts = formData.startTime.split(':').map(Number)
+        const endParts = props.initialEndTime.split(':').map(Number)
+        const startMin = (startParts[0] ?? 9) * 60 + (startParts[1] ?? 0)
+        const endMin = (endParts[0] ?? 9) * 60 + (endParts[1] ?? 0)
+        const draggedMinutes = endMin - startMin
+        formData.duration = draggedMinutes > 0
+          ? validDurations.reduce((prev, curr) =>
+            Math.abs(curr - draggedMinutes) < Math.abs(prev - draggedMinutes) ? curr : prev)
+          : clinic.slotDuration.value || 30
+      } else {
+        formData.duration = clinic.slotDuration.value || 30
+      }
       formData.cabinet = clinic.cabinets.value[0]?.name || ''
       formData.notes = ''
       selectedTreatments.value = []

--- a/frontend/app/pages/appointments/index.vue
+++ b/frontend/app/pages/appointments/index.vue
@@ -114,6 +114,7 @@ const isModalOpen = ref(false)
 const selectedAppointment = ref<Appointment | null>(null)
 const initialDate = ref<Date | undefined>()
 const initialTime = ref<string | undefined>()
+const initialEndTime = ref<string | undefined>()
 const initialProfessionalId = ref<string | undefined>()
 
 // Get Monday of the current week
@@ -152,6 +153,17 @@ function handleSlotClick(date: Date, time: string) {
   selectedAppointment.value = null
   initialDate.value = date
   initialTime.value = time
+  initialEndTime.value = undefined
+  initialProfessionalId.value = undefined
+  isModalOpen.value = true
+}
+
+// Handle drag-to-create from weekly view - open modal with end time pre-filled
+function handleSlotDragCreate(date: Date, startTime: string, endTime: string) {
+  selectedAppointment.value = null
+  initialDate.value = date
+  initialTime.value = startTime
+  initialEndTime.value = endTime
   initialProfessionalId.value = undefined
   isModalOpen.value = true
 }
@@ -161,6 +173,17 @@ function handleDailySlotClick(professionalId: string, time: string) {
   selectedAppointment.value = null
   initialDate.value = currentDate.value
   initialTime.value = time
+  initialEndTime.value = undefined
+  initialProfessionalId.value = professionalId
+  isModalOpen.value = true
+}
+
+// Handle drag-to-create from daily view - open modal with professional and end time pre-filled
+function handleDailySlotDragCreate(professionalId: string, startTime: string, endTime: string) {
+  selectedAppointment.value = null
+  initialDate.value = currentDate.value
+  initialTime.value = startTime
+  initialEndTime.value = endTime
   initialProfessionalId.value = professionalId
   isModalOpen.value = true
 }
@@ -338,6 +361,7 @@ function handleAppointmentClick(appointment: Appointment) {
   selectedAppointment.value = appointment
   initialDate.value = undefined
   initialTime.value = undefined
+  initialEndTime.value = undefined
   initialProfessionalId.value = undefined
   isModalOpen.value = true
 }
@@ -440,6 +464,7 @@ function openCreateModal() {
   selectedAppointment.value = null
   initialDate.value = viewMode.value === 'day' ? currentDate.value : new Date()
   initialTime.value = '09:00'
+  initialEndTime.value = undefined
   initialProfessionalId.value = undefined
   isModalOpen.value = true
 }
@@ -588,6 +613,7 @@ onMounted(async () => {
         :current-week-start="currentWeekStart"
         :is-loading="isLoading"
         @slot-click="handleSlotClick"
+        @slot-drag-create="handleSlotDragCreate"
         @appointment-click="handleAppointmentClick"
         @week-change="handleWeekChange"
         @appointment-move="handleAppointmentMove"
@@ -602,6 +628,7 @@ onMounted(async () => {
         :current-date="currentDate"
         :is-loading="isLoading"
         @slot-click="handleDailySlotClick"
+        @slot-drag-create="handleDailySlotDragCreate"
         @appointment-click="handleAppointmentClick"
         @date-change="handleDateChange"
         @appointment-move="handleDailyAppointmentMove"
@@ -615,6 +642,7 @@ onMounted(async () => {
       :appointment="selectedAppointment"
       :initial-date="initialDate"
       :initial-time="initialTime"
+      :initial-end-time="initialEndTime"
       :initial-professional-id="initialProfessionalId"
       :existing-appointments="appointments"
       @saved="handleSaved"


### PR DESCRIPTION
## Summary

  - Add drag-to-create interaction on empty time slots in both weekly and daily calendar views
  - Display an animated ghost block with the time range while dragging
  - Open the appointment modal with start and end time pre-filled when releasing the mouse
  - Simple click (no drag) maintains existing behavior — modal opens with default duration

  ## How it works

  1. Click and hold on any empty slot in the calendar
  2. Drag downward to define the duration — a blue dashed block expands showing the time range
  3. Release the mouse — the appointment modal opens with the exact start and end time
  pre-filled

  ## Files changed

  - `frontend/app/components/clinical/AppointmentCalendar.vue` — weekly view
  - `frontend/app/components/clinical/AppointmentDailyView.vue` — daily view
  - `frontend/app/components/clinical/AppointmentModal.vue` — accepts `initialEndTime` prop
  - `frontend/app/pages/appointments/index.vue` — wires up new events and state

  ## Test plan

  - [ ] Click on empty slot → modal opens with default duration (existing behavior unchanged)
  - [ ] Click and drag down on empty slot → ghost block appears while dragging
  - [ ] Ghost block shows correct time range (e.g. `09:00 – 09:45`)
  - [ ] Releasing the mouse opens the modal with start and end time pre-filled
  - [ ] Works in both weekly view and daily view
  - [ ] Existing drag-to-move and drag-to-resize still work correctly