### PR TITLE
feat(currency): unify currency as clinic-level setting (#68)

### DIFF
--- a/backend/alembic/versions/0005_clinic_currency.py
+++ b/backend/alembic/versions/0005_clinic_currency.py
@@ -1,0 +1,58 @@
+"""core — add clinics.currency column.
+
+Currency is a clinic-level concern (one clinic, one currency). Until
+now it was either hard-coded as ``"EUR"`` on each Budget/Invoice/
+catalog row or stored loosely under ``clinics.settings.currency``.
+
+This migration promotes currency to a first-class typed column on
+``clinics`` (ISO 4217, default ``EUR``), backfills from any pre-
+existing JSONB key, and removes that key so there is no drift.
+
+The redundant ``currency`` columns on Budget, Invoice, catalog and
+the odontogram snapshot are dropped by per-module follow-up
+migrations on each module's chain — every module owns the lifecycle
+of its own table.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "clinics",
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default="EUR",
+        ),
+    )
+    # Backfill from the pre-existing JSONB key when it looks like a
+    # valid ISO 4217 code (3 letters). Anything else stays as default.
+    op.execute(
+        """
+        UPDATE clinics
+        SET currency = upper(settings->>'currency')
+        WHERE settings ? 'currency'
+          AND settings->>'currency' ~ '^[A-Za-z]{3}$';
+        """
+    )
+    # Remove the JSONB key — the typed column is now the source of truth.
+    op.execute("UPDATE clinics SET settings = settings - 'currency';")
+
+
+def downgrade() -> None:
+    op.drop_column("clinics", "currency")

--- a/backend/app/core/auth/models.py
+++ b/backend/app/core/auth/models.py
@@ -32,6 +32,9 @@ class Clinic(Base, TimestampMixin):
     timezone: Mapped[str] = mapped_column(
         String(64), nullable=False, server_default="Europe/Madrid"
     )
+    # ISO 4217 currency code. Single source of truth for any module
+    # that renders money — budgets, invoices, catalog, reports.
+    currency: Mapped[str] = mapped_column(String(3), nullable=False, server_default="EUR")
     settings: Mapped[dict] = mapped_column(JSONB, default=dict)
 
     # Relationships

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -593,9 +593,23 @@ async def update_clinic_metadata(
         clinic.address = {**existing_address, **new_address}
     if data.timezone is not None:
         clinic.timezone = data.timezone
+    if data.currency is not None:
+        clinic.currency = data.currency
 
     await db.commit()
-    await db.refresh(clinic)
+    # Re-query with cabinets eagerly loaded so ClinicMetadataResponse
+    # serialization doesn't trigger an async lazy load. The response
+    # always returns the full metadata shape including cabinets.
+    from app.modules.agenda.models import Cabinet as _Cabinet
+    from app.core.auth.models import Clinic as _ClinicModel
+
+    result = await db.execute(
+        select(_ClinicModel)
+        .where(_ClinicModel.id == clinic.id)
+        .options(selectinload(_ClinicModel.cabinets))
+    )
+    clinic = result.scalar_one()
+    _ = _Cabinet  # keep the import live for forward refs
 
     return ApiResponse(data=ClinicMetadataResponse.model_validate(clinic))
 

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -18,7 +18,7 @@ from app.core.schemas import ApiResponse, PaginatedApiResponse
 from app.database import get_db
 
 from .dependencies import ClinicContext, get_clinic_context, get_current_user, require_permission
-from .models import ClinicMembership, User
+from .models import Clinic, ClinicMembership, User
 from .permissions import CORE_PERMISSIONS, ROLES, expand_permissions, get_role_permissions
 from .schemas import (
     AuthResponse,
@@ -600,16 +600,10 @@ async def update_clinic_metadata(
     # Re-query with cabinets eagerly loaded so ClinicMetadataResponse
     # serialization doesn't trigger an async lazy load. The response
     # always returns the full metadata shape including cabinets.
-    from app.modules.agenda.models import Cabinet as _Cabinet
-    from app.core.auth.models import Clinic as _ClinicModel
-
     result = await db.execute(
-        select(_ClinicModel)
-        .where(_ClinicModel.id == clinic.id)
-        .options(selectinload(_ClinicModel.cabinets))
+        select(Clinic).where(Clinic.id == clinic.id).options(selectinload(Clinic.cabinets))
     )
     clinic = result.scalar_one()
-    _ = _Cabinet  # keep the import live for forward refs
 
     return ApiResponse(data=ClinicMetadataResponse.model_validate(clinic))
 

--- a/backend/app/core/auth/schemas.py
+++ b/backend/app/core/auth/schemas.py
@@ -82,6 +82,7 @@ class ClinicMetadataUpdate(BaseModel):
     phone: str | None = Field(default=None, max_length=20)
     email: EmailStr | None = None
     timezone: str | None = Field(default=None, max_length=64)
+    currency: str | None = Field(default=None, pattern="^[A-Z]{3}$")
 
     @field_validator("timezone")
     @classmethod
@@ -128,6 +129,7 @@ class ClinicMetadataResponse(BaseModel):
     phone: str | None
     email: str | None
     timezone: str
+    currency: str
     settings: dict
     cabinets: list[_ClinicCabinetBrief]
 

--- a/backend/app/core/utils/currency.py
+++ b/backend/app/core/utils/currency.py
@@ -1,0 +1,24 @@
+"""Locale-aware currency formatting.
+
+Single helper used by every server-rendered surface (PDFs, emails,
+report exports) so the format is consistent and never reinvents
+symbols, separators, or decimal places. Wraps ``babel.numbers`` —
+the standard for ICU-quality formatting in Python.
+"""
+
+from decimal import Decimal
+
+from babel.numbers import format_currency as _babel_format_currency
+
+
+def format_currency(
+    amount: Decimal | float | int,
+    currency: str,
+    locale: str = "es_ES",
+) -> str:
+    """Render ``amount`` as a localized currency string.
+
+    ``locale`` accepts both BCP 47 (``en-US``) and POSIX (``en_US``);
+    babel only accepts the latter, so we normalize.
+    """
+    return _babel_format_currency(amount, currency, locale=locale.replace("-", "_"))

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
@@ -296,7 +296,6 @@ watch(() => props.open, async (isOpen) => {
           status: 'planned',
           catalog_item_id: t.catalog_item_id,
           price_snapshot: t.default_price ? String(t.default_price) : null,
-          currency_snapshot: 'EUR',
           teeth: t.tooth_number
             ? [{
                 tooth_number: t.tooth_number,
@@ -310,8 +309,7 @@ watch(() => props.open, async (isOpen) => {
               id: t.catalog_item_id,
               internal_code: t.internal_code,
               names: t.names,
-              default_price: t.default_price != null ? String(t.default_price) : null,
-              currency: 'EUR'
+              default_price: t.default_price != null ? String(t.default_price) : null
             }
           : undefined,
         media: []

--- a/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
+++ b/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
@@ -3,7 +3,6 @@ import type { InvoiceItem, InvoiceItemCreate, TreatmentCatalogItem, VatType } fr
 
 const props = defineProps<{
   invoiceId: string
-  currency?: string
   editItem?: InvoiceItem // If provided, modal is in edit mode
 }>()
 
@@ -273,7 +272,6 @@ watch(open, async (isOpen) => {
             >
               <TreatmentVisualSelector
                 :model-value="selectedItem"
-                :currency="currency"
                 :in-modal="true"
                 @update:model-value="handleItemSelect"
               />
@@ -376,7 +374,7 @@ watch(open, async (isOpen) => {
             >
               <span class="text-muted">{{ t('budget.items.lineTotal') }}</span>
               <span class="text-h1 tnum text-default">
-                {{ formatPrice(previewTotal, currency || 'EUR') }}
+                {{ formatPrice(previewTotal) }}
               </span>
             </div>
           </form>

--- a/backend/app/modules/billing/frontend/components/billing/NewInvoiceItemModal.vue
+++ b/backend/app/modules/billing/frontend/components/billing/NewInvoiceItemModal.vue
@@ -3,7 +3,6 @@ import type { InvoiceItemCreate, TreatmentCatalogItem, VatType } from '~~/app/ty
 
 const props = defineProps<{
   open: boolean
-  currency?: string
 }>()
 
 const emit = defineEmits<{
@@ -197,7 +196,6 @@ watch(() => props.open, async (isOpen) => {
             >
               <TreatmentVisualSelector
                 :model-value="selectedItem"
-                :currency="currency"
                 :in-modal="true"
                 @update:model-value="handleItemSelect"
               />
@@ -300,7 +298,7 @@ watch(() => props.open, async (isOpen) => {
             >
               <span class="text-muted">{{ t('budget.items.lineTotal') }}</span>
               <span class="text-h1 tnum text-default">
-                {{ formatPrice(previewTotal, currency || 'EUR') }}
+                {{ formatPrice(previewTotal) }}
               </span>
             </div>
           </form>

--- a/backend/app/modules/billing/frontend/components/clinical/PatientBillingSummary.vue
+++ b/backend/app/modules/billing/frontend/components/clinical/PatientBillingSummary.vue
@@ -52,13 +52,8 @@ async function toggleInvoice(invoiceId: string) {
   }
 }
 
-// Format currency
-function formatCurrency(amount: number, currency: string = 'EUR'): string {
-  return new Intl.NumberFormat(locale.value, {
-    style: 'currency',
-    currency
-  }).format(amount)
-}
+// Format currency — clinic-wide, no per-invoice override.
+const { format: formatCurrency } = useCurrency()
 
 // Format date
 function formatDate(dateStr: string | undefined): string {
@@ -121,7 +116,7 @@ watch(() => props.patientId, loadData)
             {{ t('patientBilling.totalBudgeted') }}
           </p>
           <p class="text-display text-default text-default mt-1">
-            {{ formatCurrency(summary.total_budgeted, summary.currency) }}
+            {{ formatCurrency(summary.total_budgeted) }}
           </p>
         </div>
 
@@ -130,7 +125,7 @@ watch(() => props.patientId, loadData)
             {{ t('patientBilling.workInProgress') }}
           </p>
           <p class="text-display tnum mt-1">
-            {{ formatCurrency(summary.work_in_progress, summary.currency) }}
+            {{ formatCurrency(summary.work_in_progress) }}
           </p>
         </div>
 
@@ -139,7 +134,7 @@ watch(() => props.patientId, loadData)
             {{ t('patientBilling.workCompleted') }}
           </p>
           <p class="text-display tnum mt-1">
-            {{ formatCurrency(summary.work_completed, summary.currency) }}
+            {{ formatCurrency(summary.work_completed) }}
           </p>
         </div>
 
@@ -149,7 +144,7 @@ watch(() => props.patientId, loadData)
             {{ t('patientBilling.totalInvoiced') }}
           </p>
           <p class="text-display tnum text-default mt-1">
-            {{ formatCurrency(summary.total_invoiced, summary.currency) }}
+            {{ formatCurrency(summary.total_invoiced) }}
           </p>
         </div>
 
@@ -158,7 +153,7 @@ watch(() => props.patientId, loadData)
             {{ t('patientBilling.totalPaid') }}
           </p>
           <p class="text-display tnum mt-1">
-            {{ formatCurrency(summary.total_paid, summary.currency) }}
+            {{ formatCurrency(summary.total_paid) }}
           </p>
         </div>
 
@@ -184,7 +179,7 @@ watch(() => props.patientId, loadData)
               summary.balance_pending > 0 ? '' : 'text-default'
             ]"
           >
-            {{ formatCurrency(summary.balance_pending, summary.currency) }}
+            {{ formatCurrency(summary.balance_pending) }}
           </p>
         </div>
       </div>
@@ -290,13 +285,13 @@ watch(() => props.patientId, loadData)
                     </UBadge>
                   </td>
                   <td class="px-3 py-3 text-right font-medium text-default">
-                    {{ formatCurrency(invoice.total, invoice.currency) }}
+                    {{ formatCurrency(invoice.total) }}
                   </td>
                   <td class="px-3 py-3 text-right">
                     <span
                       :class="invoice.balance_due > 0 ? 'text-warning font-medium' : 'text-muted'"
                     >
-                      {{ formatCurrency(invoice.balance_due, invoice.currency) }}
+                      {{ formatCurrency(invoice.balance_due) }}
                     </span>
                   </td>
                   <td class="px-3 py-3 text-right">
@@ -360,7 +355,7 @@ watch(() => props.patientId, loadData)
                           class="font-medium"
                           :class="payment.is_voided ? 'line-through text-subtle' : 'text-default'"
                         >
-                          {{ formatCurrency(payment.amount, invoice.currency) }}
+                          {{ formatCurrency(payment.amount) }}
                         </span>
                         <UBadge
                           v-if="payment.is_voided"

--- a/backend/app/modules/billing/frontend/composables/useInvoices.ts
+++ b/backend/app/modules/billing/frontend/composables/useInvoices.ts
@@ -201,7 +201,6 @@ export function useInvoices() {
       total: response.data.total,
       total_paid: response.data.total_paid,
       balance_due: response.data.balance_due,
-      currency: response.data.currency,
       created_at: response.data.created_at,
       patient: response.data.patient,
       creator: response.data.creator
@@ -227,7 +226,6 @@ export function useInvoices() {
       total: response.data.total,
       total_paid: response.data.total_paid,
       balance_due: response.data.balance_due,
-      currency: response.data.currency,
       created_at: response.data.created_at,
       patient: response.data.patient,
       creator: response.data.creator
@@ -389,7 +387,6 @@ export function useInvoices() {
       total: response.data.total,
       total_paid: response.data.total_paid,
       balance_due: response.data.balance_due,
-      currency: response.data.currency,
       created_at: response.data.created_at,
       patient: response.data.patient,
       creator: response.data.creator
@@ -596,12 +593,7 @@ export function useInvoices() {
     return ['issued', 'partial', 'paid'].includes(invoice.status)
   }
 
-  function formatCurrency(amount: number, currency: string = 'EUR'): string {
-    return new Intl.NumberFormat('es-ES', {
-      style: 'currency',
-      currency
-    }).format(amount)
-  }
+  const { format: formatCurrency } = useCurrency()
 
   // Internal helper to update status in local state
   function updateInvoiceStatus(id: string, status: InvoiceStatus): void {

--- a/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
@@ -591,7 +591,6 @@ function goBack() {
     <InvoiceItemModal
       v-model:open="isItemModalOpen"
       :invoice-id="invoiceId"
-      :currency="currentInvoice?.currency"
       :edit-item="editingItem"
       @saved="handleItemSaved"
     />

--- a/backend/app/modules/billing/frontend/pages/invoices/[id]/index.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/[id]/index.vue
@@ -667,16 +667,16 @@ function goToCreditNoteFor() {
                   </div>
                   <div class="text-right">
                     <p class="text-caption text-subtle">
-                      {{ item.quantity }} x {{ formatCurrency(item.unit_price, currentInvoice.currency) }}
+                      {{ item.quantity }} x {{ formatCurrency(item.unit_price) }}
                     </p>
                     <p
                       v-if="item.line_discount > 0"
                       class="text-sm text-success-accent"
                     >
-                      -{{ formatCurrency(item.line_discount, currentInvoice.currency) }}
+                      -{{ formatCurrency(item.line_discount) }}
                     </p>
                     <p class="font-semibold text-default">
-                      {{ formatCurrency(item.line_total, currentInvoice.currency) }}
+                      {{ formatCurrency(item.line_total) }}
                     </p>
                     <p class="text-xs text-subtle">
                       {{ t('invoice.vat') }} {{ item.vat_rate }}%
@@ -704,7 +704,7 @@ function goToCreditNoteFor() {
               >
                 <div>
                   <p class="font-medium text-default">
-                    {{ formatCurrency(payment.amount, currentInvoice.currency) }}
+                    {{ formatCurrency(payment.amount) }}
                   </p>
                   <p class="text-caption text-subtle">
                     {{ getPaymentMethodLabel(payment.payment_method) }} - {{ formatDate(payment.payment_date) }}
@@ -749,23 +749,23 @@ function goToCreditNoteFor() {
             <div class="space-y-3">
               <div class="flex justify-between">
                 <span class="text-subtle">{{ t('invoice.subtotal') }}</span>
-                <span class="font-medium">{{ formatCurrency(currentInvoice.subtotal, currentInvoice.currency) }}</span>
+                <span class="font-medium">{{ formatCurrency(currentInvoice.subtotal) }}</span>
               </div>
               <div
                 v-if="currentInvoice.total_discount > 0"
                 class="flex justify-between text-success-accent"
               >
                 <span>{{ t('invoice.discount') }}</span>
-                <span>-{{ formatCurrency(currentInvoice.total_discount, currentInvoice.currency) }}</span>
+                <span>-{{ formatCurrency(currentInvoice.total_discount) }}</span>
               </div>
               <div class="flex justify-between">
                 <span class="text-subtle">{{ t('invoice.tax') }}</span>
-                <span class="font-medium">{{ formatCurrency(currentInvoice.total_tax, currentInvoice.currency) }}</span>
+                <span class="font-medium">{{ formatCurrency(currentInvoice.total_tax) }}</span>
               </div>
               <div class="flex justify-between pt-3 border-t border-default">
                 <span class="font-semibold text-default">{{ t('invoice.total') }}</span>
                 <span class="font-bold text-lg text-default">
-                  {{ formatCurrency(currentInvoice.total, currentInvoice.currency) }}
+                  {{ formatCurrency(currentInvoice.total) }}
                 </span>
               </div>
               <div
@@ -774,7 +774,7 @@ function goToCreditNoteFor() {
               >
                 <span class="text-subtle">{{ t('invoice.paid') }}</span>
                 <span class="font-medium text-success-accent">
-                  {{ formatCurrency(currentInvoice.total_paid, currentInvoice.currency) }}
+                  {{ formatCurrency(currentInvoice.total_paid) }}
                 </span>
               </div>
               <div
@@ -783,7 +783,7 @@ function goToCreditNoteFor() {
               >
                 <span class="font-semibold text-warning-accent">{{ t('invoice.balanceDue') }}</span>
                 <span class="font-bold text-warning-accent">
-                  {{ formatCurrency(currentInvoice.balance_due, currentInvoice.currency) }}
+                  {{ formatCurrency(currentInvoice.balance_due) }}
                 </span>
               </div>
             </div>

--- a/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
@@ -158,13 +158,8 @@ const totals = computed(() => {
   }
 })
 
-// Format currency
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat(locale.value, {
-    style: 'currency',
-    currency: 'EUR'
-  }).format(amount)
-}
+// Format currency — clinic-wide.
+const { format: formatCurrency } = useCurrency()
 
 // Submit
 async function handleSubmit() {

--- a/backend/app/modules/billing/frontend/pages/invoices/index.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/index.vue
@@ -275,14 +275,13 @@ function isOverdue(invoice: InvoiceListItem): boolean {
             <div class="text-right">
               <Money
                 :value="invoice.total"
-                :currency="invoice.currency"
                 strong
               />
               <div
                 v-if="invoice.balance_due > 0 && invoice.status !== 'draft'"
                 class="text-caption text-warning tnum"
               >
-                {{ t('invoice.balance') }}: {{ formatCurrency(invoice.balance_due, invoice.currency) }}
+                {{ t('invoice.balance') }}: {{ formatCurrency(invoice.balance_due) }}
               </div>
             </div>
           </template>

--- a/backend/app/modules/billing/frontend/pages/invoices/new.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/new.vue
@@ -123,13 +123,8 @@ const totals = computed(() => {
   }
 })
 
-// Format currency
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat(locale.value, {
-    style: 'currency',
-    currency: 'EUR'
-  }).format(amount)
-}
+// Format currency — clinic-wide.
+const { format: formatCurrency } = useCurrency()
 
 // Submit
 async function handleSubmit() {
@@ -491,7 +486,6 @@ function goBack() {
     <!-- Add Item Modal -->
     <NewInvoiceItemModal
       v-model:open="isItemModalOpen"
-      currency="EUR"
       @added="handleItemAdded"
     />
   </div>

--- a/backend/app/modules/billing/migrations/versions/bil_0003_drop_currency.py
+++ b/backend/app/modules/billing/migrations/versions/bil_0003_drop_currency.py
@@ -1,0 +1,37 @@
+"""billing — drop currency column.
+
+Currency is now clinic-level (``clinics.currency``, core 0005). A
+clinic operates in a single currency, so the per-invoice snapshot is
+redundant. Renderers read ``clinic.currency`` at PDF/email time.
+
+Revision ID: bil_0003
+Revises: bil_0002
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "bil_0003"
+down_revision: str | None = "bil_0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("invoices", "currency")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "invoices",
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default="EUR",
+        ),
+    )

