### PR TITLE
feat(modules): admin module manager UI + reconcile base_revision

### DIFF
--- a/backend/app/core/plugins/operation_log.py
+++ b/backend/app/core/plugins/operation_log.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -37,6 +38,18 @@ class LogEntry:
     step: Step
     status: Status
     details: dict[str, Any] | None
+    created_at: datetime
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "module_name": self.module_name,
+            "operation": self.operation,
+            "step": self.step,
+            "status": self.status,
+            "details": self.details,
+            "created_at": self.created_at.isoformat(),
+        }
 
 
 class OperationLog:
@@ -87,14 +100,20 @@ class OperationLog:
         await self._finalize(log_id, "failed", payload)
 
     async def last_for_module(self, db: AsyncSession, module_name: str) -> LogEntry | None:
+        entries = await self.recent_for_module(db, module_name, limit=1)
+        return entries[0] if entries else None
+
+    async def recent_for_module(
+        self, db: AsyncSession, module_name: str, *, limit: int = 20
+    ) -> list[LogEntry]:
+        """Return most recent log entries for ``module_name`` in desc order."""
         result = await db.execute(
             select(ModuleOperationLog)
             .where(ModuleOperationLog.module_name == module_name)
             .order_by(ModuleOperationLog.id.desc())
-            .limit(1)
+            .limit(limit)
         )
-        row = result.scalar_one_or_none()
-        return _to_entry(row) if row else None
+        return [_to_entry(row) for row in result.scalars()]
 
     async def _finalize(self, log_id: int, status: Status, details: dict[str, Any] | None) -> None:
         async with self._session_factory() as session:
@@ -113,7 +132,8 @@ class OperationLog:
             )
 
 
-def _to_entry(row: ModuleOperationLog) -> LogEntry:
+def log_entry_from_row(row: ModuleOperationLog) -> LogEntry:
+    """Convert an ORM row to a plain ``LogEntry`` dataclass."""
     return LogEntry(
         id=row.id,
         module_name=row.module_name,
@@ -121,4 +141,8 @@ def _to_entry(row: ModuleOperationLog) -> LogEntry:
         step=row.step,
         status=row.status,
         details=dict(row.details) if row.details else None,
+        created_at=row.created_at,
     )
+
+
+_to_entry = log_entry_from_row  # backwards-compatible alias

--- a/backend/app/core/plugins/router.py
+++ b/backend/app/core/plugins/router.py
@@ -134,6 +134,26 @@ async def module_doctor(
     return ApiResponse(data=(await svc.doctor()).to_dict())
 
 
+@router.get("/{name}/-/operations")
+async def module_operations(
+    name: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[None, Depends(require_permission("admin.clinic.read"))],
+    limit: int = 20,
+) -> ApiResponse[list[dict[str, Any]]]:
+    """Return the most recent operation log rows for ``name``.
+
+    ``limit`` is clamped to ``[1, 100]``. 404 if the module is unknown.
+    """
+    clamped = max(1, min(limit, 100))
+    svc = ModuleService(db)
+    try:
+        entries = await svc.operation_log(name, limit=clamped)
+    except ModuleOperationError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ApiResponse(data=[entry.to_dict() for entry in entries])
+
+
 # --- Mutating endpoints --------------------------------------------------
 
 

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -9,18 +9,21 @@ Install, uninstall and upgrade flows arrive in Etapa 3.
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .base import BaseModule
-from .db_models import ModuleRecord
+from .db_models import ModuleOperationLog, ModuleRecord
 from .loader import discover_modules
 from .manifest import Manifest, ManifestError
+from .operation_log import LogEntry, log_entry_from_row
 from .registry import module_registry
 from .state import ModuleCategory, ModuleState
 
@@ -144,6 +147,13 @@ class ModuleService:
                 )
                 continue
 
+            # Resolve the Alembic branch head for modules that ship their
+            # own migrations — without this, uninstall cannot safely
+            # downgrade because the processor only populates
+            # ``base_revision`` during the install flow, which auto-
+            # installed modules never go through.
+            branch_head = _resolve_module_branch_head(module)
+
             record = existing.get(module.name)
             if record is None:
                 self.db.add(
@@ -157,6 +167,8 @@ class ModuleService:
                         installed_at=now,
                         last_state_change=now,
                         manifest_snapshot=manifest.to_snapshot(),
+                        base_revision=branch_head,
+                        applied_revision=branch_head,
                     )
                 )
                 logger.info("Reconciled: inserted new module %s", manifest.name)
@@ -176,6 +188,14 @@ class ModuleService:
             record.category = manifest.category.value
             record.removable = manifest.removable
             record.auto_install = manifest.auto_install
+
+            # Backfill base_revision for modules reconciled before this
+            # logic existed — enables uninstall of already-installed
+            # removable modules.
+            if record.base_revision is None and branch_head is not None:
+                record.base_revision = branch_head
+                if record.applied_revision is None:
+                    record.applied_revision = branch_head
 
         await self.db.commit()
 
@@ -305,6 +325,24 @@ class ModuleService:
             manifest_errors=manifest_errors,
             errored_modules=errored,
         )
+
+    async def operation_log(self, name: str, *, limit: int = 20) -> list[LogEntry]:
+        """Return the most recent log entries for ``name`` (desc by id).
+
+        Raises :class:`ModuleOperationError` if the module is unknown to
+        the DB. ``limit`` is clamped by the caller.
+        """
+        records = await self._load_existing_records()
+        if name not in records:
+            raise ModuleOperationError(f"Unknown module: '{name}'")
+
+        result = await self.db.execute(
+            select(ModuleOperationLog)
+            .where(ModuleOperationLog.module_name == name)
+            .order_by(ModuleOperationLog.id.desc())
+            .limit(limit)
+        )
+        return [log_entry_from_row(row) for row in result.scalars()]
 
     async def orphan(self, name: str) -> bool:
         """Mark a missing-from-disk module as ``uninstalled`` for recovery."""
@@ -506,6 +544,58 @@ class ModuleService:
         except ManifestError as exc:
             logger.error("Manifest error for %s: %s", module.name, exc)
             return None
+
+
+def _resolve_module_branch_head(module: BaseModule) -> str | None:
+    """Return the tip revision of ``module``'s own Alembic branch, if any.
+
+    Modules that ship a ``migrations/versions`` directory alongside their
+    code are the "owners" of every revision file inside it. The head of
+    the module's branch is the module-owned revision that comes first
+    when Alembic walks the full graph from ``heads`` to ``base`` (i.e.
+    the latest descendant of every module revision).
+
+    Returns ``None`` when:
+
+    * the module lives in the legacy main linear chain (no per-module
+      migrations dir),
+    * the module's migrations dir exists but has zero revision files,
+    * the Alembic graph can't be loaded (missing alembic.ini).
+    """
+    spec = importlib.util.find_spec(type(module).__module__)
+    if spec is None or spec.origin is None:
+        return None
+    versions_dir = (Path(spec.origin).parent / "migrations" / "versions").resolve()
+    if not versions_dir.is_dir():
+        return None
+
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    cfg_path = Path(__file__).resolve().parents[3] / "alembic.ini"
+    if not cfg_path.is_file():
+        return None
+
+    try:
+        script = ScriptDirectory.from_config(Config(str(cfg_path)))
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("Could not load Alembic ScriptDirectory: %s", exc)
+        return None
+
+    # walk_revisions yields revisions from head → base. The first one
+    # whose source file lives in this module's versions dir is, by
+    # definition, the latest module-owned revision — the branch head.
+    for rev in script.walk_revisions():
+        rev_path_str = getattr(rev, "path", None)
+        if not rev_path_str:
+            continue
+        try:
+            rev_dir = Path(rev_path_str).resolve().parent
+        except (OSError, ValueError):
+            continue
+        if rev_dir == versions_dir:
+            return rev.revision
+    return None
 
 
 async def rediscover_and_reconcile(db: AsyncSession) -> None:

