### PR TITLE
fix: cleanup drag event listeners on component unmount

### DIFF
--- a/frontend/app/components/clinical/AppointmentCalendar.vue
+++ b/frontend/app/components/clinical/AppointmentCalendar.vue
@@ -61,6 +61,11 @@ const calendarRef = ref<HTMLElement | null>(null)
 const wasDragging = ref(false)
 const hasMoved = ref(false)
 
+onUnmounted(() => {
+  document.removeEventListener('mousemove', handleDragMove)
+  document.removeEventListener('mouseup', handleDragEnd)
+})
+
 // Generate time slots
 const timeSlots = computed(() => {
   const slots: string[] = []

--- a/frontend/app/components/clinical/AppointmentDailyView.vue
+++ b/frontend/app/components/clinical/AppointmentDailyView.vue
@@ -55,6 +55,11 @@ const calendarRef = ref<HTMLElement | null>(null)
 const wasDragging = ref(false)
 const hasMoved = ref(false)
 
+onUnmounted(() => {
+  document.removeEventListener('mousemove', handleDragMove)
+  document.removeEventListener('mouseup', handleDragEnd)
+})
+
 // Generate time slots
 const timeSlots = computed(() => {
   const slots: string[] = []


### PR DESCRIPTION
## Summary

  Fixes a memory leak reported in #1 (the drag-to-create PR).

  If the component unmounts while the user is dragging, the `mousemove` and `mouseup` event
  listeners attached to `document` were never removed.

  Added `onUnmounted` cleanup in both calendar components:
  - `AppointmentCalendar.vue` (weekly view)
  - `AppointmentDailyView.vue` (daily view)