--- a/backend/app/modules/billing/models.py
+++ b/backend/app/modules/billing/models.py
@@ -130,7 +130,6 @@ class Invoice(Base, TimestampMixin):
     total: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal("0.00"))
     total_paid: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal("0.00"))
     balance_due: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal("0.00"))
-    currency: Mapped[str] = mapped_column(String(3), default="EUR")
 
     # Notes
     internal_notes: Mapped[str | None] = mapped_column(Text, default=None)

--- a/backend/app/modules/billing/pdf.py
+++ b/backend/app/modules/billing/pdf.py
@@ -6,10 +6,14 @@ from decimal import Decimal
 from io import BytesIO
 from typing import TYPE_CHECKING
 
+from app.core.utils.currency import format_currency as _fmt_currency
+
 if TYPE_CHECKING:
     from app.core.auth.models import Clinic
 
 from .models import Invoice
+
+_LOCALE_BY_LANG = {"es": "es_ES", "en": "en_US"}
 
 
 class InvoicePDFService:
@@ -89,9 +93,11 @@ class InvoicePDFService:
         # Determine if this is a credit note
         is_credit_note = invoice.credit_note_for_id is not None
 
-        # Format currency
+        # Format currency from clinic.currency, locale derived from language.
+        money_locale = _LOCALE_BY_LANG.get(locale, "es_ES")
+
         def format_currency(amount: Decimal) -> str:
-            return f"{amount:,.2f} {invoice.currency}"
+            return _fmt_currency(amount, clinic.currency, locale=money_locale)
 
         # Build items table rows
         items_html = ""

--- a/backend/app/modules/billing/schemas.py
+++ b/backend/app/modules/billing/schemas.py
@@ -471,7 +471,6 @@ class InvoiceResponse(BaseModel):
     total: Decimal
     total_paid: Decimal
     balance_due: Decimal
-    currency: str
 
     # Notes
     internal_notes: str | None
@@ -523,7 +522,6 @@ class InvoiceListResponse(BaseModel):
     total: Decimal
     total_paid: Decimal
     balance_due: Decimal
-    currency: str
     created_at: datetime
 
     # Generic compliance summary — shape is country-keyed
@@ -610,7 +608,6 @@ class PatientBillingSummary(BaseModel):
     """Schema for patient billing summary in profile."""
 
     patient_id: UUID
-    currency: str
 
     # Budget metrics
     total_budgeted: Decimal

--- a/backend/app/modules/billing/workflow.py
+++ b/backend/app/modules/billing/workflow.py
@@ -619,7 +619,6 @@ class InvoiceWorkflowService:
             billing_tax_id=original_invoice.billing_tax_id,
             billing_address=original_invoice.billing_address,
             billing_email=original_invoice.billing_email,
-            currency=original_invoice.currency,
             internal_notes=f"Nota de crédito por: {reason}",
             public_notes=f"Rectificación de factura {original_invoice.invoice_number}",
             created_by=created_by,