--- a/backend/tests/test_module_install_flow.py
+++ b/backend/tests/test_module_install_flow.py
@@ -29,8 +29,35 @@ async def _reconcile(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_uninstall_blocked_for_legacy_module(db_session: AsyncSession) -> None:
+async def test_uninstall_blocked_for_non_removable_module(db_session: AsyncSession) -> None:
+    """Non-removable modules must reject uninstall even when they ship an
+    Alembic branch — ``billing`` has its own ``bil_0001`` branch that the
+    service auto-resolves during reconcile."""
     await _reconcile(db_session)
+
+    svc = ModuleService(db_session)
+    with pytest.raises(ModuleOperationError, match="removable=False"):
+        await svc.uninstall("billing")
+
+
+@pytest.mark.asyncio
+async def test_uninstall_blocked_for_legacy_module_without_branch(
+    db_session: AsyncSession,
+) -> None:
+    """Modules whose migrations live in the main linear chain (no
+    per-module ``migrations/versions`` dir) have ``base_revision=None``
+    even after reconcile, so uninstall falls back to the legacy guard."""
+    await _reconcile(db_session)
+
+    # Force a pristine state by wiping base_revision and marking removable.
+    from app.core.plugins.db_models import ModuleRecord
+
+    billing = (
+        await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "billing"))
+    ).scalar_one()
+    billing.base_revision = None
+    billing.removable = True
+    await db_session.commit()
 
     svc = ModuleService(db_session)
     with pytest.raises(ModuleOperationError, match="no Alembic branch"):

