### PR TITLE
fix(plugins): unblock restart + alembic under uvicorn --reload

### DIFF
--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -421,24 +421,35 @@ def _has_branch(module: BaseModule) -> bool:
 
 
 def _alembic_cmd(args: list[str]) -> str | None:
-    """Run an Alembic command in-process and return the resulting head.
+    """Run an Alembic command in a subprocess and return the target head.
 
-    Runs in the backend container via the same Python interpreter so we
-    don't spawn a subprocess. Returns the head revision name after the
-    command completed (or ``None`` if not determinable).
+    Previously this called ``alembic.command.X`` in-process, but our
+    ``alembic/env.py`` uses ``asyncio.run()`` to run async migrations —
+    which crashes with ``RuntimeError: asyncio.run() cannot be called
+    from a running event loop`` when the lifespan invokes it. A
+    subprocess gives Alembic a fresh interpreter with no parent loop.
+
+    ``args`` is forwarded verbatim to the ``alembic`` CLI (e.g.
+    ``["upgrade", "schedules@head"]`` or ``["downgrade", "base"]``).
     """
+    cfg_path = Path(__file__).resolve().parents[3] / "alembic.ini"
+    backend_root = cfg_path.parent
+
+    try:
+        subprocess.run(
+            ["alembic", "-c", str(cfg_path), *args],
+            cwd=str(backend_root),
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"alembic {' '.join(args)} failed with exit code {exc.returncode}"
+        ) from exc
+
+    # Resolve the current head so the caller can persist applied_revision.
+    # We still import ScriptDirectory in-process (no asyncio involved).
     from alembic.config import Config
     from alembic.script import ScriptDirectory
 
-    from alembic import command
-
-    # Production layout: alembic.ini sits at backend/alembic.ini.
-    cfg_path = Path(__file__).resolve().parents[3] / "alembic.ini"
-    cfg = Config(str(cfg_path))
-
-    command_name, *command_args = args
-    getattr(command, command_name)(cfg, *command_args)
-
-    script = ScriptDirectory.from_config(cfg)
-    head = script.get_current_head()
-    return head
+    script = ScriptDirectory.from_config(Config(str(cfg_path)))
+    return script.get_current_head()

--- a/backend/app/core/plugins/router.py
+++ b/backend/app/core/plugins/router.py
@@ -219,12 +219,18 @@ async def restart_backend(
     background_tasks: BackgroundTasks,
     _: Annotated[None, Depends(require_permission("admin.clinic.write"))],
 ) -> ApiResponse[dict[str, Any]]:
-    """Send SIGTERM to the backend process so Docker respawns it.
+    """Send SIGTERM to container PID 1 so Docker respawns the process.
 
     The endpoint returns immediately; the actual shutdown runs in a
     background task with a small delay so the HTTP response flushes
     first. The container must have ``restart: unless-stopped`` set for
     the respawn to happen (see ``docker-compose.yml``).
+
+    We target PID 1 rather than ``os.getpid()`` because under uvicorn's
+    ``--reload`` (dev mode) the supervisor is PID 1 and the app worker
+    is a child — killing only the worker leaves the supervisor idle
+    without spawning a replacement. In production (no ``--reload``)
+    PID 1 *is* the worker, so the same kill works identically.
     """
     background_tasks.add_task(_graceful_exit)
     return ApiResponse(
@@ -235,5 +241,10 @@ async def restart_backend(
 
 async def _graceful_exit() -> None:
     await asyncio.sleep(0.5)
-    logger.info("Sending SIGTERM to self (pid=%s) for module restart", os.getpid())
-    os.kill(os.getpid(), signal.SIGTERM)
+    logger.info("Sending SIGTERM to PID 1 (current pid=%s) for module restart", os.getpid())
+    try:
+        os.kill(1, signal.SIGTERM)
+    except PermissionError:
+        # Fallback: signal self. Works in prod where we are PID 1.
+        logger.warning("No permission to signal PID 1; signalling self instead")
+        os.kill(os.getpid(), signal.SIGTERM)


### PR DESCRIPTION
## Summary

Two contributory fixes for the \`POST /modules/-/restart\` flow that surfaced the first time the admin UI (PR #54) exercised it end-to-end:

- **SIGTERM to PID 1**: under \`uvicorn --reload\`, PID 1 is the supervisor and the app is a child. Killing \`os.getpid()\` left the supervisor idle. Signaling PID 1 works in both dev and prod.
- **Alembic via subprocess**: \`alembic.command.X()\` in-process crashed with \`RuntimeError: asyncio.run() cannot be called from a running event loop\` because \`env.py\` uses \`asyncio.run()\`. Matches what \`test_alembic_roundtrip\` already does.

The remaining uninstall-pipeline bugs (wrong downgrade target, Fase A linear chain, missing \`pg_dump\`) are tracked in #56.

## Test plan

- [x] 18 module tests pass (test_module_install_flow, test_module_service, test_module_operations_endpoint).
- [x] Ruff clean.
- [x] Manual: click "Aplicar cambios" on /settings/modules → backend respawns → pending ops processed → toast success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)