--- a/backend/app/modules/budget/frontend/components/budget/BudgetItemModal.vue
+++ b/backend/app/modules/budget/frontend/components/budget/BudgetItemModal.vue
@@ -4,7 +4,6 @@ import type { BudgetItemCreate, TreatmentCatalogItem } from '~~/app/types'
 const props = defineProps<{
   open: boolean
   budgetId: string
-  currency?: string
 }>()
 
 const emit = defineEmits<{
@@ -161,7 +160,6 @@ watch(() => props.open, (isOpen) => {
           >
             <TreatmentVisualSelector
               :model-value="selectedItem"
-              :currency="currency"
               :in-modal="true"
               @update:model-value="handleItemSelect"
             />
@@ -251,7 +249,7 @@ watch(() => props.open, (isOpen) => {
           >
             <span class="text-muted">{{ t('budget.items.lineTotal') }}</span>
             <span class="text-h1 tnum text-default">
-              {{ formatPrice(previewTotal, currency || 'EUR') }}
+              {{ formatPrice(previewTotal) }}
             </span>
           </div>
         </form>

--- a/backend/app/modules/budget/frontend/composables/useBudgets.ts
+++ b/backend/app/modules/budget/frontend/composables/useBudgets.ts
@@ -140,7 +140,6 @@ export function useBudgets() {
       valid_from: response.data.valid_from,
       valid_until: response.data.valid_until,
       total: response.data.total,
-      currency: response.data.currency,
       created_at: response.data.created_at,
       patient: response.data.patient,
       creator: response.data.creator
@@ -298,7 +297,6 @@ export function useBudgets() {
       valid_from: response.data.valid_from,
       valid_until: response.data.valid_until,
       total: response.data.total,
-      currency: response.data.currency,
       created_at: response.data.created_at,
       patient: response.data.patient,
       creator: response.data.creator

--- a/backend/app/modules/budget/frontend/composables/usePublicBudget.ts
+++ b/backend/app/modules/budget/frontend/composables/usePublicBudget.ts
@@ -26,10 +26,10 @@ export interface PublicMeta {
   clinic_email: string | null
   clinic_address_line: string | null
   clinic_language: string | null
+  clinic_currency: string | null
   patient_first_name: string | null
   budget_number: string | null
   budget_total: string | null
-  budget_currency: string | null
   valid_until: string | null
 }
 
@@ -58,7 +58,6 @@ export interface PublicBudget {
   total_discount: number
   total_tax: number
   total: number
-  currency: string
   patient_notes: string | null
   items: PublicBudgetItem[]
 }

--- a/backend/app/modules/budget/frontend/pages/budgets/[id].vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/[id].vue
@@ -324,12 +324,7 @@ async function handleDownloadPDF() {
 }
 
 // Format helpers
-function formatCurrency(amount: number, currency: string = 'EUR'): string {
-  return new Intl.NumberFormat(locale.value, {
-    style: 'currency',
-    currency
-  }).format(amount)
-}
+const { format: formatMoney } = useCurrency()
 
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString(locale.value)
@@ -538,7 +533,7 @@ function getItemName(item: BudgetItem): string {
                 <p class="font-medium">
                   {{ currentBudget.global_discount_type === 'percentage'
                     ? `${currentBudget.global_discount_value}%`
-                    : formatCurrency(currentBudget.global_discount_value, currentBudget.currency) }}
+                    : formatMoney(currentBudget.global_discount_value) }}
                 </p>
               </div>
               <div v-if="currentBudget.patient_notes">
@@ -671,12 +666,12 @@ function getItemName(item: BudgetItem): string {
                     </span>
                   </div>
                   <div class="text-caption text-subtle mt-1">
-                    {{ item.quantity }} x {{ formatCurrency(item.unit_price, currentBudget.currency) }}
+                    {{ item.quantity }} x {{ formatMoney(item.unit_price) }}
                     <span
                       v-if="item.line_discount > 0"
                       class="text-success-accent"
                     >
-                      -{{ formatCurrency(item.line_discount, currentBudget.currency) }}
+                      -{{ formatMoney(item.line_discount) }}
                     </span>
                   </div>
                   <p
@@ -688,7 +683,7 @@ function getItemName(item: BudgetItem): string {
                 </div>
                 <div class="text-right">
                   <p class="font-semibold">
-                    {{ formatCurrency(item.line_total, currentBudget.currency) }}
+                    {{ formatMoney(item.line_total) }}
                   </p>
                 </div>
                 <UButton
@@ -717,25 +712,25 @@ function getItemName(item: BudgetItem): string {
             <div class="space-y-3">
               <div class="flex justify-between">
                 <span class="text-subtle">{{ t('budget.subtotal') }}</span>
-                <span>{{ formatCurrency(currentBudget.subtotal, currentBudget.currency) }}</span>
+                <span>{{ formatMoney(currentBudget.subtotal) }}</span>
               </div>
               <div
                 v-if="currentBudget.total_discount > 0"
                 class="flex justify-between text-success-accent"
               >
                 <span>{{ t('budget.totalDiscount') }}</span>
-                <span>-{{ formatCurrency(currentBudget.total_discount, currentBudget.currency) }}</span>
+                <span>-{{ formatMoney(currentBudget.total_discount) }}</span>
               </div>
               <div
                 v-if="currentBudget.total_tax > 0"
                 class="flex justify-between"
               >
                 <span class="text-subtle">{{ t('budget.totalTax') }}</span>
-                <span>{{ formatCurrency(currentBudget.total_tax, currentBudget.currency) }}</span>
+                <span>{{ formatMoney(currentBudget.total_tax) }}</span>
               </div>
               <div class="border-t pt-3 flex justify-between font-bold text-lg">
                 <span>{{ t('budget.total') }}</span>
-                <span>{{ formatCurrency(currentBudget.total, currentBudget.currency) }}</span>
+                <span>{{ formatMoney(currentBudget.total) }}</span>
               </div>
             </div>
           </UCard>
@@ -793,7 +788,6 @@ function getItemName(item: BudgetItem): string {
     <BudgetItemModal
       v-model:open="isAddItemModalOpen"
       :budget-id="budgetId"
-      :currency="currentBudget?.currency"
       @added="handleItemAdded"
     />
 

--- a/backend/app/modules/budget/frontend/pages/budgets/index.vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/index.vue
@@ -203,7 +203,6 @@ function getPatientName(budget: BudgetListItem): string {
             </span>
             <Money
               :value="budget.total"
-              :currency="budget.currency"
               strong
             />
           </template>

--- a/backend/app/modules/budget/frontend/pages/p/budget/[token].vue
+++ b/backend/app/modules/budget/frontend/pages/p/budget/[token].vue
@@ -189,15 +189,13 @@ async function onRejectSubmit() {
 
 // ----- formatting helpers ---------------------------------------------
 
-function formatMoney(amount: number | string | null | undefined, currency = 'EUR'): string {
+function formatMoney(amount: number | string | null | undefined, currency: string | null | undefined): string {
   const n = typeof amount === 'string' ? Number(amount) : (amount ?? 0)
+  const cur = currency || 'EUR'
   try {
-    return new Intl.NumberFormat(locale.value, {
-      style: 'currency',
-      currency,
-    }).format(n)
+    return new Intl.NumberFormat(locale.value, { style: 'currency', currency: cur }).format(n)
   } catch {
-    return `${n.toFixed(2)} €`
+    return `${n.toFixed(2)} ${cur}`
   }
 }
 
@@ -428,9 +426,9 @@ const greeting = computed(() => {
               </div>
               <div class="treatments-money">
                 <p class="treatments-qty">
-                  {{ item.quantity }} × {{ formatMoney(item.unit_price, budget.currency) }}
+                  {{ item.quantity }} × {{ formatMoney(item.unit_price, meta?.clinic_currency) }}
                 </p>
-                <p class="treatments-total">{{ formatMoney(item.line_total, budget.currency) }}</p>
+                <p class="treatments-total">{{ formatMoney(item.line_total, meta?.clinic_currency) }}</p>
               </div>
             </li>
           </ul>
@@ -441,19 +439,19 @@ const greeting = computed(() => {
           <dl class="totals">
             <div class="totals-row">
               <dt>{{ t('budget.public.subtotal') }}</dt>
-              <dd>{{ formatMoney(budget.subtotal, budget.currency) }}</dd>
+              <dd>{{ formatMoney(budget.subtotal, meta?.clinic_currency) }}</dd>
             </div>
             <div v-if="Number(budget.total_discount) > 0" class="totals-row totals-row-discount">
               <dt>{{ t('budget.public.discount') }}</dt>
-              <dd>−{{ formatMoney(budget.total_discount, budget.currency) }}</dd>
+              <dd>−{{ formatMoney(budget.total_discount, meta?.clinic_currency) }}</dd>
             </div>
             <div class="totals-row">
               <dt>{{ t('budget.public.tax') }}</dt>
-              <dd>{{ formatMoney(budget.total_tax, budget.currency) }}</dd>
+              <dd>{{ formatMoney(budget.total_tax, meta?.clinic_currency) }}</dd>
             </div>
             <div class="totals-row totals-grand">
               <dt>{{ t('budget.public.total') }}</dt>
-              <dd>{{ formatMoney(budget.total, budget.currency) }}</dd>
+              <dd>{{ formatMoney(budget.total, meta?.clinic_currency) }}</dd>
             </div>
           </dl>
         </UCard>

--- a/backend/app/modules/budget/migrations/versions/bud_0003_drop_currency.py
+++ b/backend/app/modules/budget/migrations/versions/bud_0003_drop_currency.py
@@ -1,0 +1,40 @@
+"""budget — drop currency column.
+
+Currency is now clinic-level (``clinics.currency``, core 0005). A
+clinic operates in a single currency, so the per-budget snapshot is
+redundant. Renderers read ``clinic.currency`` at PDF/email time.
+
+The app is not in production, so we drop the column outright instead
+of carrying a deprecated NOT-NULL field forever.
+
+Revision ID: bud_0003
+Revises: bud_0002
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "bud_0003"
+down_revision: str | None = "bud_0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("budgets", "currency")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "budgets",
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default="EUR",
+        ),
+    )

--- a/backend/app/modules/budget/models.py
+++ b/backend/app/modules/budget/models.py
@@ -81,9 +81,6 @@ class Budget(Base, TimestampMixin):
     total_tax: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal("0.00"))  # Total VAT
     total: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal("0.00"))  # Final amount
 
-    # Currency
-    currency: Mapped[str] = mapped_column(String(3), default="EUR")
-
     # Notes
     internal_notes: Mapped[str | None] = mapped_column(Text, default=None)
     patient_notes: Mapped[str | None] = mapped_column(Text, default=None)

--- a/backend/app/modules/budget/pdf.py
+++ b/backend/app/modules/budget/pdf.py
@@ -6,10 +6,14 @@ from decimal import Decimal
 from io import BytesIO
 from typing import TYPE_CHECKING
 
+from app.core.utils.currency import format_currency as _fmt_currency
+
 if TYPE_CHECKING:
     from app.core.auth.models import Clinic
 
 from .models import Budget, BudgetSignature
+
+_LOCALE_BY_LANG = {"es": "es_ES", "en": "en_US"}
 
 
 class BudgetPDFService:
@@ -160,9 +164,11 @@ class BudgetPDFService:
         # Localized labels
         labels = BudgetPDFService._get_labels(locale)
 
-        # Format currency
+        # Format currency from clinic.currency, locale derived from language.
+        money_locale = _LOCALE_BY_LANG.get(locale, "es_ES")
+
         def format_currency(amount: Decimal) -> str:
-            return f"{amount:,.2f} {budget.currency}"
+            return _fmt_currency(amount, clinic.currency, locale=money_locale)
 
         # Build items table rows
         items_html = ""

--- a/backend/app/modules/budget/public_router.py
+++ b/backend/app/modules/budget/public_router.py
@@ -134,10 +134,10 @@ class PublicBudgetMeta(BaseModel):
     clinic_email: str | None = None
     clinic_address_line: str | None = None
     clinic_language: str | None = None
+    clinic_currency: str | None = None
     patient_first_name: str | None = None
     budget_number: str | None = None
     budget_total: str | None = None
-    budget_currency: str | None = None
     valid_until: str | None = None
 
 
@@ -188,13 +188,16 @@ async def get_public_budget_meta(
 
     clinic_row = (
         await db.execute(
-            _text("SELECT name, phone, email, address, settings FROM clinics WHERE id = :id"),
+            _text(
+                "SELECT name, phone, email, address, settings, currency FROM clinics WHERE id = :id"
+            ),
             {"id": budget.clinic_id},
         )
     ).first()
     clinic_name = clinic_row.name if clinic_row else None
     clinic_phone = clinic_row.phone if clinic_row else None
     clinic_email = clinic_row.email if clinic_row else None
+    clinic_currency = clinic_row.currency if clinic_row else None
     clinic_address_line: str | None = None
     clinic_language: str | None = None
     if clinic_row and clinic_row.address:
@@ -229,10 +232,10 @@ async def get_public_budget_meta(
             clinic_email=clinic_email,
             clinic_address_line=clinic_address_line,
             clinic_language=clinic_language,
+            clinic_currency=clinic_currency,
             patient_first_name=patient_first_name,
             budget_number=budget.budget_number,
             budget_total=str(budget.total) if budget.total is not None else None,
-            budget_currency=budget.currency,
             valid_until=budget.valid_until.isoformat() if budget.valid_until else None,
         )
     )

--- a/backend/app/modules/budget/schemas.py
+++ b/backend/app/modules/budget/schemas.py
@@ -371,7 +371,6 @@ class BudgetResponse(BaseModel):
     total_discount: Decimal
     total_tax: Decimal
     total: Decimal
-    currency: str
 
     # Notes
     internal_notes: str | None
@@ -420,7 +419,6 @@ class BudgetListResponse(BaseModel):
     valid_from: date
     valid_until: date | None
     total: Decimal
-    currency: str
     created_at: datetime
 
     # Related (brief)

--- a/backend/app/modules/budget/service.py
+++ b/backend/app/modules/budget/service.py
@@ -651,7 +651,6 @@ class BudgetService:
             assigned_professional_id=source_budget.assigned_professional_id,
             global_discount_type=source_budget.global_discount_type,
             global_discount_value=source_budget.global_discount_value,
-            currency=source_budget.currency,
             internal_notes=source_budget.internal_notes,
             patient_notes=source_budget.patient_notes,
         )

--- a/backend/app/modules/budget/workflow.py
+++ b/backend/app/modules/budget/workflow.py
@@ -808,7 +808,6 @@ class BudgetWorkflowService:
             assigned_professional_id=budget.assigned_professional_id,
             global_discount_type=budget.global_discount_type,
             global_discount_value=budget.global_discount_value,
-            currency=budget.currency,
             plan_number_snapshot=budget.plan_number_snapshot,
             plan_status_snapshot=budget.plan_status_snapshot,
         )

--- a/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
+++ b/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
@@ -72,7 +72,6 @@ watch(
         descriptions: newItem.descriptions ? { ...newItem.descriptions } : undefined,
         default_price: newItem.default_price,
         cost_price: newItem.cost_price,
-        currency: newItem.currency,
         pricing_strategy: newItem.pricing_strategy || 'flat',
         pricing_config: newItem.pricing_config ?? null,
         surface_prices: newItem.surface_prices ? { ...newItem.surface_prices } : null,
@@ -101,7 +100,6 @@ watch(
         names: { [locale.value]: '' },
         default_price: 0,
         cost_price: 0,
-        currency: 'EUR',
         pricing_strategy: 'flat',
         pricing_config: null,
         surface_prices: null,
@@ -326,7 +324,7 @@ function handleClose() {
               <h4 class="font-medium text-default dark:text-white mb-4">
                 {{ t('catalog.pricing') }}
               </h4>
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <UFormField :label="t('catalog.defaultPrice')">
                   <UInput
                     v-model.number="formData.default_price"
@@ -342,14 +340,6 @@ function handleClose() {
                     type="number"
                     step="0.01"
                     min="0"
-                  />
-                </UFormField>
-
-                <UFormField :label="t('catalog.currency')">
-                  <UInput
-                    v-model="formData.currency"
-                    maxlength="3"
-                    placeholder="EUR"
                   />
                 </UFormField>
               </div>

--- a/backend/app/modules/catalog/frontend/composables/useCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useCatalog.ts
@@ -397,12 +397,13 @@ export function useCatalog() {
     return item.names[loc] || item.names.es || item.names.en || item.internal_code
   }
 
-  function formatPrice(price: number | undefined, currency = 'EUR'): string {
+  // Clinic-wide currency from useCurrency. The legacy second arg
+  // (currency override) is ignored — kept in the signature so existing
+  // callers compile without churn.
+  const { format } = useCurrency()
+  function formatPrice(price: number | undefined | null, _currency?: string): string {
     if (price === undefined || price === null) return '-'
-    return new Intl.NumberFormat('es-ES', {
-      style: 'currency',
-      currency
-    }).format(price)
+    return format(price)
   }
 
   return {

--- a/backend/app/modules/catalog/frontend/pages/settings/catalog/index.vue
+++ b/backend/app/modules/catalog/frontend/pages/settings/catalog/index.vue
@@ -397,7 +397,7 @@ const categoryOptions = computed(() => [
                     </UBadge>
                   </td>
                   <td class="py-2.5 px-4 text-right font-medium">
-                    {{ catalog.formatPrice(item.default_price, item.currency) }}
+                    {{ catalog.formatPrice(item.default_price) }}
                   </td>
                   <td class="hidden sm:table-cell py-2.5 px-4 text-center">
                     <UBadge
@@ -552,7 +552,7 @@ const categoryOptions = computed(() => [
                 {{ getCategoryName(item.category_id) }}
               </td>
               <td class="py-3 px-4 text-right font-medium">
-                {{ catalog.formatPrice(item.default_price, item.currency) }}
+                {{ catalog.formatPrice(item.default_price) }}
               </td>
               <td class="hidden sm:table-cell py-3 px-4 text-center">
                 <UBadge

--- a/backend/app/modules/catalog/migrations/versions/cat_0002_drop_currency.py
+++ b/backend/app/modules/catalog/migrations/versions/cat_0002_drop_currency.py
@@ -1,0 +1,38 @@
+"""catalog — drop currency column.
+
+Currency is now clinic-level (``clinics.currency``, core 0005). All
+catalog items in a clinic price in the clinic's currency; storing it
+per item was leftover from a multi-currency design that is out of
+scope.
+
+Revision ID: cat_0002
+Revises: cat_0001
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "cat_0002"
+down_revision: str | None = "cat_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("treatment_catalog_items", "currency")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "treatment_catalog_items",
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default="EUR",
+        ),
+    )

--- a/backend/app/modules/catalog/models.py
+++ b/backend/app/modules/catalog/models.py
@@ -143,7 +143,6 @@ class TreatmentCatalogItem(Base, TimestampMixin):
     # Pricing (MVP: single default price)
     default_price: Mapped[Decimal | None] = mapped_column(Numeric(10, 2))
     cost_price: Mapped[Decimal | None] = mapped_column(Numeric(10, 2))  # For margin calculation
-    currency: Mapped[str] = mapped_column(String(3), default="EUR")  # ISO 4217
 
     # Scheduling
     default_duration_minutes: Mapped[int | None] = mapped_column(Integer)

--- a/backend/app/modules/catalog/schemas.py
+++ b/backend/app/modules/catalog/schemas.py
@@ -159,7 +159,6 @@ class CatalogItemCreate(BaseModel):
     # Pricing
     default_price: Decimal | None = Field(default=None, ge=0)
     cost_price: Decimal | None = Field(default=None, ge=0)
-    currency: str = Field(default="EUR", max_length=3)
 
     # Scheduling
     default_duration_minutes: int | None = Field(default=None, ge=0, le=480)  # Max 8 hours
@@ -198,7 +197,6 @@ class CatalogItemUpdate(BaseModel):
     # Pricing
     default_price: Decimal | None = Field(default=None, ge=0)
     cost_price: Decimal | None = Field(default=None, ge=0)
-    currency: str | None = Field(default=None, max_length=3)
 
     # Scheduling
     default_duration_minutes: int | None = Field(default=None, ge=0, le=480)
@@ -240,7 +238,6 @@ class CatalogItemResponse(BaseModel):
     # Pricing
     default_price: Decimal | None
     cost_price: Decimal | None
-    currency: str
 
     # Scheduling
     default_duration_minutes: int | None
@@ -314,7 +311,6 @@ class OdontogramTreatmentResponse(BaseModel):
     internal_code: str
     names: dict[str, str]
     default_price: Decimal | None
-    currency: str = "EUR"
     treatment_scope: str
     requires_surfaces: bool
     is_diagnostic: bool

--- a/backend/app/modules/catalog/service.py
+++ b/backend/app/modules/catalog/service.py
@@ -612,7 +612,6 @@ class OdontogramCatalogService:
                         "internal_code": item.internal_code,
                         "names": item.names,
                         "default_price": float(item.default_price) if item.default_price else None,
-                        "currency": item.currency or "EUR",
                         "treatment_scope": item.treatment_scope,
                         "requires_surfaces": item.requires_surfaces,
                         "is_diagnostic": item.is_diagnostic,

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentBar.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentBar.vue
@@ -172,8 +172,7 @@ interface TreatmentBarItem {
 }
 
 function formatSurfaceRangeLabel(
-  surfacePrices: Record<string, number> | null | undefined,
-  currency: string | undefined
+  surfacePrices: Record<string, number> | null | undefined
 ): string | null {
   if (!surfacePrices) return null
   const values = Object.values(surfacePrices)
@@ -182,9 +181,10 @@ function formatSurfaceRangeLabel(
   if (values.length === 0) return null
   const min = Math.min(...values)
   const max = Math.max(...values)
-  const cur = currency === 'EUR' ? '€' : (currency || '')
+  // Pricing-tier hint is purely numeric — full localized formatting
+  // happens in <Money> elsewhere. We just want a compact range label.
   const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2))
-  return min === max ? `${fmt(min)}${cur}` : `${fmt(min)}–${fmt(max)}${cur}`
+  return min === max ? fmt(min) : `${fmt(min)}–${fmt(max)}`
 }
 
 // One button per catalog item (no dedupe by type — Metal-cerámica vs Zirconio bridges
@@ -238,7 +238,7 @@ const currentTreatments = computed<TreatmentBarItem[]>(() => {
         const label = isRealCatalogItem
           ? (c.names[locale.value] || c.names.es || c.names.en || oType)
           : t(`odontogram.treatments.types.${oType}`, oType)
-        const rangeLabel = formatSurfaceRangeLabel(c.surface_prices, c.currency)
+        const rangeLabel = formatSurfaceRangeLabel(c.surface_prices)
         const tooltip = rangeLabel
           ? `${label}  •  ${t('odontogram.surfacePricingHint', { range: rangeLabel })}`
           : label

--- a/backend/app/modules/odontogram/migrations/versions/odo_0002_drop_currency_snapshot.py
+++ b/backend/app/modules/odontogram/migrations/versions/odo_0002_drop_currency_snapshot.py
@@ -1,0 +1,33 @@
+"""odontogram — drop treatments.currency_snapshot column.
+
+Currency is now clinic-level (``clinics.currency``, core 0005). The
+per-treatment snapshot existed to capture the catalog item's currency
+at the time of creation in case it could differ from the clinic's —
+that scenario no longer exists.
+
+Revision ID: odo_0002
+Revises: odo_0001
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "odo_0002"
+down_revision: str | None = "odo_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("treatments", "currency_snapshot")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "treatments",
+        sa.Column("currency_snapshot", sa.String(length=3), nullable=True),
+    )

--- a/backend/app/modules/odontogram/models.py
+++ b/backend/app/modules/odontogram/models.py
@@ -115,7 +115,6 @@ class Treatment(Base, TimestampMixin):
 
     # Pricing snapshots (frozen at creation; decouples history from catalog edits).
     price_snapshot: Mapped[Decimal | None] = mapped_column(Numeric(10, 2))
-    currency_snapshot: Mapped[str | None] = mapped_column(String(3))
     duration_snapshot: Mapped[int | None] = mapped_column(Integer)
     vat_rate_snapshot: Mapped[float | None] = mapped_column(Numeric(5, 2))
 

--- a/backend/app/modules/odontogram/schemas.py
+++ b/backend/app/modules/odontogram/schemas.py
@@ -186,7 +186,6 @@ class CatalogItemBrief(BaseModel):
     internal_code: str
     names: dict[str, str]
     default_price: Decimal | None = None
-    currency: str = "EUR"
 
 
 class TreatmentToothResponse(BaseModel):
@@ -221,7 +220,6 @@ class TreatmentResponse(BaseModel):
     performed_by_name: str | None = None
 
     price_snapshot: Decimal | None = None
-    currency_snapshot: str | None = None
     duration_snapshot: int | None = None
     vat_rate_snapshot: Decimal | None = None
 

--- a/backend/app/modules/odontogram/service.py
+++ b/backend/app/modules/odontogram/service.py
@@ -42,7 +42,6 @@ def build_treatment_response(treatment: Treatment) -> dict:
             "internal_code": treatment.catalog_item.internal_code,
             "names": treatment.catalog_item.names,
             "default_price": treatment.catalog_item.default_price,
-            "currency": treatment.catalog_item.currency,
         }
 
     return {
@@ -68,7 +67,6 @@ def build_treatment_response(treatment: Treatment) -> dict:
         "performed_by": treatment.performed_by,
         "performed_by_name": performer_name,
         "price_snapshot": treatment.price_snapshot,
-        "currency_snapshot": treatment.currency_snapshot,
         "duration_snapshot": treatment.duration_snapshot,
         "vat_rate_snapshot": treatment.vat_rate_snapshot,
         "budget_item_id": treatment.budget_item_id,
@@ -673,7 +671,6 @@ class TreatmentService:
 
         # 4. Compute snapshots.
         price_snapshot = None
-        currency_snapshot = None
         duration_snapshot = None
         vat_rate_snapshot = None
         if catalog_item is not None:
@@ -681,7 +678,6 @@ class TreatmentService:
                 PricingTooth(role=t["role"], surfaces=t["surfaces"]) for t in teeth_inputs
             ]
             price_snapshot = compute_price_snapshot(catalog_item, pricing_teeth)
-            currency_snapshot = catalog_item.currency
             duration_snapshot = compute_duration_snapshot(catalog_item, len(teeth_inputs))
             if catalog_item.vat_type_rel is not None:
                 vat_rate_snapshot = catalog_item.vat_type_rel.rate
@@ -700,7 +696,6 @@ class TreatmentService:
             performed_at=now if is_performed else None,
             performed_by=user_id if is_performed else None,
             price_snapshot=price_snapshot,
-            currency_snapshot=currency_snapshot,
             duration_snapshot=duration_snapshot,
             vat_rate_snapshot=vat_rate_snapshot,
             budget_item_id=budget_item_id,

--- a/backend/app/modules/patient_timeline/frontend/components/patient/PatientTimeline.vue
+++ b/backend/app/modules/patient_timeline/frontend/components/patient/PatientTimeline.vue
@@ -126,14 +126,12 @@ interface MetaChip {
   label: string
 }
 
-const currencyFormatter = computed(() =>
-  new Intl.NumberFormat(localeCode.value, { style: 'currency', currency: 'EUR', maximumFractionDigits: 2 })
-)
+const { format: formatCurrencyAmount } = useCurrency()
 
 function formatMoney(value: unknown): string | null {
   const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
   if (!isFinite(n)) return null
-  return currencyFormatter.value.format(n)
+  return formatCurrencyAmount(n)
 }
 
 function getEventMeta(entry: TimelineEntry): MetaChip[] {

--- a/backend/app/modules/patients/frontend/components/patient/AdministrationTab.vue
+++ b/backend/app/modules/patients/frontend/components/patient/AdministrationTab.vue
@@ -53,13 +53,8 @@ function formatDate(dateStr: string): string {
   })
 }
 
-// Format currency
-function formatCurrency(amount: number, currency: string = 'EUR'): string {
-  return new Intl.NumberFormat(locale.value, {
-    style: 'currency',
-    currency
-  }).format(amount)
-}
+// Format currency — clinic-wide via useCurrency.
+const { format: formatCurrency } = useCurrency()
 </script>
 
 <template>
@@ -174,7 +169,7 @@ function formatCurrency(amount: number, currency: string = 'EUR'): string {
               </div>
               <div class="flex items-center gap-4">
                 <span class="font-semibold text-default">
-                  {{ formatCurrency(budget.total, budget.currency) }}
+                  {{ formatCurrency(budget.total) }}
                 </span>
                 <UIcon
                   name="i-lucide-chevron-right"

--- a/backend/app/modules/reports/frontend/components/home/OverdueHeroTile.vue
+++ b/backend/app/modules/reports/frontend/components/home/OverdueHeroTile.vue
@@ -21,9 +21,7 @@ const surfaceClass = computed(() =>
   total.value === 0 ? 'bg-surface ring-1 ring-[var(--color-border)] shadow-[var(--shadow-sm)]' : 'alert-surface-danger'
 )
 
-function formatMoney(n: number): string {
-  return n.toLocaleString(locale.value, { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 })
-}
+const { format: formatMoney } = useCurrency()
 </script>
 
 <template>

--- a/backend/app/modules/reports/frontend/components/home/OverdueInvoicesPanel.vue
+++ b/backend/app/modules/reports/frontend/components/home/OverdueInvoicesPanel.vue
@@ -15,13 +15,7 @@ onActivated(() => {
 
 const topFive = computed(() => overdue.value.slice(0, 5))
 
-function formatMoney(n: number | string): string {
-  return Number(n).toLocaleString(locale.value, {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 2
-  })
-}
+const { format: formatMoney } = useCurrency()
 </script>
 
 <template>

--- a/backend/app/modules/reports/frontend/components/home/WeekGlancePanel.vue
+++ b/backend/app/modules/reports/frontend/components/home/WeekGlancePanel.vue
@@ -46,9 +46,7 @@ async function load() {
 onMounted(load)
 onActivated(load)
 
-function formatMoney(n: number): string {
-  return n.toLocaleString(locale.value, { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 })
-}
+const { format: formatMoney } = useCurrency()
 
 function delta(cur: number, prev: number): { pct: number | null, dir: 'up' | 'down' | 'flat' } {
   if (!prev) return { pct: null, dir: 'flat' }

--- a/backend/app/modules/reports/frontend/composables/useReports.ts
+++ b/backend/app/modules/reports/frontend/composables/useReports.ts
@@ -461,12 +461,11 @@ export function useReports() {
   // Helpers
   // ============================================================================
 
+  // Currency follows clinic.currency; locale follows the user's UI.
+  const { format } = useCurrency()
   function formatCurrency(value: string | number): string {
     const num = typeof value === 'string' ? parseFloat(value) : value
-    return new Intl.NumberFormat('es-ES', {
-      style: 'currency',
-      currency: 'EUR'
-    }).format(num)
+    return format(num)
   }
 
   function getBudgetStatusLabel(status: string): string {

--- a/backend/app/modules/reports/schemas.py
+++ b/backend/app/modules/reports/schemas.py
@@ -92,7 +92,6 @@ class PatientBillingSummary(BaseModel):
     """Patient billing summary (budgets + invoices)."""
 
     patient_id: UUID
-    currency: str
 
     # Budget metrics
     total_budgeted: Decimal

--- a/backend/app/modules/reports/services/billing.py
+++ b/backend/app/modules/reports/services/billing.py
@@ -9,7 +9,7 @@ from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from app.core.auth.models import Clinic, User
+from app.core.auth.models import User
 from app.modules.billing.models import Invoice, InvoiceItem, InvoiceSeries, Payment
 from app.modules.budget.models import Budget
 from app.modules.catalog.models import VatType
@@ -27,7 +27,6 @@ class BillingReportService:
         """Get billing summary for a specific patient.
 
         Returns:
-            - currency: Clinic currency
             - total_budgeted: Sum of all budgets
             - work_in_progress: Sum of accepted budgets
             - work_completed: Sum of completed budgets
@@ -36,11 +35,6 @@ class BillingReportService:
             - balance_pending: total_invoiced - total_paid
         """
         from sqlalchemy import case
-
-        # Get clinic currency
-        clinic_result = await db.execute(select(Clinic).where(Clinic.id == clinic_id))
-        clinic = clinic_result.scalar_one()
-        currency = clinic.settings.get("currency", "EUR") if clinic.settings else "EUR"
 
         # Budget aggregation
         budget_result = await db.execute(
@@ -82,7 +76,6 @@ class BillingReportService:
 
         return {
             "patient_id": patient_id,
-            "currency": currency,
             "total_budgeted": budget_totals.total_budgeted,
             "work_in_progress": budget_totals.work_in_progress,
             "work_completed": budget_totals.work_completed,

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/PlanTreatmentList.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/PlanTreatmentList.vue
@@ -170,14 +170,8 @@ function getItemPrice(item: PlannedTreatmentItem): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
-// Format currency
-function formatCurrency(amount: number | undefined): string {
-  if (amount === undefined) return ''
-  return new Intl.NumberFormat(locale.value, {
-    style: 'currency',
-    currency: 'EUR'
-  }).format(amount)
-}
+// Format currency — clinic-wide via useCurrency.
+const { format: formatCurrency } = useCurrency()
 </script>
 
 <template>

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanDetail.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanDetail.vue
@@ -14,7 +14,8 @@ const emit = defineEmits<{
   'item-remove': [itemId: string]
 }>()
 
-const { t, d, n } = useI18n()
+const { t, d } = useI18n()
+const { format: formatMoney } = useCurrency()
 
 // Collapsible state for completed items
 const showCompleted = ref(false)
@@ -190,7 +191,7 @@ function getBudgetStatusColor(status: string): string {
           {{ t(`budget.status.${plan.budget.status}`) }}
         </UBadge>
         <span class="text-sm font-semibold text-default">
-          {{ n(plan.budget.total, 'currency') }}
+          {{ formatMoney(plan.budget.total) }}
         </span>
         <UIcon
           name="i-lucide-external-link"
@@ -308,7 +309,7 @@ function getBudgetStatusColor(status: string): string {
                 v-if="getItemPrice(item)"
                 class="text-sm font-medium text-muted"
               >
-                {{ n(getItemPrice(item)!, 'currency') }}
+                {{ formatMoney(getItemPrice(item)) }}
               </span>
               <UButton
                 color="success"
@@ -384,7 +385,7 @@ function getBudgetStatusColor(status: string): string {
               v-if="getItemPrice(item)"
               class="text-sm text-muted flex-shrink-0"
             >
-              {{ n(getItemPrice(item)!, 'currency') }}
+              {{ formatMoney(getItemPrice(item)) }}
             </span>
           </div>
         </div>

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanMiniCard.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanMiniCard.vue
@@ -36,10 +36,8 @@ function getStatusColor(status: TreatmentPlanStatus) {
   return statusColors[status] || 'neutral'
 }
 
-// Format currency
-function formatCurrency(amount: number, currency = 'EUR') {
-  return new Intl.NumberFormat(locale.value, { style: 'currency', currency }).format(amount)
-}
+// Format currency — clinic-wide via useCurrency.
+const { format: formatCurrency } = useCurrency()
 </script>
 
 <template>

--- a/backend/app/modules/treatment_plan/schemas.py
+++ b/backend/app/modules/treatment_plan/schemas.py
@@ -66,7 +66,6 @@ class TreatmentBrief(BaseModel):
     catalog_item_id: UUID | None = None
     catalog_item: CatalogItemBrief | None = None
     price_snapshot: Decimal | None = None
-    currency_snapshot: str | None = None
     teeth: list[TreatmentToothBrief] = Field(default_factory=list)
 
 

--- a/backend/app/seeds/demo_data.py
+++ b/backend/app/seeds/demo_data.py
@@ -91,10 +91,10 @@ def get_clinic_data() -> dict:
         },
         "phone": t({"es": "+34 912 345 678", "en": "+1 (212) 555-0100"}),
         "email": "info@demo.clinic",
+        "currency": t({"es": "EUR", "en": "USD"}),
+        "timezone": t({"es": "Europe/Madrid", "en": "America/New_York"}),
         "settings": {
             "slot_duration_min": 30,
-            "currency": t({"es": "EUR", "en": "USD"}),
-            "timezone": t({"es": "Europe/Madrid", "en": "America/New_York"}),
             "working_hours": {
                 "monday": {"morning": ["09:00", "14:00"], "afternoon": ["16:00", "20:00"]},
                 "tuesday": {"morning": ["09:00", "14:00"], "afternoon": ["16:00", "20:00"]},
@@ -1240,7 +1240,6 @@ def generate_odontogram_data() -> dict:
                     "performed_at": performed_at,
                     "performed_by": USER_DENTIST_ID if status == "performed" else None,
                     "price_snapshot": None,
-                    "currency_snapshot": None,
                     "duration_snapshot": None,
                     "vat_rate_snapshot": None,
                     "budget_item_id": None,
@@ -1961,7 +1960,6 @@ def generate_treatment_plans_data(catalog_items_map: dict[str, dict]) -> dict:
                     "performed_at": performed_at,
                     "performed_by": USER_DENTIST_ID if is_completed else None,
                     "price_snapshot": catalog_item.get("default_price"),
-                    "currency_snapshot": "EUR",
                     "duration_snapshot": None,
                     "vat_rate_snapshot": None,
                     "budget_item_id": None,
@@ -2149,7 +2147,6 @@ def generate_budgets_data(catalog_items_map: dict[str, dict], plans_result: dict
                 "total_discount": total_discount,
                 "total_tax": total_tax,
                 "total": total,
-                "currency": t({"es": "EUR", "en": "USD"}),
                 "internal_notes": t(budget_scenario["notes"])
                 if budget_scenario.get("notes")
                 else None,
@@ -2555,7 +2552,6 @@ def generate_invoices_data(catalog_items_map: dict[str, dict], budgets_result: d
                 "total": total,
                 "total_paid": total_paid,
                 "balance_due": total - total_paid,
-                "currency": t({"es": "EUR", "en": "USD"}),
                 "internal_notes": t(invoice_scenario["notes"])
                 if invoice_scenario.get("notes")
                 else None,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     # which Python base image the backend runs on (Alpine ships with
     # no system tzdata by default).
     "tzdata>=2024.1",
+    # Locale-aware currency formatting (PDFs, emails). Stdlib has no
+    # equivalent of Intl.NumberFormat; babel is the de facto standard.
+    "babel>=2.14",
     # Verifactu (AEAT) module dependencies. httpx for mTLS submissions,
     # lxml for SOAP response parsing, qrcode for the per-invoice QR.
     "httpx>=0.26.0",

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -155,6 +155,8 @@ async def seed_clinic(db: AsyncSession) -> Clinic:
         address=clinic_data["address"],
         phone=clinic_data["phone"],
         email=clinic_data["email"],
+        timezone=clinic_data["timezone"],
+        currency=clinic_data["currency"],
         settings=clinic_data["settings"],
     )
     db.add(clinic)

--- a/backend/tests/test_budget.py
+++ b/backend/tests/test_budget.py
@@ -74,7 +74,6 @@ async def budget_clinic_setup(
         names={"es": "Tratamiento Test", "en": "Test Treatment"},
         descriptions={"es": "Descripción", "en": "Description"},
         default_price=100.00,
-        currency="EUR",
         vat_type_id=vat_type.id,
         treatment_scope="whole_tooth",
         is_diagnostic=False,

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -236,7 +236,6 @@ async def test_create_catalog_item(
             "names": {"es": "Tratamiento de Prueba", "en": "Test Treatment"},
             "descriptions": {"es": "Descripción", "en": "Description"},
             "default_price": 100.00,
-            "currency": "EUR",
             "vat_type_id": catalog_clinic_setup["vat_exempt_id"],
             "treatment_scope": "tooth",
             "is_diagnostic": False,

--- a/backend/tests/test_currency.py
+++ b/backend/tests/test_currency.py
@@ -1,0 +1,79 @@
+"""Currency: helper + clinic-level setting + cross-module inheritance."""
+
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic
+from app.core.utils.currency import format_currency
+
+# ---------------------------------------------------------------------------
+# Helper: babel-backed format_currency
+# ---------------------------------------------------------------------------
+
+
+def test_format_currency_eur_es() -> None:
+    out = format_currency(Decimal("1234.56"), "EUR", locale="es_ES")
+    # Babel renders es_ES EUR with comma decimal + non-breaking space + €.
+    assert "1234" in out.replace(".", "") or "1.234" in out
+    assert "€" in out
+
+
+def test_format_currency_usd_en() -> None:
+    out = format_currency(Decimal("1234.56"), "USD", locale="en_US")
+    assert out == "$1,234.56"
+
+
+def test_format_currency_locale_dash_normalized() -> None:
+    """``en-US`` (BCP 47) is accepted and normalized to ``en_US``."""
+    out = format_currency(100, "USD", locale="en-US")
+    assert out == "$100.00"
+
+
+# ---------------------------------------------------------------------------
+# Clinic currency PUT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clinic_currency_default_is_eur(
+    db_session: AsyncSession, test_clinic: Clinic
+) -> None:
+    await db_session.refresh(test_clinic)
+    assert test_clinic.currency == "EUR"
+
+
+@pytest.mark.asyncio
+async def test_update_clinic_currency_persists(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    test_clinic: Clinic,
+    db_session: AsyncSession,
+) -> None:
+    response = await client.put(
+        "/api/v1/auth/clinics",
+        json={"currency": "USD"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["currency"] == "USD"
+
+    db_session.expire_all()
+    await db_session.refresh(test_clinic)
+    assert test_clinic.currency == "USD"
+
+
+@pytest.mark.asyncio
+async def test_update_clinic_currency_rejects_invalid_iso(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    test_clinic: Clinic,
+) -> None:
+    response = await client.put(
+        "/api/v1/auth/clinics",
+        json={"currency": "euro"},  # not 3 uppercase letters
+        headers=auth_headers,
+    )
+    assert response.status_code == 422

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -77,7 +77,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 These literals appear in `event_bus.publish(...)` but do not match any `EventType` constant. Add them to `backend/app/core/events/types.py` to keep the enum authoritative.
 
 - `treatment_plan.items_reordered` — 1 site(s):
-  - `app/app/modules/treatment_plan/service.py:552`
+  - `backend/app/modules/treatment_plan/service.py:552`
 
 ## Detail
 
@@ -85,7 +85,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.AGENDA_VISIT_NOTE_UPDATED`
 - **Publishers:**
-  - `agenda` — `app/app/modules/agenda/service.py:812`
+  - `agenda` — `backend/app/modules/agenda/service.py:812`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -93,7 +93,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.APPOINTMENT_CABINET_CHANGED`
 - **Publishers:**
-  - `agenda` — `app/app/modules/agenda/service.py:749`
+  - `agenda` — `backend/app/modules/agenda/service.py:749`
 - **Subscribers:** —
 
 ### `appointment.cancelled`
@@ -145,7 +145,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.APPOINTMENT_SCHEDULED`
 - **Publishers:**
-  - `agenda` — `app/app/modules/agenda/service.py:453`
+  - `agenda` — `backend/app/modules/agenda/service.py:453`
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
@@ -155,14 +155,14 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.APPOINTMENT_STATUS_CHANGED`
 - **Publishers:**
-  - `agenda` — `app/app/modules/agenda/service.py:678`
+  - `agenda` — `backend/app/modules/agenda/service.py:678`
 - **Subscribers:** —
 
 ### `appointment.updated`
 
 - **Constant:** `EventType.APPOINTMENT_UPDATED`
 - **Publishers:**
-  - `agenda` — `app/app/modules/agenda/service.py:578`
+  - `agenda` — `backend/app/modules/agenda/service.py:578`
 - **Subscribers:**
   - `schedules`
 
@@ -170,7 +170,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_ACCEPTED`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:298`
+  - `budget` — `backend/app/modules/budget/workflow.py:298`
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
@@ -186,7 +186,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_EXPIRED`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:472`
+  - `budget` — `backend/app/modules/budget/workflow.py:472`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -194,7 +194,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_REJECTED`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:375`
+  - `budget` — `backend/app/modules/budget/workflow.py:375`
 - **Subscribers:**
   - `patient_timeline`
   - `treatment_plan`
@@ -203,7 +203,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_REMINDER_SENT`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:598`
+  - `budget` — `backend/app/modules/budget/workflow.py:598`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -211,7 +211,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_RENEGOTIATED`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:543`
+  - `budget` — `backend/app/modules/budget/workflow.py:543`
 - **Subscribers:**
   - `patient_timeline`
   - `treatment_plan`
@@ -220,7 +220,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_SENT`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:160`
+  - `budget` — `backend/app/modules/budget/workflow.py:160`
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
@@ -229,7 +229,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.BUDGET_VIEWED`
 - **Publishers:**
-  - `budget` — `app/app/modules/budget/workflow.py:571`
+  - `budget` — `backend/app/modules/budget/workflow.py:571`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -277,14 +277,14 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.DOCUMENT_DELETED`
 - **Publishers:**
-  - `media` — `app/app/modules/media/service.py:178`
+  - `media` — `backend/app/modules/media/service.py:178`
 - **Subscribers:** —
 
 ### `document.uploaded`
 
 - **Constant:** `EventType.DOCUMENT_UPLOADED`
 - **Publishers:**
-  - `media` — `app/app/modules/media/service.py:138`
+  - `media` — `backend/app/modules/media/service.py:138`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -318,7 +318,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.INVOICE_ISSUED`
 - **Publishers:**
-  - `billing` — `app/app/modules/billing/workflow.py:278`
+  - `billing` — `backend/app/modules/billing/workflow.py:278`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -326,7 +326,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.INVOICE_PAID`
 - **Publishers:**
-  - `billing` — `app/app/modules/billing/workflow.py:488`
+  - `billing` — `backend/app/modules/billing/workflow.py:488`
 - **Subscribers:**
   - `patient_timeline`
   - `verifactu`
@@ -341,7 +341,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.INVOICE_SENT`
 - **Publishers:**
-  - `billing` — `app/app/modules/billing/router.py:659`
+  - `billing` — `backend/app/modules/billing/router.py:659`
 - **Subscribers:**
   - `notifications`
 
@@ -373,21 +373,21 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.ODONTOGRAM_TREATMENT_ADDED`
 - **Publishers:**
-  - `odontogram` — `app/app/modules/odontogram/service.py:730`
+  - `odontogram` — `backend/app/modules/odontogram/service.py:725`
 - **Subscribers:** —
 
 ### `odontogram.treatment.deleted`
 
 - **Constant:** `EventType.ODONTOGRAM_TREATMENT_DELETED`
 - **Publishers:**
-  - `odontogram` — `app/app/modules/odontogram/service.py:876`
+  - `odontogram` — `backend/app/modules/odontogram/service.py:871`
 - **Subscribers:** —
 
 ### `odontogram.treatment.performed`
 
 - **Constant:** `EventType.ODONTOGRAM_TREATMENT_PERFORMED`
 - **Publishers:**
-  - `odontogram` — `app/app/modules/odontogram/service.py:830`
+  - `odontogram` — `backend/app/modules/odontogram/service.py:825`
 - **Subscribers:**
   - `budget`
   - `patient_timeline`
@@ -397,14 +397,14 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.ODONTOGRAM_TREATMENT_STATUS_CHANGED`
 - **Publishers:**
-  - `odontogram` — `app/app/modules/odontogram/service.py:774`
+  - `odontogram` — `backend/app/modules/odontogram/service.py:769`
 - **Subscribers:** —
 
 ### `patient.archived`
 
 - **Constant:** `EventType.PATIENT_ARCHIVED`
 - **Publishers:**
-  - `patients` — `app/app/modules/patients/service.py:142`
+  - `patients` — `backend/app/modules/patients/service.py:142`
 - **Subscribers:**
   - `media`
 
@@ -412,7 +412,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.PATIENT_CREATED`
 - **Publishers:**
-  - `patients` — `app/app/modules/patients/service.py:113`
+  - `patients` — `backend/app/modules/patients/service.py:113`
 - **Subscribers:**
   - `notifications`
 
@@ -420,8 +420,8 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.PATIENT_MEDICAL_UPDATED`
 - **Publishers:**
-  - `patients_clinical` — `app/app/modules/patients_clinical/router.py:94`
-  - `patients_clinical` — `app/app/modules/patients_clinical/router.py:593`
+  - `patients_clinical` — `backend/app/modules/patients_clinical/router.py:94`
+  - `patients_clinical` — `backend/app/modules/patients_clinical/router.py:593`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -429,7 +429,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.PATIENT_UPDATED`
 - **Publishers:**
-  - `patients` — `app/app/modules/patients/service.py:131`
+  - `patients` — `backend/app/modules/patients/service.py:131`
 - **Subscribers:** —
 
 ### `payment.recorded`
@@ -454,7 +454,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_BUDGET_SYNC_REQUESTED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:837`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:837`
 - **Subscribers:**
   - `budget`
 
@@ -462,8 +462,8 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_CLOSED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1268`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1406`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1268`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1406`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -471,7 +471,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_CONFIRMED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1175`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1175`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -479,7 +479,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_CREATED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:221`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:221`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -487,7 +487,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_ITEM_COMPLETED_WITHOUT_NOTE`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:710`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:710`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -495,7 +495,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_REACTIVATED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1314`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1314`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -503,21 +503,21 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_STATUS_CHANGED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:287`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:746`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1176`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1223`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1281`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1325`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1363`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:1419`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:287`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:746`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1176`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1223`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1281`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1325`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1363`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1419`
 - **Subscribers:** —
 
 ### `treatment_plan.treatment_added`
 
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_ADDED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:438`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:438`
 - **Subscribers:**
   - `budget`
 
@@ -525,9 +525,9 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/events.py:61`
-  - `treatment_plan` — `app/app/modules/treatment_plan/events.py:199`
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:693`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:61`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:199`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:693`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -535,7 +535,7 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_REMOVED`
 - **Publishers:**
-  - `treatment_plan` — `app/app/modules/treatment_plan/service.py:616`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:616`
 - **Subscribers:**
   - `budget`
 
@@ -543,5 +543,5 @@ These literals appear in `event_bus.publish(...)` but do not match any `EventTyp
 
 - **Constant:** `EventType.VERIFACTU_RECORD_REJECTED`
 - **Publishers:**
-  - `verifactu` — `app/app/modules/verifactu/services/submission_queue.py:271`
+  - `verifactu` — `backend/app/modules/verifactu/services/submission_queue.py:271`
 - **Subscribers:** —

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -50,7 +50,7 @@ Appointments, scheduling, cabinets.
   - `appointment.status_changed`
   - `appointment.updated`
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/agenda/CLAUDE.md`](../app/app/modules/agenda/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/agenda/CLAUDE.md`](../backend/app/modules/agenda/CLAUDE.md)
 
 ### `billing` — v0.1.0
 
@@ -71,7 +71,7 @@ Invoices, payments, credit notes, PDF billing.
   - `invoice.paid`
   - `invoice.sent`
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/billing/CLAUDE.md`](../app/app/modules/billing/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/billing/CLAUDE.md`](../backend/app/modules/billing/CLAUDE.md)
 
 ### `budget` — v0.1.0
 
@@ -102,7 +102,7 @@ Dental treatment quotes, versioning, signatures.
   - `treatment_plan.budget_sync_requested`
   - `treatment_plan.treatment_added`
   - `treatment_plan.treatment_removed`
-- **Module CLAUDE.md:** [`app/app/modules/budget/CLAUDE.md`](../app/app/modules/budget/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/budget/CLAUDE.md`](../backend/app/modules/budget/CLAUDE.md)
 
 ### `catalog` — v0.1.0
 
@@ -120,7 +120,7 @@ Treatment catalog, categories, VAT types.
   - `catalog.write`
 - **Events emitted:** —
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/catalog/CLAUDE.md`](../app/app/modules/catalog/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/catalog/CLAUDE.md`](../backend/app/modules/catalog/CLAUDE.md)
 
 ### `clinical_notes` — v0.1.0
 
@@ -137,7 +137,7 @@ Polymorphic clinical notes (administrative, diagnosis, treatment, treatment plan
   - `clinical_notes.notes.write`
 - **Events emitted:** —
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/clinical_notes/CLAUDE.md`](../app/app/modules/clinical_notes/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/clinical_notes/CLAUDE.md`](../backend/app/modules/clinical_notes/CLAUDE.md)
 
 ### `media` — v0.1.0
 
@@ -157,7 +157,7 @@ Patient documents, images, file storage.
   - `document.uploaded`
 - **Events consumed:**
   - `patient.archived`
-- **Module CLAUDE.md:** [`app/app/modules/media/CLAUDE.md`](../app/app/modules/media/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/media/CLAUDE.md`](../backend/app/modules/media/CLAUDE.md)
 
 ### `notifications` — v0.1.0
 
@@ -186,7 +186,7 @@ Email templates, preferences, SMTP, event-driven sending.
   - `budget.sent`
   - `invoice.sent`
   - `patient.created`
-- **Module CLAUDE.md:** [`app/app/modules/notifications/CLAUDE.md`](../app/app/modules/notifications/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/notifications/CLAUDE.md`](../backend/app/modules/notifications/CLAUDE.md)
 
 ### `odontogram` — v0.3.0
 
@@ -209,7 +209,7 @@ Dental charting, tooth state, clinical treatments.
   - `odontogram.treatment.performed`
   - `odontogram.treatment.status_changed`
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/odontogram/CLAUDE.md`](../app/app/modules/odontogram/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/odontogram/CLAUDE.md`](../backend/app/modules/odontogram/CLAUDE.md)
 
 ### `patient_timeline` — v0.1.0
 
@@ -257,7 +257,7 @@ Patient timeline — unified activity log.
   - `treatment_plan.item_completed_without_note`
   - `treatment_plan.reactivated`
   - `treatment_plan.treatment_completed`
-- **Module CLAUDE.md:** [`app/app/modules/patient_timeline/CLAUDE.md`](../app/app/modules/patient_timeline/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/patient_timeline/CLAUDE.md`](../backend/app/modules/patient_timeline/CLAUDE.md)
 
 ### `patients` — v0.1.0
 
@@ -277,7 +277,7 @@ Patient identity: name, contact, demographics, status.
   - `patient.created`
   - `patient.updated`
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/patients/CLAUDE.md`](../app/app/modules/patients/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/patients/CLAUDE.md`](../backend/app/modules/patients/CLAUDE.md)
 
 ### `patients_clinical` — v0.1.0
 
@@ -297,7 +297,7 @@ Normalized medical history, allergies, medications, emergency contacts.
 - **Events emitted:**
   - `patient.medical_updated`
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/patients_clinical/CLAUDE.md`](../app/app/modules/patients_clinical/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/patients_clinical/CLAUDE.md`](../backend/app/modules/patients_clinical/CLAUDE.md)
 
 ### `reports` — v0.1.0
 
@@ -315,7 +315,7 @@ Cross-module reporting: billing, budgets, scheduling.
   - `reports.scheduling.read`
 - **Events emitted:** —
 - **Events consumed:** —
-- **Module CLAUDE.md:** [`app/app/modules/reports/CLAUDE.md`](../app/app/modules/reports/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/reports/CLAUDE.md`](../backend/app/modules/reports/CLAUDE.md)
 
 ### `schedules` — v0.1.0
 
@@ -341,7 +341,7 @@ Clinic + professional operating hours, overrides, availability, and occupancy an
   - `appointment.cancelled`
   - `appointment.scheduled`
   - `appointment.updated`
-- **Module CLAUDE.md:** [`app/app/modules/schedules/CLAUDE.md`](../app/app/modules/schedules/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/schedules/CLAUDE.md`](../backend/app/modules/schedules/CLAUDE.md)
 
 ### `treatment_plan` — v0.1.0
 
@@ -377,7 +377,7 @@ Patient treatment plans with budget + odontogram sync.
   - `budget.rejected`
   - `budget.renegotiated`
   - `odontogram.treatment.performed`
-- **Module CLAUDE.md:** [`app/app/modules/treatment_plan/CLAUDE.md`](../app/app/modules/treatment_plan/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/treatment_plan/CLAUDE.md`](../backend/app/modules/treatment_plan/CLAUDE.md)
 
 ### `verifactu` — v0.1.0
 
@@ -399,4 +399,4 @@ Cumplimiento Veri*Factu (AEAT) para clínicas en España.
   - `verifactu.record.rejected`
 - **Events consumed:**
   - `invoice.paid`
-- **Module CLAUDE.md:** [`app/app/modules/verifactu/CLAUDE.md`](../app/app/modules/verifactu/CLAUDE.md)
+- **Module CLAUDE.md:** [`backend/app/modules/verifactu/CLAUDE.md`](../backend/app/modules/verifactu/CLAUDE.md)

--- a/frontend/app/components/settings/pages/ClinicInfoPage.vue
+++ b/frontend/app/components/settings/pages/ClinicInfoPage.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type { ClinicAddress, ClinicUpdate } from '~/types'
+import { SUPPORTED_CURRENCIES } from '~/constants/currencies'
 
 const { t } = useI18n()
 const clinic = useClinic()
-const { isAdmin } = usePermissions()
+const { can } = usePermissions()
+const canEdit = computed(() => can('admin.clinic.write'))
 
 const COUNTRY_CODES = [
   'AD', 'AE', 'AF', 'AG', 'AL', 'AM', 'AO', 'AR', 'AT', 'AU', 'AZ',
@@ -63,6 +65,20 @@ function translateCountry(value: string | undefined | null): string {
   return value
 }
 
+const currencyOptions = computed(() => {
+  let displayNames: Intl.DisplayNames | null = null
+  try {
+    displayNames = new Intl.DisplayNames([currentLocale.value], { type: 'currency' })
+  } catch {
+    displayNames = null
+  }
+  const collator = new Intl.Collator(currentLocale.value, { sensitivity: 'base' })
+  return SUPPORTED_CURRENCIES.map(code => ({
+    value: code,
+    label: displayNames?.of(code) ? `${code} — ${displayNames.of(code)}` : code
+  })).sort((a, b) => collator.compare(a.label, b.label))
+})
+
 const timezoneOptions = [
   { label: 'Europe/Madrid', value: 'Europe/Madrid' },
   { label: 'Europe/London', value: 'Europe/London' },
@@ -93,7 +109,8 @@ const form = ref({
   country: '',
   phone: '',
   email: '',
-  timezone: 'Europe/Madrid'
+  timezone: 'Europe/Madrid',
+  currency: 'EUR'
 })
 
 function loadForm() {
@@ -108,7 +125,8 @@ function loadForm() {
     country: c?.address?.country || '',
     phone: c?.phone || '',
     email: c?.email || '',
-    timezone: c?.timezone || 'Europe/Madrid'
+    timezone: c?.timezone || 'Europe/Madrid',
+    currency: c?.currency || 'EUR'
   }
 }
 
@@ -136,7 +154,8 @@ async function save() {
     address,
     phone: form.value.phone || undefined,
     email: form.value.email || undefined,
-    timezone: form.value.timezone || undefined
+    timezone: form.value.timezone || undefined,
+    currency: form.value.currency || undefined
   }
   const result = await clinic.updateClinic(updateData)
   isSaving.value = false
@@ -160,7 +179,7 @@ function formatAddress(address?: Record<string, string>): string {
     :title="t('settings.clinicInfo')"
   >
     <template
-      v-if="isAdmin && !editing"
+      v-if="canEdit && !editing"
       #actions
     >
       <UButton
@@ -217,6 +236,10 @@ function formatAddress(address?: Record<string, string>): string {
       <DataField
         :label="t('settings.timezone')"
         :value="clinic.currentClinic.value.timezone"
+      />
+      <DataField
+        :label="t('settings.currency')"
+        :value="clinic.currentClinic.value.currency"
       />
     </div>
 
@@ -285,17 +308,30 @@ function formatAddress(address?: Record<string, string>): string {
         </UFormField>
       </div>
 
-      <UFormField
-        :label="t('settings.timezone')"
-        :help="t('settings.timezoneHelp')"
-      >
-        <USelect
-          v-model="form.timezone"
-          :items="timezoneOptions"
-          value-key="value"
-          label-key="label"
-        />
-      </UFormField>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <UFormField
+          :label="t('settings.timezone')"
+          :help="t('settings.timezoneHelp')"
+        >
+          <USelect
+            v-model="form.timezone"
+            :items="timezoneOptions"
+            value-key="value"
+            label-key="label"
+          />
+        </UFormField>
+        <UFormField
+          :label="t('settings.currency')"
+          :help="t('settings.currencyHelp')"
+        >
+          <USelect
+            v-model="form.currency"
+            :items="currencyOptions"
+            value-key="value"
+            label-key="label"
+          />
+        </UFormField>
+      </div>
 
       <div class="flex justify-end gap-2 pt-2">
         <UButton

--- a/frontend/app/components/shared/Money.vue
+++ b/frontend/app/components/shared/Money.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 interface Props {
   /** Amount in major units (e.g. euros). Accepts null/undefined → renders placeholder */
-  value: number | null | undefined
-  /** ISO 4217 code */
-  currency?: string
-  /** BCP 47 locale */
-  locale?: string
+  value: number | string | null | undefined
   /** Render negative values in `--color-danger-text` */
   signed?: boolean
   /** Bold weight (e.g. for total rows) */
@@ -15,26 +11,20 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  currency: 'EUR',
-  locale: 'es-ES',
   signed: false,
   strong: false,
   placeholder: '—'
 })
 
-const formatted = computed(() => {
-  if (props.value === null || props.value === undefined || Number.isNaN(props.value)) {
-    return props.placeholder
-  }
-  return new Intl.NumberFormat(props.locale, {
-    style: 'currency',
-    currency: props.currency
-  }).format(props.value)
-})
+const { format } = useCurrency()
 
-const isNegative = computed(() =>
-  props.signed && typeof props.value === 'number' && props.value < 0
-)
+const formatted = computed(() => format(props.value) || props.placeholder)
+
+const isNegative = computed(() => {
+  if (!props.signed) return false
+  const n = typeof props.value === 'string' ? Number(props.value) : props.value
+  return typeof n === 'number' && !Number.isNaN(n) && n < 0
+})
 </script>
 
 <template>

--- a/frontend/app/components/shared/PlannedTreatmentSelector.vue
+++ b/frontend/app/components/shared/PlannedTreatmentSelector.vue
@@ -5,7 +5,6 @@ const props = defineProps<{
   modelValue?: PlannedTreatmentItem[]
   patientId?: string
   placeholder?: string
-  currency?: string
 }>()
 
 const emit = defineEmits<{
@@ -225,7 +224,7 @@ const hasPendingTreatments = computed(() => {
               v-if="getItemPrice(item)"
               class="text-sm font-semibold text-primary-accent"
             >
-              {{ formatPrice(getItemPrice(item), currency || 'EUR') }}
+              {{ formatPrice(getItemPrice(item)) }}
             </span>
             <UButton
               variant="ghost"
@@ -321,7 +320,7 @@ const hasPendingTreatments = computed(() => {
                 v-if="getItemPrice(item)"
                 class="text-sm font-semibold text-primary-accent whitespace-nowrap"
               >
-                {{ formatPrice(getItemPrice(item), currency || 'EUR') }}
+                {{ formatPrice(getItemPrice(item)) }}
               </span>
             </div>
           </button>

--- a/frontend/app/components/shared/TreatmentMultiSelector.vue
+++ b/frontend/app/components/shared/TreatmentMultiSelector.vue
@@ -4,7 +4,6 @@ import type { TreatmentCatalogItem, ApiResponse } from '~/types'
 const props = defineProps<{
   modelValue?: TreatmentCatalogItem[]
   placeholder?: string
-  currency?: string
 }>()
 
 const emit = defineEmits<{
@@ -145,7 +144,7 @@ const totalDuration = computed(() => {
             {{ item.default_duration_minutes }} min
           </span>
           <span class="text-sm font-semibold text-primary-accent">
-            {{ formatPrice(item.default_price, currency || 'EUR') }}
+            {{ formatPrice(item.default_price) }}
           </span>
           <UButton
             variant="ghost"
@@ -218,7 +217,7 @@ const totalDuration = computed(() => {
             <div class="flex items-center justify-between">
               <span class="text-caption text-subtle">{{ item.internal_code }}</span>
               <span class="text-sm font-semibold text-primary-accent">
-                {{ formatPrice(item.default_price, currency || 'EUR') }}
+                {{ formatPrice(item.default_price) }}
               </span>
             </div>
             <UBadge

--- a/frontend/app/components/shared/TreatmentVisualSelector.vue
+++ b/frontend/app/components/shared/TreatmentVisualSelector.vue
@@ -4,7 +4,6 @@ import type { TreatmentCatalogItem, ApiResponse } from '~/types'
 const props = defineProps<{
   modelValue?: TreatmentCatalogItem | null
   placeholder?: string
-  currency?: string
   inModal?: boolean
 }>()
 
@@ -104,7 +103,7 @@ function getCategoryName(item: TreatmentCatalogItem): string {
         </div>
         <div class="flex items-center gap-2">
           <span class="text-h1 text-default text-primary-accent">
-            {{ formatPrice(selectedItem.default_price, currency || 'EUR') }}
+            {{ formatPrice(selectedItem.default_price) }}
           </span>
           <UButton
             variant="ghost"
@@ -139,7 +138,7 @@ function getCategoryName(item: TreatmentCatalogItem): string {
           <div class="flex items-center justify-between">
             <span class="text-caption text-subtle">{{ item.internal_code }}</span>
             <span class="text-sm font-semibold text-primary-accent">
-              {{ formatPrice(item.default_price, currency || 'EUR') }}
+              {{ formatPrice(item.default_price) }}
             </span>
           </div>
           <UBadge

--- a/frontend/app/composables/useCurrency.ts
+++ b/frontend/app/composables/useCurrency.ts
@@ -1,0 +1,28 @@
+// Single source of truth for rendering money in the frontend.
+// - Currency comes from `currentClinic.currency` (one clinic = one currency).
+// - Locale follows the user's UI language (Intl handles separators/symbols).
+//
+// Components that render money should call `format()` (or use the `<Money>`
+// component, which delegates here). No callsite should hardcode 'EUR' or
+// inline `Intl.NumberFormat`.
+
+export function useCurrency() {
+  const { currentClinic } = useClinic()
+  const { currentLocale } = useLocale()
+
+  function format(amount: number | string | null | undefined): string {
+    if (amount == null || amount === '') return '—'
+    const value = typeof amount === 'string' ? Number(amount) : amount
+    if (Number.isNaN(value)) return '—'
+    const currency = currentClinic.value?.currency ?? 'EUR'
+    return new Intl.NumberFormat(currentLocale.value, {
+      style: 'currency',
+      currency
+    }).format(value)
+  }
+
+  return {
+    format,
+    currency: computed(() => currentClinic.value?.currency ?? 'EUR')
+  }
+}

--- a/frontend/app/constants/currencies.ts
+++ b/frontend/app/constants/currencies.ts
@@ -1,0 +1,18 @@
+// Curated ISO 4217 currency list for the clinic settings selector.
+// Localized names are resolved at render time via Intl.DisplayNames,
+// so we only ship the codes here.
+
+export const SUPPORTED_CURRENCIES: readonly string[] = [
+  'EUR',
+  'USD',
+  'GBP',
+  'MXN',
+  'ARS',
+  'CLP',
+  'COP',
+  'BRL',
+  'PEN',
+  'UYU',
+  'DOP',
+  'CHF'
+]

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -355,7 +355,10 @@ function isActive(to: string): boolean {
           their banners via `useModuleSlots`; the layout knows nothing
           about them.
         -->
-        <ModuleSlot name="app.banners" :ctx="{}" />
+        <ModuleSlot
+          name="app.banners"
+          :ctx="{}"
+        />
         <slot />
       </main>
     </div>

--- a/frontend/app/layouts/public.vue
+++ b/frontend/app/layouts/public.vue
@@ -9,7 +9,10 @@
   <div class="min-h-screen bg-[var(--ui-bg)] flex flex-col">
     <header class="border-b border-[var(--ui-border)] bg-[var(--ui-bg-elevated)]">
       <div class="max-w-3xl mx-auto px-4 py-3 flex items-center gap-2">
-        <UIcon name="i-lucide-tooth" class="w-6 h-6 text-[var(--ui-primary)]" />
+        <UIcon
+          name="i-lucide-tooth"
+          class="w-6 h-6 text-[var(--ui-primary)]"
+        />
         <span class="font-semibold tracking-tight">DentalPin</span>
       </div>
     </header>

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -55,6 +55,7 @@ export interface ClinicUpdate {
   phone?: string
   email?: string
   timezone?: string
+  currency?: string
 }
 
 export interface Clinic {
@@ -66,9 +67,9 @@ export interface Clinic {
   phone?: string
   email?: string
   timezone: string
+  currency: string
   settings: {
     slot_duration_min?: number
-    currency?: string
   }
   cabinets: Cabinet[]
   created_at: string
@@ -546,7 +547,6 @@ export interface TreatmentCatalogItemBrief {
   internal_code: string
   names: Record<string, string>
   default_price?: string | null
-  currency: string
 }
 
 /** Treatment = one clinical act. Bridges, splints and multiple-veneers/crowns are
@@ -565,7 +565,6 @@ export interface Treatment {
   performed_by?: string | null
   performed_by_name?: string | null
   price_snapshot?: string | null
-  currency_snapshot?: string | null
   duration_snapshot?: number | null
   vat_rate_snapshot?: string | null
   budget_item_id?: string | null
@@ -640,7 +639,6 @@ export interface ToothTreatmentView {
   performed_by_name?: string | null
   notes?: string | null
   price_snapshot?: string | null
-  currency_snapshot?: string | null
   catalog_item_id?: string | null
   catalog_item?: TreatmentCatalogItemBrief | null
   source_module: string
@@ -761,7 +759,6 @@ export interface TreatmentCatalogItem {
   // Pricing
   default_price?: number
   cost_price?: number
-  currency: string
   pricing_strategy?: PricingStrategy
   pricing_config?: Record<string, number> | null
   surface_prices?: Record<string, number> | null
@@ -797,7 +794,6 @@ export interface TreatmentCatalogItemCreate {
   // Pricing
   default_price?: number
   cost_price?: number
-  currency?: string
   pricing_strategy?: PricingStrategy
   pricing_config?: Record<string, number> | null
   surface_prices?: Record<string, number> | null
@@ -823,7 +819,6 @@ export interface TreatmentCatalogItemUpdate {
   descriptions?: Record<string, string>
   default_price?: number
   cost_price?: number
-  currency?: string
   pricing_strategy?: PricingStrategy
   pricing_config?: Record<string, number> | null
   surface_prices?: Record<string, number> | null
@@ -853,7 +848,6 @@ export interface OdontogramTreatment {
   internal_code: string
   names: Record<string, string>
   default_price?: string | null
-  currency?: string
   treatment_scope: 'tooth' | 'multi_tooth' | 'global_mouth' | 'global_arch'
   requires_surfaces: boolean
   is_diagnostic: boolean
@@ -1039,7 +1033,6 @@ export interface Budget {
   total_discount: number
   total_tax: number
   total: number
-  currency: string
   // Notes
   internal_notes?: string
   patient_notes?: string
@@ -1072,7 +1065,6 @@ export interface BudgetListItem {
   valid_from: string
   valid_until?: string
   total: number
-  currency: string
   created_at: string
   patient?: PatientBrief
   creator?: UserBrief
@@ -1505,7 +1497,6 @@ export interface Invoice {
   total: number
   total_paid: number
   balance_due: number
-  currency: string
   // Notes
   internal_notes?: string
   public_notes?: string
@@ -1541,7 +1532,6 @@ export interface InvoiceListItem {
   total: number
   total_paid: number
   balance_due: number
-  currency: string
   created_at: string
   // Generic compliance summary keyed by ISO country (e.g.
   // {"ES": {state, severity, error_message, ...}}). Owned by the
@@ -1675,7 +1665,6 @@ export interface NumberingGap {
 
 export interface PatientBillingSummary {
   patient_id: string
-  currency: string
   // Budget metrics
   total_budgeted: number
   work_in_progress: number
@@ -1921,7 +1910,6 @@ export interface TreatmentBrief {
   catalog_item_id?: string | null
   catalog_item?: TreatmentCatalogItemBrief | null
   price_snapshot?: string | null
-  currency_snapshot?: string | null
   teeth: Array<{
     tooth_number: number
     role?: 'pillar' | 'pontic' | null

--- a/frontend/app/utils/treatmentView.ts
+++ b/frontend/app/utils/treatmentView.ts
@@ -28,7 +28,6 @@ export function viewForTooth(treatment: Treatment, toothNumber: number): ToothTr
     performed_by_name: treatment.performed_by_name,
     notes: treatment.notes,
     price_snapshot: treatment.price_snapshot,
-    currency_snapshot: treatment.currency_snapshot,
     catalog_item_id: treatment.catalog_item_id,
     catalog_item: treatment.catalog_item,
     source_module: treatment.source_module,

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -927,6 +927,8 @@
     "phone": "Phone",
     "timezone": "Timezone",
     "timezoneHelp": "All schedules and appointments are interpreted in this timezone.",
+    "currency": "Currency",
+    "currencyHelp": "Clinic-wide currency used in quotes, invoices and the catalog.",
     "editClinicInfo": "Edit information",
     "clinicUpdated": "Clinic information updated",
     "clinicUpdateError": "Error updating information",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -948,6 +948,8 @@
     "phone": "Teléfono",
     "timezone": "Zona horaria",
     "timezoneHelp": "Todos los horarios y citas se interpretan en esta zona.",
+    "currency": "Moneda",
+    "currencyHelp": "Moneda de la clínica para presupuestos, facturas y catálogo.",
     "editClinicInfo": "Editar información",
     "clinicUpdated": "Información de la clínica actualizada",
     "clinicUpdateError": "Error al actualizar la información",


### PR DESCRIPTION
## Summary
- Add `clinics.currency` (ISO 4217, default EUR) as first-class column. Core migration `0005` backfills from `clinic.settings.currency` JSONB and drops the key.
- Drop redundant per-document currency columns: `budgets.currency`, `invoices.currency`, `treatment_catalog_items.currency`, `treatments.currency_snapshot`. Each module owns its drop migration.
- New `app.core.utils.currency.format_currency` helper (babel) for locale-aware PDF/email rendering.
- New frontend `useCurrency()` composable + `SUPPORTED_CURRENCIES` constants. `Money.vue` simplified. Sweep across budget, billing, catalog, reports, treatment_plan, odontogram, patient_timeline, agenda, and shared selectors removes 5 duplicated `formatCurrency` impls and 7 hardcoded `'EUR'` fallbacks.
- ClinicInfoPage: currency selector + permission fix to `admin.clinic.write`.

Closes #68.

## Test plan
- [ ] `docker-compose exec backend alembic upgrade heads` applies cleanly (core 0005 + 4 module-drop migrations)
- [ ] `pytest tests/test_currency.py tests/test_catalog.py tests/test_budget.py` (57+ pass)
- [ ] `ruff check .` + `ruff format --check .` + `npm run lint` clean
- [ ] Login as admin → Settings → Clínica → cambiar moneda a USD → persiste
- [ ] Crear nuevo budget → totals en USD; PDF renderiza con `$`
- [ ] Crear invoice → totals en USD; PDF idem
- [ ] Cambiar idioma de UI → cifras se reformatean (separadores localizados)
- [ ] No hardcoded `'EUR'` / `'€'` fuera de `constants/currencies.ts` y fallback final del composable

🤖 Generated with [Claude Code](https://claude.com/claude-code)