--- a/backend/tests/test_module_operations_endpoint.py
+++ b/backend/tests/test_module_operations_endpoint.py
@@ -1,0 +1,195 @@
+"""Tests for GET /api/v1/modules/{name}/-/operations."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic, ClinicMembership
+from app.core.plugins.db_models import ModuleOperationLog, ModuleRecord
+from app.core.plugins.service import ModuleService
+from app.core.plugins.state import ModuleState
+
+
+async def _reconcile(db_session: AsyncSession) -> None:
+    await ModuleService(db_session).reconcile_with_db()
+
+
+async def _register_and_assign(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    *,
+    email: str,
+    role: str,
+) -> str:
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": "TestPass1234",
+            "first_name": "Test",
+            "last_name": "User",
+        },
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+
+    me = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    user_id = me.json()["data"]["user"]["id"]
+
+    clinic = Clinic(
+        id=uuid4(),
+        name=f"Test Clinic for {role}",
+        tax_id=f"B{uuid4().int % 100_000_000:08d}",
+        address={"street": "Test St"},
+        settings={},
+    )
+    db_session.add(clinic)
+    await db_session.flush()
+
+    membership = ClinicMembership(
+        id=uuid4(),
+        user_id=user_id,
+        clinic_id=clinic.id,
+        role=role,
+    )
+    db_session.add(membership)
+    await db_session.commit()
+
+    return token
+
+
+async def _seed_log_rows(db_session: AsyncSession, module_name: str, count: int) -> None:
+    for idx in range(count):
+        db_session.add(
+            ModuleOperationLog(
+                module_name=module_name,
+                operation="install",
+                step=f"step_{idx}",
+                status="completed" if idx % 2 == 0 else "failed",
+                details={"idx": idx},
+            )
+        )
+    await db_session.commit()
+
+
+async def _ensure_module(db_session: AsyncSession, name: str) -> None:
+    existing = await db_session.get(ModuleRecord, name)
+    if existing is not None:
+        return
+    db_session.add(
+        ModuleRecord(
+            name=name,
+            version="0.1.0",
+            state=ModuleState.INSTALLED.value,
+            category="official",
+            removable=True,
+            auto_install=False,
+            manifest_snapshot={"name": name, "version": "0.1.0"},
+        )
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_operations_returns_recent_entries_desc(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _register_and_assign(
+        client, db_session, email="ops-admin@example.com", role="admin"
+    )
+    await _reconcile(db_session)
+    await _ensure_module(db_session, "patients")
+    await _seed_log_rows(db_session, "patients", 5)
+
+    response = await client.get(
+        "/api/v1/modules/patients/-/operations",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 5
+    # Desc by id: latest first.
+    ids = [row["id"] for row in data]
+    assert ids == sorted(ids, reverse=True)
+    # Shape.
+    row = data[0]
+    assert set(row) >= {
+        "id",
+        "module_name",
+        "operation",
+        "step",
+        "status",
+        "details",
+        "created_at",
+    }
+    assert row["module_name"] == "patients"
+
+
+@pytest.mark.asyncio
+async def test_operations_respects_limit_and_clamps(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _register_and_assign(
+        client, db_session, email="ops-limit@example.com", role="admin"
+    )
+    await _reconcile(db_session)
+    await _ensure_module(db_session, "patients")
+    await _seed_log_rows(db_session, "patients", 30)
+
+    # limit below default
+    response = await client.get(
+        "/api/v1/modules/patients/-/operations?limit=3",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == 3
+
+    # limit above cap is clamped to 100 (we have 30 rows, so all 30 returned)
+    response = await client.get(
+        "/api/v1/modules/patients/-/operations?limit=500",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == 30
+
+
+@pytest.mark.asyncio
+async def test_operations_404_on_unknown_module(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _register_and_assign(
+        client, db_session, email="ops-404@example.com", role="admin"
+    )
+    await _reconcile(db_session)
+
+    response = await client.get(
+        "/api/v1/modules/does_not_exist/-/operations",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_operations_forbidden_without_admin_permission(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _register_and_assign(
+        client, db_session, email="ops-hyg@example.com", role="hygienist"
+    )
+    await _reconcile(db_session)
+
+    response = await client.get(
+        "/api/v1/modules/patients/-/operations",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_operations_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/modules/patients/-/operations")
+    assert response.status_code in (401, 403)

--- a/frontend/app/components/settings/modules/ModuleCard.vue
+++ b/frontend/app/components/settings/modules/ModuleCard.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import type { ModuleInfo } from '~/types'
+import type { UiColor } from '~/config/severity'
+import { MODULE_STATE_ROLE } from '~/config/severity'
+
+interface Props {
+  module: ModuleInfo
+  upgradeAvailable?: boolean
+  canWrite: boolean
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  install: [name: string]
+  uninstall: [name: string]
+  upgrade: [name: string]
+  viewDetails: [name: string]
+}>()
+const { t } = useI18n()
+
+const stateRole = computed(() => MODULE_STATE_ROLE[props.module.state] ?? 'neutral')
+const stateLabel = computed(() => t(`settings.modules.state.${camelState(props.module.state)}`))
+const categoryLabel = computed(() => t(`settings.modules.category.${props.module.category}`))
+
+function camelState(state: string): string {
+  return state.replace(/_(.)/g, (_, c) => c.toUpperCase())
+}
+
+const canInstall = computed(
+  () => props.module.state === 'uninstalled' && props.module.in_disk
+)
+// Show uninstall for any installed, removable module. The backend still
+// enforces reverse-dep checks and Alembic safety, surfacing a 400 with a
+// readable reason if removal isn't safe yet — the UI then offers `force`.
+const canUninstall = computed(
+  () => props.module.state === 'installed' && props.module.removable
+)
+const canUpgrade = computed(
+  () => props.module.state === 'installed' && props.upgradeAvailable
+)
+const pending = computed(() =>
+  ['to_install', 'to_upgrade', 'to_remove'].includes(props.module.state)
+)
+
+const categoryColor = computed<UiColor>(() =>
+  props.module.category === 'official' ? 'primary' : 'info'
+)
+</script>
+
+<template>
+  <UCard>
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 flex-wrap">
+          <h3 class="font-semibold text-default">
+            {{ module.name }}
+          </h3>
+          <UBadge
+            :color="categoryColor"
+            variant="subtle"
+            size="xs"
+          >
+            {{ categoryLabel }}
+          </UBadge>
+          <span class="text-caption text-subtle">v{{ module.version }}</span>
+        </div>
+
+        <p
+          v-if="module.summary"
+          class="mt-1 text-sm text-muted line-clamp-2"
+        >
+          {{ module.summary }}
+        </p>
+
+        <div class="mt-3 flex items-center gap-3 flex-wrap">
+          <StatusBadge
+            :role="stateRole"
+            :label="stateLabel"
+            dot
+          />
+          <span
+            v-if="module.depends.length > 0"
+            class="text-caption text-subtle"
+          >
+            {{ t('settings.modules.deps') }}:
+            <code
+              v-for="(dep, idx) in module.depends"
+              :key="dep"
+              class="ml-1"
+            >{{ dep }}{{ idx < module.depends.length - 1 ? ',' : '' }}</code>
+          </span>
+          <span
+            v-else
+            class="text-caption text-subtle"
+          >
+            {{ t('settings.modules.noDeps') }}
+          </span>
+        </div>
+
+        <p
+          v-if="module.error_message"
+          class="mt-2 text-sm text-danger-accent"
+        >
+          <UIcon
+            name="i-lucide-alert-circle"
+            class="w-4 h-4 inline-block mr-1 align-text-bottom"
+          />
+          {{ module.error_message }}
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-2 shrink-0">
+        <UButton
+          variant="ghost"
+          size="xs"
+          icon="i-lucide-info"
+          @click="emit('viewDetails', module.name)"
+        >
+          {{ t('settings.modules.actions.viewDetails') }}
+        </UButton>
+
+        <UButton
+          v-if="canWrite && canInstall && !pending"
+          size="xs"
+          icon="i-lucide-download"
+          @click="emit('install', module.name)"
+        >
+          {{ t('settings.modules.actions.install') }}
+        </UButton>
+
+        <UButton
+          v-if="canWrite && canUpgrade && !pending"
+          size="xs"
+          color="info"
+          icon="i-lucide-arrow-up-circle"
+          @click="emit('upgrade', module.name)"
+        >
+          {{ t('settings.modules.actions.upgrade') }}
+        </UButton>
+
+        <UButton
+          v-if="canWrite && canUninstall && !pending"
+          size="xs"
+          color="error"
+          variant="soft"
+          icon="i-lucide-trash-2"
+          @click="emit('uninstall', module.name)"
+        >
+          {{ t('settings.modules.actions.uninstall') }}
+        </UButton>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/frontend/app/components/settings/modules/ModuleConfirmModal.vue
+++ b/frontend/app/components/settings/modules/ModuleConfirmModal.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import type { UiColor } from '~/config/severity'
+
+type Variant = 'install' | 'uninstall' | 'upgrade' | 'apply'
+
+interface Props {
+  open: boolean
+  variant: Variant
+  moduleName?: string
+  scheduled?: string[]
+  loading?: boolean
+  error?: string | null
+  forceAvailable?: boolean
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'confirm': [force: boolean]
+}>()
+const { t } = useI18n()
+
+const force = ref(false)
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) {
+      force.value = false
+    }
+  }
+)
+
+const iconByVariant: Record<Variant, string> = {
+  install: 'i-lucide-download',
+  uninstall: 'i-lucide-alert-triangle',
+  upgrade: 'i-lucide-arrow-up-circle',
+  apply: 'i-lucide-play'
+}
+
+const iconColorClass: Record<Variant, string> = {
+  install: 'text-primary-accent',
+  uninstall: 'text-danger-accent',
+  upgrade: 'text-info-accent',
+  apply: 'text-primary-accent'
+}
+
+const confirmColor: Record<Variant, UiColor> = {
+  install: 'primary',
+  uninstall: 'error',
+  upgrade: 'info',
+  apply: 'primary'
+}
+
+const titleKey = computed(() => {
+  switch (props.variant) {
+    case 'install':
+      return 'settings.modules.confirmInstall.title'
+    case 'uninstall':
+      return 'settings.modules.confirmUninstall.title'
+    case 'upgrade':
+      return 'settings.modules.confirmUpgrade.title'
+    case 'apply':
+      return 'settings.modules.confirmApply.title'
+  }
+  return 'common.confirm'
+})
+
+const confirmLabelKey = computed(() => {
+  switch (props.variant) {
+    case 'install':
+      return 'settings.modules.actions.install'
+    case 'uninstall':
+      return 'settings.modules.actions.uninstall'
+    case 'upgrade':
+      return 'settings.modules.actions.upgrade'
+    case 'apply':
+      return 'settings.modules.actions.apply'
+  }
+  return 'common.confirm'
+})
+
+function closeModal() {
+  if (!props.loading) {
+    emit('update:open', false)
+  }
+}
+
+function onConfirm() {
+  emit('confirm', force.value)
+}
+</script>
+
+<template>
+  <UModal
+    :open="open"
+    :dismissible="!loading"
+    @update:open="emit('update:open', $event)"
+  >
+    <template #content>
+      <UCard>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon
+              :name="iconByVariant[variant]"
+              class="w-5 h-5"
+              :class="iconColorClass[variant]"
+            />
+            <h3 class="font-semibold text-default">
+              {{ t(titleKey, { name: moduleName ?? '' }) }}
+            </h3>
+          </div>
+        </template>
+
+        <div class="space-y-3">
+          <p
+            v-if="variant === 'install'"
+            class="text-muted"
+          >
+            {{ t('settings.modules.confirmInstall.message', { name: moduleName ?? '' }) }}
+          </p>
+
+          <div
+            v-if="variant === 'install' && scheduled && scheduled.length > 1"
+            class="text-sm text-subtle"
+          >
+            <p class="font-semibold">
+              {{ t('settings.modules.confirmInstall.scheduled') }}
+            </p>
+            <ul class="list-disc pl-5">
+              <li
+                v-for="dep in scheduled"
+                :key="dep"
+              >
+                {{ dep }}
+              </li>
+            </ul>
+          </div>
+
+          <p
+            v-if="variant === 'uninstall'"
+            class="text-muted"
+          >
+            {{ t('settings.modules.confirmUninstall.warning', { name: moduleName ?? '' }) }}
+          </p>
+
+          <p
+            v-if="variant === 'upgrade'"
+            class="text-muted"
+          >
+            {{ t('settings.modules.confirmUpgrade.message', { name: moduleName ?? '' }) }}
+          </p>
+
+          <p
+            v-if="variant === 'apply'"
+            class="text-muted"
+          >
+            {{ t('settings.modules.confirmApply.message') }}
+          </p>
+
+          <div
+            v-if="error"
+            class="rounded-md bg-[var(--color-danger-soft)] p-3 text-sm text-danger-accent"
+          >
+            {{ error }}
+          </div>
+
+          <div
+            v-if="variant === 'uninstall' && forceAvailable"
+            class="pt-2 border-t border-default"
+          >
+            <label class="flex items-start gap-2 cursor-pointer">
+              <UCheckbox v-model="force" />
+              <span class="text-sm">
+                <span class="font-medium text-danger-accent">
+                  {{ t('settings.modules.actions.force') }}
+                </span>
+                <span class="block text-caption text-subtle">
+                  {{ t('settings.modules.confirmUninstall.forceHint') }}
+                </span>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 pt-6">
+          <UButton
+            variant="ghost"
+            :disabled="loading"
+            @click="closeModal"
+          >
+            {{ t('common.cancel') }}
+          </UButton>
+          <UButton
+            :color="confirmColor[variant]"
+            :loading="loading"
+            @click="onConfirm"
+          >
+            {{ t(confirmLabelKey) }}
+          </UButton>
+        </div>
+      </UCard>
+    </template>
+  </UModal>
+</template>

--- a/frontend/app/components/settings/modules/ModuleDetailModal.vue
+++ b/frontend/app/components/settings/modules/ModuleDetailModal.vue
@@ -1,0 +1,251 @@
+<script setup lang="ts">
+import type { ModuleInfo, ModuleOperationLogEntry } from '~/types'
+import type { UiColor } from '~/config/severity'
+
+interface Props {
+  open: boolean
+  module: ModuleInfo | null
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+const { t, d } = useI18n()
+const { operations } = useModuleAdmin()
+
+const logEntries = ref<ModuleOperationLogEntry[]>([])
+const loadingLog = ref(false)
+const logError = ref<string | null>(null)
+
+const manifestJson = computed(() => JSON.stringify(props.module, null, 2))
+
+async function fetchLog() {
+  if (!props.module) {
+    return
+  }
+  loadingLog.value = true
+  logError.value = null
+  try {
+    logEntries.value = await operations(props.module.name, 20)
+  } catch (err: unknown) {
+    const e = err as { data?: { detail?: string }, message?: string }
+    logError.value = e?.data?.detail ?? e?.message ?? 'error'
+    logEntries.value = []
+  } finally {
+    loadingLog.value = false
+  }
+}
+
+watch(
+  () => [props.open, props.module?.name],
+  ([open]) => {
+    if (open && props.module) {
+      fetchLog()
+    }
+  }
+)
+
+function closeModal() {
+  emit('update:open', false)
+}
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return '—'
+  }
+  try {
+    return d(new Date(value), 'short')
+  } catch {
+    return value
+  }
+}
+
+function statusColor(status: string): UiColor {
+  if (status === 'completed') {
+    return 'success'
+  }
+  if (status === 'failed') {
+    return 'error'
+  }
+  return 'neutral'
+}
+</script>
+
+<template>
+  <UModal
+    :open="open"
+    :ui="{ content: 'sm:max-w-3xl' }"
+    @update:open="emit('update:open', $event)"
+  >
+    <template #content>
+      <UCard v-if="module">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <UIcon
+                name="i-lucide-puzzle"
+                class="w-5 h-5 text-primary-accent"
+              />
+              <h3 class="font-semibold text-default">
+                {{ module.name }}
+                <span class="text-caption text-subtle">v{{ module.version }}</span>
+              </h3>
+            </div>
+            <UButton
+              icon="i-lucide-x"
+              variant="ghost"
+              size="xs"
+              @click="closeModal"
+            />
+          </div>
+        </template>
+
+        <div class="space-y-5">
+          <!-- Key facts grid -->
+          <div class="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <p class="text-caption text-subtle">
+                {{ t('settings.modules.detail.state') }}
+              </p>
+              <p class="text-default">
+                {{ module.state }}
+              </p>
+            </div>
+            <div>
+              <p class="text-caption text-subtle">
+                {{ t('settings.modules.detail.category') }}
+              </p>
+              <p class="text-default">
+                {{ t(`settings.modules.category.${module.category}`) }}
+              </p>
+            </div>
+            <div>
+              <p class="text-caption text-subtle">
+                {{ t('settings.modules.detail.installedAt') }}
+              </p>
+              <p class="text-default">
+                {{ formatDate(module.installed_at) }}
+              </p>
+            </div>
+            <div>
+              <p class="text-caption text-subtle">
+                {{ t('settings.modules.detail.lastChange') }}
+              </p>
+              <p class="text-default">
+                {{ formatDate(module.last_state_change) }}
+              </p>
+            </div>
+            <div>
+              <p class="text-caption text-subtle">
+                {{ t('settings.modules.detail.baseRevision') }}
+              </p>
+              <p class="text-default font-mono text-xs">
+                {{ module.base_revision ?? '—' }}
+              </p>
+            </div>
+            <div>
+              <p class="text-caption text-subtle">
+                {{ t('settings.modules.detail.appliedRevision') }}
+              </p>
+              <p class="text-default font-mono text-xs">
+                {{ module.applied_revision ?? '—' }}
+              </p>
+            </div>
+          </div>
+
+          <div
+            v-if="module.error_message"
+            class="rounded-md bg-[var(--color-danger-soft)] p-3 text-sm"
+          >
+            <p class="font-semibold text-danger-accent">
+              {{ t('settings.modules.detail.errorMessage') }}
+            </p>
+            <p class="mt-1 text-danger-accent">
+              {{ module.error_message }}
+            </p>
+          </div>
+
+          <!-- Operation log -->
+          <div>
+            <div class="flex items-center justify-between mb-2">
+              <h4 class="font-semibold text-default">
+                {{ t('settings.modules.detail.operationLog') }}
+              </h4>
+              <UButton
+                size="xs"
+                variant="ghost"
+                icon="i-lucide-refresh-cw"
+                :loading="loadingLog"
+                @click="fetchLog"
+              >
+                {{ t('common.refresh') }}
+              </UButton>
+            </div>
+
+            <div
+              v-if="logError"
+              class="text-sm text-danger-accent"
+            >
+              {{ logError }}
+            </div>
+
+            <div
+              v-else-if="loadingLog && logEntries.length === 0"
+              class="space-y-2"
+            >
+              <USkeleton class="h-6 w-full" />
+              <USkeleton class="h-6 w-full" />
+            </div>
+
+            <p
+              v-else-if="logEntries.length === 0"
+              class="text-caption text-subtle"
+            >
+              {{ t('settings.modules.detail.noOperations') }}
+            </p>
+
+            <div
+              v-else
+              class="space-y-1 max-h-64 overflow-y-auto"
+            >
+              <div
+                v-for="entry in logEntries"
+                :key="entry.id"
+                class="grid grid-cols-12 gap-2 text-xs py-1 border-b border-default last:border-0"
+              >
+                <span class="col-span-3 text-subtle">{{ formatDate(entry.created_at) }}</span>
+                <span class="col-span-2 font-mono">{{ entry.operation }}</span>
+                <span class="col-span-3 font-mono">{{ entry.step }}</span>
+                <span class="col-span-2">
+                  <UBadge
+                    :color="statusColor(entry.status)"
+                    size="xs"
+                    variant="subtle"
+                  >
+                    {{ entry.status }}
+                  </UBadge>
+                </span>
+                <span
+                  v-if="entry.details"
+                  class="col-span-2 truncate text-subtle"
+                  :title="JSON.stringify(entry.details)"
+                >
+                  {{ JSON.stringify(entry.details) }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Raw manifest snapshot -->
+          <details>
+            <summary class="cursor-pointer font-semibold text-default">
+              {{ t('settings.modules.detail.manifest') }}
+            </summary>
+            <pre class="mt-2 text-xs bg-[var(--color-bg-muted)] rounded p-3 overflow-auto max-h-64">{{ manifestJson }}</pre>
+          </details>
+        </div>
+      </UCard>
+    </template>
+  </UModal>
+</template>

--- a/frontend/app/components/settings/modules/ModuleDoctorBanner.vue
+++ b/frontend/app/components/settings/modules/ModuleDoctorBanner.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import type { ModuleDoctorReport } from '~/types'
+
+interface Props {
+  report: ModuleDoctorReport
+}
+
+const props = defineProps<Props>()
+const { t } = useI18n()
+
+const expanded = ref(false)
+
+const counts = computed(() => ({
+  orphans: props.report.orphans.length,
+  missingDeps: props.report.missing_dependencies.length,
+  manifestErrors: props.report.manifest_errors.length,
+  errored: props.report.errored_modules.length
+}))
+</script>
+
+<template>
+  <UAlert
+    color="warning"
+    variant="soft"
+    icon="i-lucide-alert-triangle"
+    :title="t('settings.modules.doctor.banner')"
+  >
+    <template #description>
+      <div class="space-y-2">
+        <div class="flex flex-wrap gap-4 text-sm">
+          <span v-if="counts.orphans > 0">
+            <strong>{{ counts.orphans }}</strong>
+            {{ t('settings.modules.doctor.orphans') }}
+          </span>
+          <span v-if="counts.missingDeps > 0">
+            <strong>{{ counts.missingDeps }}</strong>
+            {{ t('settings.modules.doctor.missingDeps') }}
+          </span>
+          <span v-if="counts.manifestErrors > 0">
+            <strong>{{ counts.manifestErrors }}</strong>
+            {{ t('settings.modules.doctor.manifestErrors') }}
+          </span>
+          <span v-if="counts.errored > 0">
+            <strong>{{ counts.errored }}</strong>
+            {{ t('settings.modules.doctor.errored') }}
+          </span>
+        </div>
+
+        <UButton
+          variant="ghost"
+          size="xs"
+          :icon="expanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+          @click="expanded = !expanded"
+        >
+          {{ expanded ? t('common.hide') : t('common.viewDetails') }}
+        </UButton>
+
+        <div
+          v-if="expanded"
+          class="mt-3 space-y-3 text-sm"
+        >
+          <div v-if="report.orphans.length > 0">
+            <p class="font-semibold">
+              {{ t('settings.modules.doctor.orphans') }}
+            </p>
+            <ul class="list-disc pl-5 text-subtle">
+              <li
+                v-for="name in report.orphans"
+                :key="`orphan-${name}`"
+              >
+                {{ name }}
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="report.missing_dependencies.length > 0">
+            <p class="font-semibold">
+              {{ t('settings.modules.doctor.missingDeps') }}
+            </p>
+            <ul class="list-disc pl-5 text-subtle">
+              <li
+                v-for="entry in report.missing_dependencies"
+                :key="`miss-${entry.module}-${entry.missing}`"
+              >
+                <code>{{ entry.module }}</code> → <code>{{ entry.missing }}</code>
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="report.manifest_errors.length > 0">
+            <p class="font-semibold">
+              {{ t('settings.modules.doctor.manifestErrors') }}
+            </p>
+            <ul class="list-disc pl-5 text-subtle">
+              <li
+                v-for="entry in report.manifest_errors"
+                :key="`manifest-${entry.module}`"
+              >
+                <code>{{ entry.module }}</code>: {{ entry.error }}
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="report.errored_modules.length > 0">
+            <p class="font-semibold">
+              {{ t('settings.modules.doctor.errored') }}
+            </p>
+            <ul class="list-disc pl-5 text-subtle">
+              <li
+                v-for="entry in report.errored_modules"
+                :key="`err-${entry.module}`"
+              >
+                <code>{{ entry.module }}</code>: {{ entry.error }}
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </template>
+  </UAlert>
+</template>

--- a/frontend/app/composables/useModuleAdmin.ts
+++ b/frontend/app/composables/useModuleAdmin.ts
@@ -1,0 +1,149 @@
+/**
+ * Admin-only composable for the module lifecycle API.
+ *
+ * Distinct from `useModules` (backend-driven nav for the sidebar). This
+ * one powers the /settings/modules page: install / uninstall / upgrade /
+ * restart, plus status and doctor polling.
+ */
+
+import type {
+  ApiResponse,
+  ModuleDoctorReport,
+  ModuleInfo,
+  ModuleOperationLogEntry,
+  ModuleOperationResult,
+  ModuleStatus
+} from '~/types'
+
+const MODULES_BASE = '/api/v1/modules'
+
+export function useModuleAdmin() {
+  const api = useApi()
+
+  const modules = ref<ModuleInfo[]>([])
+  const status = ref<ModuleStatus | null>(null)
+  const doctor = ref<ModuleDoctorReport | null>(null)
+  const loading = ref(false)
+  const applying = ref(false)
+  const error = ref<string | null>(null)
+
+  async function refresh(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const [listResp, statusResp, doctorResp] = await Promise.all([
+        api.get<ApiResponse<ModuleInfo[]>>(MODULES_BASE),
+        api.get<ApiResponse<ModuleStatus>>(`${MODULES_BASE}/-/status`),
+        api.get<ApiResponse<ModuleDoctorReport>>(`${MODULES_BASE}/-/doctor`)
+      ])
+      modules.value = listResp.data
+      status.value = statusResp.data
+      doctor.value = doctorResp.data
+    } catch (err: unknown) {
+      error.value = extractMessage(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function install(name: string, force = false): Promise<string[]> {
+    const qs = force ? '?force=true' : ''
+    const response = await api.post<ApiResponse<ModuleOperationResult>>(
+      `${MODULES_BASE}/${encodeURIComponent(name)}/install${qs}`
+    )
+    await refresh()
+    return response.data.scheduled
+  }
+
+  async function uninstall(name: string, force = false): Promise<void> {
+    const qs = force ? '?force=true' : ''
+    await api.post<ApiResponse<ModuleOperationResult>>(
+      `${MODULES_BASE}/${encodeURIComponent(name)}/uninstall${qs}`
+    )
+    await refresh()
+  }
+
+  async function upgrade(name: string): Promise<string[]> {
+    const response = await api.post<ApiResponse<ModuleOperationResult>>(
+      `${MODULES_BASE}/${encodeURIComponent(name)}/upgrade`
+    )
+    await refresh()
+    return response.data.scheduled
+  }
+
+  async function restart(): Promise<void> {
+    applying.value = true
+    try {
+      await api.post<ApiResponse<{ pid: number }>>(`${MODULES_BASE}/-/restart`)
+    } catch (err: unknown) {
+      applying.value = false
+      throw err
+    }
+  }
+
+  /**
+   * Poll /-/status every 2s until `pending=[]` or timeout. Resolves with
+   * the final ModuleStatus. Throws on timeout.
+   */
+  async function pollUntilSettled(timeoutMs = 60_000): Promise<ModuleStatus> {
+    const started = Date.now()
+    let lastError: unknown = null
+    // Initial grace period so SIGTERM has time to happen.
+    await sleep(1_500)
+
+    while (Date.now() - started < timeoutMs) {
+      try {
+        const resp = await api.get<ApiResponse<ModuleStatus>>(`${MODULES_BASE}/-/status`)
+        lastError = null
+        if (resp.data.pending.length === 0) {
+          status.value = resp.data
+          applying.value = false
+          return resp.data
+        }
+      } catch (err) {
+        // 502/503 while the backend restarts is expected; keep polling.
+        lastError = err
+      }
+      await sleep(2_000)
+    }
+
+    applying.value = false
+    if (lastError) {
+      throw lastError
+    }
+    throw new Error('restart-timeout')
+  }
+
+  async function operations(name: string, limit = 20): Promise<ModuleOperationLogEntry[]> {
+    const resp = await api.get<ApiResponse<ModuleOperationLogEntry[]>>(
+      `${MODULES_BASE}/${encodeURIComponent(name)}/-/operations?limit=${limit}`
+    )
+    return resp.data
+  }
+
+  return {
+    modules,
+    status,
+    doctor,
+    loading,
+    applying,
+    error,
+    refresh,
+    install,
+    uninstall,
+    upgrade,
+    restart,
+    pollUntilSettled,
+    operations
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function extractMessage(err: unknown): string {
+  const e = err as { data?: { detail?: string, message?: string }, message?: string }
+  return e?.data?.detail || e?.data?.message || e?.message || 'unknown error'
+}

--- a/frontend/app/config/permissions.ts
+++ b/frontend/app/config/permissions.ts
@@ -80,6 +80,10 @@ export const PERMISSIONS = {
     supervise: 'agents.supervise',
     configure: 'agents.configure',
     manage: 'agents.manage'
+  },
+  admin: {
+    clinicRead: 'admin.clinic.read',
+    clinicWrite: 'admin.clinic.write'
   }
 } as const
 
@@ -88,6 +92,7 @@ export const ROUTE_PERMISSIONS: Record<string, string> = {
   '/patients': PERMISSIONS.patients.read,
   '/appointments': PERMISSIONS.appointments.read,
   '/settings/users': PERMISSIONS.users.write,
+  '/settings/modules': PERMISSIONS.admin.clinicRead,
   '/settings/notifications': PERMISSIONS.notifications.settingsRead,
   '/treatment-plans': PERMISSIONS.treatmentPlans.read,
   '/budgets': PERMISSIONS.budget.read,

--- a/frontend/app/config/severity.ts
+++ b/frontend/app/config/severity.ts
@@ -159,3 +159,26 @@ export const ALERT_SEVERITY_ROLE: Record<AlertSeverity, SemanticRole> = {
   medium: 'info',
   low: 'neutral'
 }
+
+// ---------------------------------------------------------------------------
+// Module lifecycle state (admin module manager)
+// ---------------------------------------------------------------------------
+
+export type ModuleStateKey
+  = | 'installed'
+    | 'uninstalled'
+    | 'to_install'
+    | 'to_upgrade'
+    | 'to_remove'
+    | 'disabled'
+    | 'error'
+
+export const MODULE_STATE_ROLE: Record<ModuleStateKey, SemanticRole> = {
+  installed: 'success',
+  uninstalled: 'neutral',
+  to_install: 'info',
+  to_upgrade: 'info',
+  to_remove: 'warning',
+  disabled: 'neutral',
+  error: 'danger'
+}

--- a/frontend/app/pages/settings/index.vue
+++ b/frontend/app/pages/settings/index.vue
@@ -673,6 +673,31 @@ async function handleSaveClinicInfo() {
           </UButton>
         </NuxtLink>
       </UCard>
+
+      <!-- Modules (admin only) -->
+      <UCard v-if="isAdmin">
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon
+              name="i-lucide-puzzle"
+              class="w-5 h-5 text-primary-accent"
+            />
+            <h2 class="font-semibold text-default">
+              {{ t('settings.modules.title') }}
+            </h2>
+          </div>
+        </template>
+
+        <p class="text-caption text-subtle mb-4">
+          {{ t('settings.modules.description') }}
+        </p>
+
+        <NuxtLink to="/settings/modules">
+          <UButton icon="i-lucide-arrow-right">
+            {{ t('settings.modules.title') }}
+          </UButton>
+        </NuxtLink>
+      </UCard>
     </div>
 
     <!-- User Management (Admin only) -->

--- a/frontend/app/pages/settings/modules/index.vue
+++ b/frontend/app/pages/settings/modules/index.vue
@@ -1,0 +1,339 @@
+<script setup lang="ts">
+import type { ModuleInfo } from '~/types'
+import { PERMISSIONS } from '~/config/permissions'
+
+const { t } = useI18n()
+const toast = useToast()
+const { can } = usePermissions()
+const modulesNav = useModules()
+
+const admin = useModuleAdmin()
+
+const canRead = computed(() => can(PERMISSIONS.admin.clinicRead))
+const canWrite = computed(() => can(PERMISSIONS.admin.clinicWrite))
+
+// Modal state.
+type ConfirmVariant = 'install' | 'uninstall' | 'upgrade' | 'apply'
+const showConfirm = ref(false)
+const confirmVariant = ref<ConfirmVariant>('install')
+const confirmTargetName = ref<string | undefined>(undefined)
+const confirmScheduled = ref<string[]>([])
+const confirmLoading = ref(false)
+const confirmError = ref<string | null>(null)
+const confirmForceAvailable = ref(false)
+
+const showDetail = ref(false)
+const detailModule = ref<ModuleInfo | null>(null)
+
+const restarting = ref(false)
+
+const pendingModules = computed(() =>
+  admin.modules.value.filter(m =>
+    ['to_install', 'to_upgrade', 'to_remove'].includes(m.state)
+  )
+)
+
+const hasDoctorIssues = computed(() => admin.doctor.value?.ok === false)
+
+onMounted(async () => {
+  if (!canRead.value) {
+    return
+  }
+  try {
+    await admin.refresh()
+  } catch (err: unknown) {
+    const e = err as { data?: { detail?: string }, message?: string }
+    toast.add({
+      title: t('common.error'),
+      description: e?.data?.detail ?? e?.message ?? t('common.networkError'),
+      color: 'error'
+    })
+  }
+})
+
+function openInstallConfirm(name: string) {
+  confirmVariant.value = 'install'
+  confirmTargetName.value = name
+  confirmScheduled.value = computeInstallPreview(name)
+  confirmError.value = null
+  confirmForceAvailable.value = false
+  showConfirm.value = true
+}
+
+function openUninstallConfirm(name: string) {
+  confirmVariant.value = 'uninstall'
+  confirmTargetName.value = name
+  confirmScheduled.value = []
+  confirmError.value = null
+  confirmForceAvailable.value = false
+  showConfirm.value = true
+}
+
+function openUpgradeConfirm(name: string) {
+  confirmVariant.value = 'upgrade'
+  confirmTargetName.value = name
+  confirmScheduled.value = []
+  confirmError.value = null
+  confirmForceAvailable.value = false
+  showConfirm.value = true
+}
+
+function openApplyConfirm() {
+  confirmVariant.value = 'apply'
+  confirmTargetName.value = undefined
+  confirmScheduled.value = pendingModules.value.map(m => m.name)
+  confirmError.value = null
+  confirmForceAvailable.value = false
+  showConfirm.value = true
+}
+
+function viewDetails(name: string) {
+  const module = admin.modules.value.find(m => m.name === name)
+  if (!module) {
+    return
+  }
+  detailModule.value = module
+  showDetail.value = true
+}
+
+async function onConfirm(force: boolean) {
+  const name = confirmTargetName.value
+  confirmLoading.value = true
+  confirmError.value = null
+  try {
+    if (confirmVariant.value === 'install' && name) {
+      await admin.install(name, force)
+      toast.add({
+        title: t('settings.modules.toasts.scheduled'),
+        color: 'success'
+      })
+      showConfirm.value = false
+    } else if (confirmVariant.value === 'uninstall' && name) {
+      await admin.uninstall(name, force)
+      toast.add({
+        title: t('settings.modules.toasts.scheduled'),
+        color: 'success'
+      })
+      showConfirm.value = false
+    } else if (confirmVariant.value === 'upgrade' && name) {
+      await admin.upgrade(name)
+      toast.add({
+        title: t('settings.modules.toasts.scheduled'),
+        color: 'success'
+      })
+      showConfirm.value = false
+    } else if (confirmVariant.value === 'apply') {
+      await runApply()
+      showConfirm.value = false
+    }
+  } catch (err: unknown) {
+    const e = err as { data?: { detail?: string }, message?: string }
+    const detail = e?.data?.detail ?? e?.message ?? 'error'
+    confirmError.value = detail
+    // If uninstall was blocked by reverse-deps or removable=false, offer force.
+    if (
+      confirmVariant.value === 'uninstall'
+      && /required by|removable=False/.test(detail)
+    ) {
+      confirmForceAvailable.value = true
+    }
+  } finally {
+    confirmLoading.value = false
+  }
+}
+
+async function runApply() {
+  restarting.value = true
+  try {
+    await admin.restart()
+    await admin.pollUntilSettled()
+    await admin.refresh()
+    await modulesNav.ensureLoaded(true)
+    const erroredCount = admin.status.value?.errored.length ?? 0
+    if (erroredCount > 0) {
+      toast.add({
+        title: t('settings.modules.restart.failed'),
+        description: (admin.status.value?.errored ?? []).join(', '),
+        color: 'error'
+      })
+    } else {
+      toast.add({
+        title: t('settings.modules.toasts.applied'),
+        color: 'success'
+      })
+    }
+  } catch (err: unknown) {
+    const e = err as { data?: { detail?: string }, message?: string }
+    const msg = e?.message === 'restart-timeout'
+      ? t('settings.modules.restart.timeout')
+      : (e?.data?.detail ?? e?.message ?? t('settings.modules.restart.failed'))
+    toast.add({
+      title: t('settings.modules.restart.failed'),
+      description: msg,
+      color: 'error'
+    })
+  } finally {
+    restarting.value = false
+  }
+}
+
+// Rough install preview: module + every uninstalled dep recursively. The
+// authoritative chain is computed server-side and returned in `scheduled`
+// after the install call; this is only for the confirmation modal.
+function computeInstallPreview(name: string): string[] {
+  const byName = new Map(admin.modules.value.map(m => [m.name, m]))
+  const seen = new Set<string>()
+  const out: string[] = []
+  function visit(current: string) {
+    if (seen.has(current)) {
+      return
+    }
+    seen.add(current)
+    const module = byName.get(current)
+    if (!module) {
+      return
+    }
+    for (const dep of module.depends) {
+      const depModule = byName.get(dep)
+      if (depModule && depModule.state !== 'installed') {
+        visit(dep)
+      }
+    }
+    out.push(current)
+  }
+  visit(name)
+  return out
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex items-center gap-3">
+      <UButton
+        to="/settings"
+        variant="ghost"
+        size="sm"
+        icon="i-lucide-arrow-left"
+      >
+        {{ t('settings.title') }}
+      </UButton>
+    </div>
+
+    <div>
+      <h1 class="text-display text-default">
+        {{ t('settings.modules.title') }}
+      </h1>
+      <p class="text-muted mt-1">
+        {{ t('settings.modules.subtitle') }}
+      </p>
+    </div>
+
+    <div
+      v-if="!canRead"
+      class="rounded-md border border-default p-6 text-sm text-muted"
+    >
+      {{ t('common.forbidden', 'Acceso denegado') }}
+    </div>
+
+    <template v-else>
+      <!-- Doctor banner -->
+      <ModuleDoctorBanner
+        v-if="hasDoctorIssues && admin.doctor.value"
+        :report="admin.doctor.value"
+      />
+
+      <!-- Pending changes banner -->
+      <div
+        v-if="pendingModules.length > 0"
+        class="rounded-md border border-[var(--color-info-soft)] bg-[var(--color-info-soft)] px-4 py-3 flex items-center justify-between gap-3 flex-wrap"
+      >
+        <div class="text-sm">
+          <span class="font-semibold">
+            {{ t('settings.modules.pending.banner') }}
+          </span>
+          <span class="ml-1 text-subtle">
+            {{ pendingModules.map(m => m.name).join(', ') }}
+          </span>
+        </div>
+        <UButton
+          v-if="canWrite"
+          color="primary"
+          icon="i-lucide-play"
+          :loading="restarting"
+          @click="openApplyConfirm"
+        >
+          {{ t('settings.modules.pending.apply') }}
+        </UButton>
+      </div>
+
+      <!-- Loading skeleton -->
+      <div
+        v-if="admin.loading.value && admin.modules.value.length === 0"
+        class="space-y-3"
+      >
+        <USkeleton class="h-24 w-full" />
+        <USkeleton class="h-24 w-full" />
+        <USkeleton class="h-24 w-full" />
+      </div>
+
+      <!-- Error state -->
+      <UAlert
+        v-else-if="admin.error.value && admin.modules.value.length === 0"
+        color="error"
+        icon="i-lucide-x-circle"
+        :title="t('common.error')"
+        :description="admin.error.value"
+        :actions="[{ label: t('common.retry'), onClick: () => admin.refresh() }]"
+      />
+
+      <!-- Module list -->
+      <div
+        v-else
+        class="space-y-3"
+      >
+        <ModuleCard
+          v-for="module in admin.modules.value"
+          :key="module.name"
+          :module="module"
+          :can-write="canWrite"
+          @install="openInstallConfirm"
+          @uninstall="openUninstallConfirm"
+          @upgrade="openUpgradeConfirm"
+          @view-details="viewDetails"
+        />
+      </div>
+    </template>
+
+    <!-- Confirmation modal -->
+    <ModuleConfirmModal
+      v-model:open="showConfirm"
+      :variant="confirmVariant"
+      :module-name="confirmTargetName"
+      :scheduled="confirmScheduled"
+      :loading="confirmLoading"
+      :error="confirmError"
+      :force-available="confirmForceAvailable"
+      @confirm="onConfirm"
+    />
+
+    <!-- Detail modal -->
+    <ModuleDetailModal
+      v-model:open="showDetail"
+      :module="detailModule"
+    />
+
+    <!-- Restart overlay -->
+    <div
+      v-if="restarting"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-bg-muted)]/80 backdrop-blur-sm"
+    >
+      <div class="rounded-md border border-default bg-[var(--color-bg-surface)] p-6 flex items-center gap-3">
+        <UIcon
+          name="i-lucide-loader-2"
+          class="w-6 h-6 animate-spin text-primary-accent"
+        />
+        <span class="text-default">{{ t('settings.modules.restart.inProgress') }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -315,6 +315,72 @@ export interface ActiveModule {
   permissions: string[]
 }
 
+// --- Module lifecycle (admin) — backend /api/v1/modules/* ----------------
+
+export type ModuleState
+  = | 'installed'
+    | 'uninstalled'
+    | 'to_install'
+    | 'to_upgrade'
+    | 'to_remove'
+    | 'disabled'
+    | 'error'
+
+export type ModuleCategory = 'official' | 'community'
+
+// Shape returned by GET /api/v1/modules and /api/v1/modules/{name}.
+export interface ModuleInfo {
+  name: string
+  version: string
+  state: ModuleState
+  category: ModuleCategory
+  removable: boolean
+  auto_install: boolean
+  installed_at: string | null
+  last_state_change: string
+  base_revision: string | null
+  applied_revision: string | null
+  error_message: string | null
+  error_at: string | null
+  summary: string
+  depends: string[]
+  in_disk: boolean
+}
+
+// Shape returned by GET /api/v1/modules/-/status.
+export interface ModuleStatus {
+  by_state: Record<string, number>
+  pending: string[]
+  errored: string[]
+  total: number
+}
+
+// Shape returned by GET /api/v1/modules/-/doctor.
+export interface ModuleDoctorReport {
+  ok: boolean
+  orphans: string[]
+  missing_dependencies: Array<{ module: string, missing: string }>
+  manifest_errors: Array<{ module: string, error: string }>
+  errored_modules: Array<{ module: string, error: string }>
+}
+
+// Shape returned by mutating endpoints (install/uninstall/upgrade).
+export interface ModuleOperationResult {
+  scheduled: string[]
+  requires_restart: boolean
+}
+
+// Shape returned by GET /api/v1/modules/{name}/-/operations.
+export interface ModuleOperationLogEntry {
+  id: number
+  module_name: string
+  operation: 'install' | 'uninstall' | 'upgrade'
+  step: string
+  status: 'started' | 'completed' | 'failed'
+  details: Record<string, unknown> | null
+  created_at: string
+}
+
 // Permission config for centralized management
 export interface PermissionConfig {
   routes: Record<string, string> // path -> permission

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -838,6 +838,85 @@
       "userCreated": "User created successfully",
       "userUpdated": "User updated successfully",
       "userDeleted": "User removed from clinic"
+    },
+    "modules": {
+      "title": "Modules",
+      "subtitle": "Install, uninstall and upgrade clinic modules.",
+      "description": "Manage which modules are active in your clinic.",
+      "deps": "Dependencies",
+      "noDeps": "No dependencies",
+      "state": {
+        "installed": "Installed",
+        "uninstalled": "Not installed",
+        "toInstall": "Pending install",
+        "toUpgrade": "Pending upgrade",
+        "toRemove": "Pending removal",
+        "disabled": "Disabled",
+        "error": "Error"
+      },
+      "category": {
+        "official": "Official",
+        "community": "Community"
+      },
+      "actions": {
+        "install": "Install",
+        "uninstall": "Uninstall",
+        "upgrade": "Upgrade",
+        "apply": "Apply changes",
+        "viewDetails": "Details",
+        "force": "Force uninstall"
+      },
+      "confirmInstall": {
+        "title": "Install {name}?",
+        "message": "The module will be scheduled for install and become active after applying changes.",
+        "scheduled": "These dependencies will also be installed:"
+      },
+      "confirmUninstall": {
+        "title": "Uninstall {name}?",
+        "warning": "The module tables will be removed. A pg_dump backup is created first so data can be recovered.",
+        "forceHint": "Ignores dependent modules. Only use this if you know what you're doing."
+      },
+      "confirmUpgrade": {
+        "title": "Upgrade {name}?",
+        "message": "The module will be upgraded to the on-disk manifest version when changes are applied."
+      },
+      "confirmApply": {
+        "title": "Apply changes",
+        "message": "The backend will restart. The session may be briefly interrupted while pending operations run."
+      },
+      "pending": {
+        "banner": "Pending changes:",
+        "apply": "Apply changes"
+      },
+      "doctor": {
+        "banner": "Issues detected in the module system.",
+        "orphans": "orphan modules",
+        "missingDeps": "missing dependencies",
+        "manifestErrors": "manifest errors",
+        "errored": "errored modules"
+      },
+      "detail": {
+        "state": "State",
+        "category": "Category",
+        "installedAt": "Installed at",
+        "lastChange": "Last change",
+        "baseRevision": "Base revision",
+        "appliedRevision": "Applied revision",
+        "manifest": "Full manifest",
+        "errorMessage": "Error message",
+        "operationLog": "Operation log",
+        "noOperations": "No operations recorded."
+      },
+      "restart": {
+        "inProgress": "Restarting backend…",
+        "done": "Changes applied",
+        "failed": "Failed to apply changes",
+        "timeout": "Timed out waiting for backend"
+      },
+      "toasts": {
+        "scheduled": "Operation scheduled. Apply changes to complete.",
+        "applied": "Changes applied successfully."
+      }
     }
   },
   "selector": {
@@ -861,6 +940,9 @@
     "success": "Success",
     "completed": "Completed",
     "retry": "Retry",
+    "refresh": "Refresh",
+    "hide": "Hide",
+    "forbidden": "Access denied",
     "confirm": "Confirm",
     "yes": "Yes",
     "no": "No",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -859,6 +859,85 @@
       "userCreated": "Usuario creado correctamente",
       "userUpdated": "Usuario actualizado correctamente",
       "userDeleted": "Usuario eliminado de la clínica"
+    },
+    "modules": {
+      "title": "Módulos",
+      "subtitle": "Instala, desinstala y actualiza los módulos de la clínica.",
+      "description": "Gestiona qué módulos están activos en tu clínica.",
+      "deps": "Dependencias",
+      "noDeps": "Sin dependencias",
+      "state": {
+        "installed": "Instalado",
+        "uninstalled": "No instalado",
+        "toInstall": "Pendiente de instalar",
+        "toUpgrade": "Pendiente de actualizar",
+        "toRemove": "Pendiente de eliminar",
+        "disabled": "Desactivado",
+        "error": "Error"
+      },
+      "category": {
+        "official": "Oficial",
+        "community": "Comunidad"
+      },
+      "actions": {
+        "install": "Instalar",
+        "uninstall": "Desinstalar",
+        "upgrade": "Actualizar",
+        "apply": "Aplicar cambios",
+        "viewDetails": "Detalles",
+        "force": "Forzar desinstalación"
+      },
+      "confirmInstall": {
+        "title": "¿Instalar {name}?",
+        "message": "El módulo se marcará para instalar y quedará activo tras aplicar los cambios.",
+        "scheduled": "Se instalarán también estas dependencias:"
+      },
+      "confirmUninstall": {
+        "title": "¿Desinstalar {name}?",
+        "warning": "Se eliminarán las tablas del módulo. Antes se creará un backup pg_dump automático para poder recuperar los datos.",
+        "forceHint": "Ignora los módulos dependientes. Úsalo solo si sabes lo que haces."
+      },
+      "confirmUpgrade": {
+        "title": "¿Actualizar {name}?",
+        "message": "El módulo se actualizará a la versión declarada en disco al aplicar los cambios."
+      },
+      "confirmApply": {
+        "title": "Aplicar cambios",
+        "message": "El backend se reiniciará. La sesión puede interrumpirse unos segundos mientras se procesan las operaciones pendientes."
+      },
+      "pending": {
+        "banner": "Cambios pendientes:",
+        "apply": "Aplicar cambios"
+      },
+      "doctor": {
+        "banner": "Se han detectado problemas en el sistema de módulos.",
+        "orphans": "módulos huérfanos",
+        "missingDeps": "dependencias faltantes",
+        "manifestErrors": "errores de manifiesto",
+        "errored": "módulos con error"
+      },
+      "detail": {
+        "state": "Estado",
+        "category": "Categoría",
+        "installedAt": "Instalado el",
+        "lastChange": "Último cambio",
+        "baseRevision": "Revisión base",
+        "appliedRevision": "Revisión aplicada",
+        "manifest": "Manifest completo",
+        "errorMessage": "Mensaje de error",
+        "operationLog": "Log de operaciones",
+        "noOperations": "Sin operaciones registradas."
+      },
+      "restart": {
+        "inProgress": "Reiniciando backend…",
+        "done": "Cambios aplicados",
+        "failed": "Error al aplicar cambios",
+        "timeout": "Timeout esperando al backend"
+      },
+      "toasts": {
+        "scheduled": "Operación programada. Aplica los cambios para completarla.",
+        "applied": "Cambios aplicados correctamente."
+      }
     }
   },
   "selector": {
@@ -883,6 +962,9 @@
     "success": "Éxito",
     "completed": "Completado",
     "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "hide": "Ocultar",
+    "forbidden": "Acceso denegado",
     "confirm": "Confirmar",
     "yes": "Sí",
     "no": "No",

--- a/frontend/tests/e2e/settings-modules.spec.ts
+++ b/frontend/tests/e2e/settings-modules.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from './_fixtures'
+
+/**
+ * Smoke for the admin module manager at /settings/modules.
+ * - Admin can reach the page and see the module list.
+ * - Non-admin cannot (page shows a forbidden message).
+ */
+
+test.describe('admin sees module manager', () => {
+  test.use({ role: 'admin' })
+
+  test('admin loads /settings/modules and sees module cards', async ({ loggedIn }) => {
+    await loggedIn.goto('/settings/modules')
+
+    // Page title (ES or EN, depending on user locale).
+    await expect(
+      loggedIn.getByRole('heading', { level: 1, name: /módulos|modules/i })
+    ).toBeVisible()
+
+    // At least one of the core modules must be listed — they are always
+    // discovered, so this is a deterministic smoke check.
+    await expect(
+      loggedIn.getByRole('heading', { level: 3, name: /^patients$/ })
+    ).toBeVisible()
+  })
+})
+
+test.describe('hygienist cannot reach module manager', () => {
+  test.use({ role: 'hygienist' })
+
+  test('hygienist sees forbidden message, no module cards', async ({ loggedIn }) => {
+    await loggedIn.goto('/settings/modules')
+
+    // No module cards rendered.
+    await expect(
+      loggedIn.getByRole('heading', { level: 3, name: /^patients$/ })
+    ).toHaveCount(0)
+
+    // The page renders a forbidden fallback.
+    await expect(
+      loggedIn.getByText(/acceso denegado|access denied/i)
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- `/settings/modules` admin page — install, uninstall, upgrade, restart.
- Consumes existing `/api/v1/modules/*` core plugin API. Zero coupling to any module.
- Backend addition: `GET /modules/{name}/-/operations` for the detail drawer; `reconcile_with_db` now auto-resolves each module's Alembic branch head so removable modules can actually be uninstalled.
- Permissions gated by `admin.clinic.read` (view) / `admin.clinic.write` (mutate).

Closes part 1 of #47.

## Test plan

- [x] Backend pytest — 423 passed (5 new for `/operations`, 2 new for the legacy/non-removable uninstall split).
- [x] Playwright — 18 passed (2 new for `/settings/modules` admin access + hygienist forbidden).
- [x] ESLint / ruff clean.
- [x] Manual: admin can see Uninstall button on `schedules`, `patient_timeline`, `patients_clinical`; hygienist sees "Acceso denegado".

🤖 Generated with [Claude Code](https://claude.com/claude-code)