### PR TITLE
feat(recalls): patient call-back workflow (issue #62)

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -8,7 +8,7 @@ version_path_separator = os
 # full graph before ``env.py`` loads. ``env.py`` still merges in any
 # additional branches discovered at runtime (e.g. community modules
 # installed from PyPI) via ``discover_version_locations``.
-version_locations = alembic/versions:app/modules/patients/migrations/versions:app/modules/patients_clinical/migrations/versions:app/modules/agenda/migrations/versions:app/modules/patient_timeline/migrations/versions:app/modules/catalog/migrations/versions:app/modules/odontogram/migrations/versions:app/modules/treatment_plan/migrations/versions:app/modules/budget/migrations/versions:app/modules/billing/migrations/versions:app/modules/media/migrations/versions:app/modules/notifications/migrations/versions:app/modules/schedules/migrations/versions:app/modules/verifactu/migrations/versions:app/modules/clinical_notes/migrations/versions
+version_locations = alembic/versions:app/modules/patients/migrations/versions:app/modules/patients_clinical/migrations/versions:app/modules/agenda/migrations/versions:app/modules/patient_timeline/migrations/versions:app/modules/catalog/migrations/versions:app/modules/odontogram/migrations/versions:app/modules/treatment_plan/migrations/versions:app/modules/budget/migrations/versions:app/modules/billing/migrations/versions:app/modules/media/migrations/versions:app/modules/notifications/migrations/versions:app/modules/schedules/migrations/versions:app/modules/verifactu/migrations/versions:app/modules/clinical_notes/migrations/versions:app/modules/recalls/migrations/versions
 
 [post_write_hooks]
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -81,11 +81,6 @@ from app.modules.odontogram.models import (  # noqa: F401
 )
 from app.modules.patient_timeline.models import PatientTimeline  # noqa: F401
 from app.modules.patients.models import Patient  # noqa: F401
-from app.modules.recalls.models import (  # noqa: F401
-    Recall,
-    RecallContactAttempt,
-    RecallSettings,
-)
 from app.modules.patients_clinical.models import (  # noqa: F401
     Allergy,
     EmergencyContact,
@@ -94,6 +89,11 @@ from app.modules.patients_clinical.models import (  # noqa: F401
     Medication,
     SurgicalHistory,
     SystemicDisease,
+)
+from app.modules.recalls.models import (  # noqa: F401
+    Recall,
+    RecallContactAttempt,
+    RecallSettings,
 )
 from app.modules.schedules.models import (  # noqa: F401
     ClinicOverride,

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -81,6 +81,11 @@ from app.modules.odontogram.models import (  # noqa: F401
 )
 from app.modules.patient_timeline.models import PatientTimeline  # noqa: F401
 from app.modules.patients.models import Patient  # noqa: F401
+from app.modules.recalls.models import (  # noqa: F401
+    Recall,
+    RecallContactAttempt,
+    RecallSettings,
+)
 from app.modules.patients_clinical.models import (  # noqa: F401
     Allergy,
     EmergencyContact,

--- a/backend/app/core/events/types.py
+++ b/backend/app/core/events/types.py
@@ -138,3 +138,13 @@ class EventType:
 
     # Verifactu compliance events
     VERIFACTU_RECORD_REJECTED = "verifactu.record.rejected"
+
+    # Recalls events (recalls module — patient call-back workflow, issue #62)
+    # Foundation for a future outreach module that will subscribe to react
+    # with WhatsApp/SMS/email automation. Recalls itself never sends.
+    RECALL_CREATED = "recall.created"
+    # Reserved for a future cron tick at month start. Not published in V1.
+    RECALL_DUE = "recall.due"
+    RECALL_COMPLETED = "recall.completed"
+    RECALL_SNOOZED = "recall.snoozed"
+    RECALL_CANCELLED = "recall.cancelled"

--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Slot uniqueness now ignores terminal statuses.** Migration
+  `ag_0004` rebuilds the partial unique index
+  `idx_appointment_slot` with
+  `WHERE status NOT IN ('cancelled', 'completed', 'no_show')`.
+  Previously the index excluded only `cancelled`, so a finished
+  visit kept reserving its `(clinic, cabinet, professional,
+  start_time)` slot and a fresh checked-in appointment couldn't
+  be assigned to that cabinet. Slot competition now only applies
+  among truly active statuses.
 - New frontend slot mount **`appointment.completed.followup`** in
   `AppointmentQuickActions.vue` (issue #62). After a successful
   transition to `completed`, agenda renders a follow-up modal whose

--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- New frontend slot mount **`appointment.completed.followup`** in
+  `AppointmentQuickActions.vue` (issue #62). After a successful
+  transition to `completed`, agenda renders a follow-up modal whose
+  body is filled by any sibling module registered into the slot
+  (e.g. `recalls` "Schedule a recall?" prompt). Modal stays hidden
+  when no module has registered into the slot — no behaviour change
+  for clinics that don't install recalls.
+
 - Week view (`AppointmentCalendar`) now paints `clinic_closed` ranges per
   day as a hatched overlay, matching the daily view. Late-start mornings,
   early-close evenings, midday gaps and fully-closed days are all

--- a/backend/app/modules/agenda/CLAUDE.md
+++ b/backend/app/modules/agenda/CLAUDE.md
@@ -16,6 +16,14 @@ surface (appointments CRUD, transitions, cabinet assignments, kanban).
 
 `agenda.appointments.{read,write}`, `agenda.cabinets.{read,write}`.
 
+## Frontend slots exposed
+
+- `appointment.completed.followup` — rendered by `AppointmentQuickActions.vue`
+  after a successful transition to `completed`. Sibling modules
+  (e.g. `recalls`) register components that prompt the receptionist
+  for a follow-up action. Modal stays hidden when no registrations
+  exist. Slot ctx: `{ appointment }`.
+
 ## Events emitted
 
 - `appointment.scheduled` — new appointment

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentKanbanView.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentKanbanView.vue
@@ -31,6 +31,7 @@ const emit = defineEmits<{
 const { t, locale } = useI18n()
 const toast = useToast()
 const { fetchAppointments, transition, assignCabinet } = useAppointments()
+const completionFollowup = useCompletionFollowup()
 const { canTransition, statusColour, statusLabel } = useAppointmentStatus()
 // Manual 30-second tick — @vueuse/core is not a dependency in this repo.
 const now = ref(new Date())
@@ -293,6 +294,9 @@ async function onDrop(col: ColumnDef, e: DragEvent, cabinetName?: string) {
       if (cabId) await safeAssign(aptId, cabId)
     }
     await transition(aptId, target)
+    if (target === 'completed') {
+      completionFollowup.trigger(apt)
+    }
   } catch {
     toast.add({ title: t('appointments.transitionFailed'), color: 'error' })
   }

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
@@ -563,19 +563,28 @@ function closeModal() {
     <template #content>
       <UCard
         :ui="{
-          root: isMobile ? 'h-full flex flex-col' : '',
+          root: isMobile ? 'h-full flex flex-col' : 'sm:max-w-2xl',
           body: isMobile ? 'flex-1 min-h-0 overflow-hidden p-0' : ''
         }"
       >
         <template #header>
-          <div class="flex items-center justify-between">
-            <h2 class="text-h1 text-default text-default">
-              {{ modalTitle }}
-            </h2>
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <h2 class="text-h1 text-default truncate">
+                {{ modalTitle }}
+              </h2>
+              <p
+                v-if="selectedPatient"
+                class="text-caption text-subtle truncate mt-0.5"
+              >
+                {{ selectedPatient.first_name }} {{ selectedPatient.last_name }}
+              </p>
+            </div>
             <UButton
               variant="ghost"
               color="neutral"
               icon="i-lucide-x"
+              size="sm"
               :aria-label="t('common.close', 'Cerrar')"
               @click="closeModal"
             />
@@ -584,72 +593,103 @@ function closeModal() {
 
         <div
           :class="isMobile
-            ? 'h-full overflow-y-auto px-4 py-3'
-            : 'max-h-[60vh] overflow-y-auto pr-1'"
+            ? 'h-full overflow-y-auto px-4 py-4'
+            : 'max-h-[65vh] overflow-y-auto pr-1'"
         >
           <form
-            class="space-y-4"
+            class="space-y-6"
             @submit.prevent="handleSave"
           >
-            <!-- Patient search -->
-            <UFormField
-              :label="t('appointments.selectPatient')"
-              required
-            >
+            <!-- Section 1: Paciente -->
+            <section class="space-y-3">
+              <div class="flex items-center gap-2 text-caption uppercase tracking-wide text-subtle">
+                <UIcon
+                  name="i-lucide-user"
+                  class="w-3.5 h-3.5"
+                />
+                {{ t('appointments.selectPatient') }}
+              </div>
               <PatientVisualSelector
                 v-model="selectedPatient"
                 in-modal
               />
-            </UFormField>
+              <div v-if="selectedPatient">
+                <p class="text-caption text-subtle mb-1.5">
+                  {{ t('appointments.treatments') }}
+                </p>
+                <PlannedTreatmentSelector
+                  v-model="selectedTreatments"
+                  :patient-id="selectedPatient?.id"
+                />
+              </div>
+            </section>
 
-            <!-- Treatments from treatment plan -->
-            <UFormField :label="t('appointments.treatments')">
-              <PlannedTreatmentSelector
-                v-model="selectedTreatments"
-                :patient-id="selectedPatient?.id"
-              />
-            </UFormField>
-
-            <!-- Date and Time -->
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <UFormField
-                :label="t('appointments.date')"
-                required
-              >
-                <UInput
-                  v-model="formData.date"
-                  type="date"
-                  :size="isMobile ? 'lg' : 'md'"
+            <!-- Section 2: Cuándo (date + time + duration chips) -->
+            <section class="space-y-3">
+              <div class="flex items-center gap-2 text-caption uppercase tracking-wide text-subtle">
+                <UIcon
+                  name="i-lucide-calendar-clock"
+                  class="w-3.5 h-3.5"
+                />
+                {{ t('appointments.when', 'Cuándo') }}
+              </div>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <UFormField
+                  :label="t('appointments.date')"
                   required
-                />
-              </UFormField>
-
-              <UFormField
-                :label="t('appointments.startTime')"
-                required
-              >
-                <UInput
-                  v-model="formData.startTime"
-                  type="time"
-                  :size="isMobile ? 'lg' : 'md'"
+                >
+                  <UInput
+                    v-model="formData.date"
+                    type="date"
+                    :size="isMobile ? 'lg' : 'md'"
+                    icon="i-lucide-calendar"
+                    required
+                  />
+                </UFormField>
+                <UFormField
+                  :label="t('appointments.startTime')"
                   required
-                />
-              </UFormField>
-            </div>
+                >
+                  <UInput
+                    v-model="formData.startTime"
+                    type="time"
+                    :size="isMobile ? 'lg' : 'md'"
+                    icon="i-lucide-clock"
+                    required
+                  />
+                </UFormField>
+              </div>
+              <div>
+                <p class="text-caption text-subtle mb-1.5">
+                  {{ t('appointments.duration') }}
+                </p>
+                <div class="flex flex-wrap gap-1.5">
+                  <button
+                    v-for="d in durationOptions"
+                    :key="d.value"
+                    type="button"
+                    class="px-3 py-1.5 rounded-token-md text-sm font-medium transition-colors border"
+                    :class="formData.duration === d.value
+                      ? 'border-primary bg-primary/10 text-primary-accent'
+                      : 'border-default bg-default text-default hover:bg-elevated'"
+                    :aria-pressed="formData.duration === d.value"
+                    @click="formData.duration = d.value"
+                  >
+                    {{ d.label }}
+                  </button>
+                </div>
+              </div>
+            </section>
 
-            <!-- Duration and Cabinet -->
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <UFormField :label="t('appointments.duration')">
-                <USelect
-                  v-model="formData.duration"
-                  :items="durationOptions"
-                  value-key="value"
-                  label-key="label"
-                  :size="isMobile ? 'lg' : 'md'"
-                  :placeholder="t('appointments.selectDuration')"
+            <!-- Section 3: Dónde + quién (cabinet + professional) -->
+            <section class="space-y-3">
+              <div class="flex items-center gap-2 text-caption uppercase tracking-wide text-subtle">
+                <UIcon
+                  name="i-lucide-map-pin"
+                  class="w-3.5 h-3.5"
                 />
-              </UFormField>
-
+                {{ t('appointments.whereWho', 'Gabinete y profesional') }}
+              </div>
               <UFormField :label="t('appointments.cabinet')">
                 <USelect
                   v-model="formData.cabinet"
@@ -658,43 +698,70 @@ function closeModal() {
                   label-key="label"
                   :size="isMobile ? 'lg' : 'md'"
                   :placeholder="t('appointments.cabinet')"
+                  icon="i-lucide-door-open"
                 />
               </UFormField>
-            </div>
 
-            <!-- Professional -->
-            <UFormField
-              :label="t('appointments.professional')"
-              required
-            >
-              <USelect
-                v-model="selectedProfessionalId"
-                :items="professionalOptions"
-                value-key="value"
-                label-key="label"
-                :size="isMobile ? 'lg' : 'md'"
-                :placeholder="t('appointments.selectProfessional')"
-              />
-            </UFormField>
+              <UFormField
+                :label="t('appointments.professional')"
+                required
+              >
+                <div class="flex flex-wrap gap-2">
+                  <button
+                    v-for="p in professionalOptions"
+                    :key="p.value"
+                    type="button"
+                    class="inline-flex items-center gap-2 px-3 py-1.5 rounded-token-md text-sm font-medium transition-colors border"
+                    :class="selectedProfessionalId === p.value
+                      ? 'border-primary bg-primary/10 text-primary-accent'
+                      : 'border-default bg-default text-default hover:bg-elevated'"
+                    :aria-pressed="selectedProfessionalId === p.value"
+                    @click="selectedProfessionalId = p.value"
+                  >
+                    <span
+                      class="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                      :style="{ background: p.color }"
+                      aria-hidden="true"
+                    />
+                    {{ p.label }}
+                  </button>
+                </div>
+              </UFormField>
+            </section>
 
-            <!-- Notes -->
-            <UFormField :label="t('appointments.notes')">
-              <UTextarea
-                v-model="formData.notes"
-                :placeholder="t('appointments.notes')"
-                :rows="3"
-              />
-            </UFormField>
+            <!-- Section 4: Notas (collapsed by default) -->
+            <details class="group">
+              <summary class="flex items-center gap-2 text-caption uppercase tracking-wide text-subtle cursor-pointer hover:text-default select-none">
+                <UIcon
+                  name="i-lucide-chevron-right"
+                  class="w-3.5 h-3.5 transition-transform group-open:rotate-90"
+                />
+                <UIcon
+                  name="i-lucide-sticky-note"
+                  class="w-3.5 h-3.5"
+                />
+                {{ t('appointments.notes') }}
+              </summary>
+              <div class="mt-2">
+                <UTextarea
+                  v-model="formData.notes"
+                  :placeholder="t('appointments.notesPlaceholder', 'Detalles internos para el equipo')"
+                  :rows="3"
+                  class="w-full"
+                />
+              </div>
+            </details>
           </form>
         </div>
 
         <template #footer>
-          <div class="flex justify-between">
-            <div class="flex items-center gap-2">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex items-center gap-2 flex-wrap">
               <UButton
                 v-if="isEditMode && appointment?.status !== 'cancelled'"
                 variant="outline"
                 color="error"
+                icon="i-lucide-x"
                 :loading="isSubmitting"
                 @click="handleCancel"
               >
@@ -728,38 +795,43 @@ function closeModal() {
                 </template>
               </UDropdownMenu>
             </div>
-            <div class="flex items-center gap-3">
-              <!-- Checkbox for sending confirmation when creating -->
-              <div
+            <div class="flex flex-col-reverse sm:flex-row sm:items-center gap-2 sm:gap-3">
+              <!-- Send-confirmation checkbox surfaces inline on desktop,
+                   stacks above on mobile so the primary action stays at
+                   the thumb. -->
+              <label
                 v-if="!isEditMode && patientHasEmail"
-                class="flex items-center gap-2"
+                class="flex items-center gap-2 text-sm text-muted cursor-pointer"
               >
                 <UCheckbox
                   v-model="sendConfirmationEmail"
                   :disabled="autoSendEnabled"
                 />
-                <span class="text-sm text-muted">
+                <span>
                   {{ t('appointments.sendConfirmationEmail') }}
                   <span
                     v-if="autoSendEnabled"
                     class="text-xs"
                   >({{ t('appointments.automatic') }})</span>
                 </span>
+              </label>
+              <div class="flex flex-col-reverse sm:flex-row gap-2">
+                <UButton
+                  variant="ghost"
+                  color="neutral"
+                  @click="closeModal"
+                >
+                  {{ t('common.cancel') }}
+                </UButton>
+                <UButton
+                  icon="i-lucide-calendar-plus"
+                  :loading="isSubmitting"
+                  :disabled="!canSave"
+                  @click="handleSave"
+                >
+                  {{ t('common.save') }}
+                </UButton>
               </div>
-              <UButton
-                variant="outline"
-                color="neutral"
-                @click="closeModal"
-              >
-                {{ t('common.cancel') }}
-              </UButton>
-              <UButton
-                :loading="isSubmitting"
-                :disabled="!canSave"
-                @click="handleSave"
-              >
-                {{ t('common.save') }}
-              </UButton>
             </div>
           </div>
         </template>

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentQuickActions.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentQuickActions.vue
@@ -22,6 +22,19 @@ const isBusy = ref(false)
 const pendingDescriptor = ref<TransitionDescriptor | null>(null)
 const pendingNote = ref('')
 
+// Post-completion follow-up slot. After a successful transition to
+// "completed", any sibling module registered into the
+// `appointment.completed.followup` slot (e.g. `recalls` "Schedule a
+// recall?" prompt, issue #62) renders inside this modal.
+const followupOpen = ref(false)
+const followupAppointment = ref<Appointment | null>(null)
+const { resolve } = useModuleSlots()
+const followupEntries = computed(() =>
+  followupAppointment.value
+    ? resolve('appointment.completed.followup', { appointment: followupAppointment.value })
+    : []
+)
+
 const transitions = computed(() => nextTransitions(props.appointment.status))
 const hasActions = computed(() => transitions.value.length > 0)
 
@@ -49,12 +62,21 @@ async function runTransition(tr: TransitionDescriptor, note?: string) {
   try {
     await transition(props.appointment.id, tr.to, note?.trim() || undefined)
     emit('transitioned', props.appointment, tr.to)
+    if (tr.to === 'completed') {
+      followupAppointment.value = { ...props.appointment, status: 'completed' }
+      followupOpen.value = followupEntries.value.length > 0
+    }
   } catch (err) {
     toast.add({ title: t('appointments.transitionFailed'), color: 'error' })
     emit('failed', err)
   } finally {
     isBusy.value = false
   }
+}
+
+function closeFollowup() {
+  followupOpen.value = false
+  followupAppointment.value = null
 }
 
 function confirmPending() {
@@ -117,6 +139,33 @@ const confirmMessage = computed(() => {
         </UButton>
         <UButton color="error" :loading="isBusy" @click="confirmPending">
           {{ pendingDescriptor ? t(pendingDescriptor.labelKey) : '' }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+
+  <!-- Post-completion follow-up slot. Renders nothing when no module
+       has registered into `appointment.completed.followup`. -->
+  <UModal
+    :open="followupOpen"
+    :title="t('appointments.followup.title')"
+    @update:open="(v: boolean) => { if (!v) closeFollowup() }"
+  >
+    <template #body>
+      <div class="space-y-3 p-4">
+        <component
+          :is="entry.component"
+          v-for="entry in followupEntries"
+          :key="entry.id"
+          :appointment="followupAppointment"
+          @done="closeFollowup"
+        />
+      </div>
+    </template>
+    <template #footer>
+      <div class="flex justify-end gap-2 p-2">
+        <UButton color="neutral" variant="ghost" @click="closeFollowup">
+          {{ t('actions.close') }}
         </UButton>
       </div>
     </template>

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentQuickActions.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentQuickActions.vue
@@ -22,18 +22,10 @@ const isBusy = ref(false)
 const pendingDescriptor = ref<TransitionDescriptor | null>(null)
 const pendingNote = ref('')
 
-// Post-completion follow-up slot. After a successful transition to
-// "completed", any sibling module registered into the
-// `appointment.completed.followup` slot (e.g. `recalls` "Schedule a
-// recall?" prompt, issue #62) renders inside this modal.
-const followupOpen = ref(false)
-const followupAppointment = ref<Appointment | null>(null)
-const { resolve } = useModuleSlots()
-const followupEntries = computed(() =>
-  followupAppointment.value
-    ? resolve('appointment.completed.followup', { appointment: followupAppointment.value })
-    : []
-)
+// Post-completion follow-up modal is hosted once at the agenda page
+// level (`CompletionFollowupHost.vue`) so it stays consistent across
+// the dropdown path and the kanban drag-drop path.
+const completionFollowup = useCompletionFollowup()
 
 const transitions = computed(() => nextTransitions(props.appointment.status))
 const hasActions = computed(() => transitions.value.length > 0)
@@ -63,10 +55,7 @@ async function runTransition(tr: TransitionDescriptor, note?: string) {
     await transition(props.appointment.id, tr.to, note?.trim() || undefined)
     emit('transitioned', props.appointment, tr.to)
     if (tr.to === 'completed') {
-      followupAppointment.value = { ...props.appointment, status: 'completed' }
-      // eslint-disable-next-line no-console
-      console.debug('[appointment.completed.followup] entries=', followupEntries.value.length, followupEntries.value.map(e => e.id))
-      followupOpen.value = followupEntries.value.length > 0
+      completionFollowup.trigger(props.appointment)
     }
   } catch (err) {
     toast.add({ title: t('appointments.transitionFailed'), color: 'error' })
@@ -74,11 +63,6 @@ async function runTransition(tr: TransitionDescriptor, note?: string) {
   } finally {
     isBusy.value = false
   }
-}
-
-function closeFollowup() {
-  followupOpen.value = false
-  followupAppointment.value = null
 }
 
 function confirmPending() {
@@ -146,30 +130,6 @@ const confirmMessage = computed(() => {
     </template>
   </UModal>
 
-  <!-- Post-completion follow-up slot. Renders nothing when no module
-       has registered into `appointment.completed.followup`. -->
-  <UModal
-    :open="followupOpen"
-    :title="t('appointments.followup.title')"
-    @update:open="(v: boolean) => { if (!v) closeFollowup() }"
-  >
-    <template #body>
-      <div class="space-y-3 p-4">
-        <component
-          :is="entry.component"
-          v-for="entry in followupEntries"
-          :key="entry.id"
-          :appointment="followupAppointment"
-          @done="closeFollowup"
-        />
-      </div>
-    </template>
-    <template #footer>
-      <div class="flex justify-end gap-2 p-2">
-        <UButton color="neutral" variant="ghost" @click="closeFollowup">
-          {{ t('actions.close') }}
-        </UButton>
-      </div>
-    </template>
-  </UModal>
+  <!-- Post-completion modal lives once in `CompletionFollowupHost`
+       at the page level, not here. -->
 </template>

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentQuickActions.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentQuickActions.vue
@@ -64,6 +64,8 @@ async function runTransition(tr: TransitionDescriptor, note?: string) {
     emit('transitioned', props.appointment, tr.to)
     if (tr.to === 'completed') {
       followupAppointment.value = { ...props.appointment, status: 'completed' }
+      // eslint-disable-next-line no-console
+      console.debug('[appointment.completed.followup] entries=', followupEntries.value.length, followupEntries.value.map(e => e.id))
       followupOpen.value = followupEntries.value.length > 0
     }
   } catch (err) {

--- a/backend/app/modules/agenda/frontend/components/clinical/CompletionFollowupHost.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/CompletionFollowupHost.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+/**
+ * Renders the post-completion follow-up modal whose body is filled
+ * by every component registered into the ``appointment.completed.followup``
+ * slot. Mounted once at the agenda page level so both
+ * ``AppointmentQuickActions`` (dropdown) and ``AppointmentKanbanView``
+ * (drag-drop) share the same UI surface.
+ */
+import { computed } from 'vue'
+
+const { t } = useI18n()
+const { resolve } = useModuleSlots()
+const { open, appointment, dismiss } = useCompletionFollowup()
+
+const entries = computed(() =>
+  appointment.value
+    ? resolve('appointment.completed.followup', { appointment: appointment.value })
+    : []
+)
+
+// Hide the modal entirely when no slot entry is registered — keeps
+// clinics that don't run recalls from seeing an empty dialog.
+const shouldRender = computed(() => open.value && entries.value.length > 0)
+</script>
+
+<template>
+  <UModal
+    :open="shouldRender"
+    :title="t('appointments.followup.title')"
+    @update:open="(v: boolean) => { if (!v) dismiss() }"
+  >
+    <template #body>
+      <div class="space-y-3 p-4">
+        <component
+          :is="entry.component"
+          v-for="entry in entries"
+          :key="entry.id"
+          :appointment="appointment"
+          @done="dismiss"
+        />
+      </div>
+    </template>
+    <template #footer>
+      <div class="flex justify-end gap-2 p-2">
+        <UButton
+          color="neutral"
+          variant="ghost"
+          @click="dismiss"
+        >
+          {{ t('actions.close') }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/backend/app/modules/agenda/frontend/composables/useCompletionFollowup.ts
+++ b/backend/app/modules/agenda/frontend/composables/useCompletionFollowup.ts
@@ -1,0 +1,37 @@
+import type { Appointment } from '~~/app/types'
+
+/**
+ * Singleton state for the post-completion follow-up modal.
+ *
+ * Any code that transitions an appointment to ``completed`` should
+ * call ``trigger(appointment)`` after the backend confirms the
+ * transition. The agenda page mounts the modal once (via
+ * ``CompletionFollowupHost.vue``) and renders any components
+ * registered into the ``appointment.completed.followup`` slot.
+ *
+ * Two call-sites today:
+ *   - ``AppointmentQuickActions.vue`` — the per-card dropdown menu.
+ *   - ``AppointmentKanbanView.vue`` — drag-drop into "Finalizadas".
+ *
+ * Lifting this out of the components keeps both paths consistent
+ * and avoids duplicated modal markup.
+ */
+export function useCompletionFollowup() {
+  const open = useState<boolean>('agenda:completion-followup:open', () => false)
+  const appointment = useState<Appointment | null>(
+    'agenda:completion-followup:appointment',
+    () => null
+  )
+
+  function trigger(apt: Appointment) {
+    appointment.value = { ...apt, status: 'completed' }
+    open.value = true
+  }
+
+  function dismiss() {
+    open.value = false
+    appointment.value = null
+  }
+
+  return { open, appointment, trigger, dismiss }
+}

--- a/backend/app/modules/agenda/frontend/pages/appointments/index.vue
+++ b/backend/app/modules/agenda/frontend/pages/appointments/index.vue
@@ -757,5 +757,10 @@ watch(isMobile, async (mobile) => {
       @saved="handleSaved"
       @cancelled="handleCancelled"
     />
+
+    <!-- Renders the post-completion follow-up modal once for the
+         whole agenda page. Triggered by `useCompletionFollowup()`
+         from QuickActions and Kanban after a `completed` transition. -->
+    <CompletionFollowupHost />
   </div>
 </template>

--- a/backend/app/modules/agenda/migrations/versions/ag_0004_slot_index_active_only.py
+++ b/backend/app/modules/agenda/migrations/versions/ag_0004_slot_index_active_only.py
@@ -1,0 +1,59 @@
+"""agenda: relax the unique slot index to active statuses only.
+
+The original ``idx_appointment_slot`` partial unique index
+(``ag_0001``) excluded only ``cancelled`` rows from the uniqueness
+check, so a ``completed`` or ``no_show`` appointment kept reserving
+its (clinic, cabinet, professional, start_time) tuple forever. This
+made it impossible to assign a *new* checked-in appointment to a
+cabinet whose slot had been used earlier by another now-finished
+visit at the same nominal hour — a 409 the operator can't recover
+from without DB surgery.
+
+Terminal statuses (``cancelled``, ``completed``, ``no_show``) are
+historical: they shouldn't compete for slot exclusivity. Only the
+*active* statuses (``scheduled``, ``confirmed``, ``checked_in``,
+``in_treatment``) need the guard.
+
+Drops the old index and recreates it with a wider exclusion. Index
+name kept the same so anything that asks Postgres about it by name
+keeps working.
+
+Revision ID: ag_0004
+Revises: ag_0003
+Create Date: 2026-05-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "ag_0004"
+down_revision: str | None = "ag_0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_index("idx_appointment_slot", table_name="appointments")
+    op.create_index(
+        "idx_appointment_slot",
+        "appointments",
+        ["clinic_id", "cabinet_id", "professional_id", "start_time"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status NOT IN ('cancelled', 'completed', 'no_show')"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_appointment_slot", table_name="appointments")
+    op.create_index(
+        "idx_appointment_slot",
+        "appointments",
+        ["clinic_id", "cabinet_id", "professional_id", "start_time"],
+        unique=True,
+        postgresql_where=sa.text("status != 'cancelled'"),
+    )

--- a/backend/app/modules/agenda/migrations/versions/ag_0004_slot_index_active_only.py
+++ b/backend/app/modules/agenda/migrations/versions/ag_0004_slot_index_active_only.py
@@ -42,9 +42,7 @@ def upgrade() -> None:
         "appointments",
         ["clinic_id", "cabinet_id", "professional_id", "start_time"],
         unique=True,
-        postgresql_where=sa.text(
-            "status NOT IN ('cancelled', 'completed', 'no_show')"
-        ),
+        postgresql_where=sa.text("status NOT IN ('cancelled', 'completed', 'no_show')"),
     )
 
 

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **`do_not_contact: bool` flag** added to the patient model
+  (issue #62, recalls). Operational opt-out — patients with this flag
+  set are excluded from the recalls call list and any future
+  outreach automation. Defaults to `false`. Editable from the
+  Demographics edit modal. Migration: `pat_0002`.
+- New slot mount `patient.summary.actions` rendered on
+  `PatientSummaryHero` so sibling modules (e.g. `recalls`) can
+  contribute action buttons to the patient summary without modifying
+  the patients module UI.
+
 - Patient detail → Administración → Presupuestos: paginated (page_size=20).
   `AdministrationTab` now owns its own paginated fetch via the shared
   `PaginationBar`; the parent `[id].vue` no longer prefetches budgets.

--- a/backend/app/modules/patients/CLAUDE.md
+++ b/backend/app/modules/patients/CLAUDE.md
@@ -52,6 +52,15 @@ None.
   This includes future agent tools.
 - **No cross-module FKs into patients without `depends: ["patients"]`**
   in the consuming module's manifest.
+- **`do_not_contact` flag** — operational opt-out used by recalls and
+  any future outreach module. Sibling modules MUST filter
+  `Patient.do_not_contact == False` in addition to the
+  `Patient.status != "archived"` filter when building call/outreach
+  lists.
+- **Slot `patient.summary.actions`** — extension point exposed on
+  `PatientSummaryHero` for sibling modules to contribute action
+  buttons (e.g. recalls "Set recall"). Stable contract — sibling
+  modules depend on it via the slot registry, not via imports.
 
 ## Related ADRs
 

--- a/backend/app/modules/patients/frontend/components/patient/PatientSectionEditModal.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientSectionEditModal.vue
@@ -267,7 +267,7 @@ const canSave = computed(() => {
         <!-- Demographics Form -->
         <div
           v-if="section === 'demographics'"
-          class="space-y-4"
+          class="space-y-4 max-h-[65vh] overflow-y-auto pr-1"
         >
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <UFormField
@@ -350,7 +350,7 @@ const canSave = computed(() => {
         <!-- Emergency Contact Form -->
         <div
           v-else-if="section === 'emergency'"
-          class="space-y-4"
+          class="space-y-4 max-h-[65vh] overflow-y-auto pr-1"
         >
           <EmergencyContactForm v-model="emergencyForm" />
         </div>
@@ -358,7 +358,7 @@ const canSave = computed(() => {
         <!-- Legal Guardian Form -->
         <div
           v-else-if="section === 'guardian'"
-          class="space-y-4"
+          class="space-y-4 max-h-[65vh] overflow-y-auto pr-1"
         >
           <LegalGuardianForm v-model="guardianForm" />
         </div>
@@ -366,7 +366,7 @@ const canSave = computed(() => {
         <!-- Billing Form -->
         <div
           v-else-if="section === 'billing'"
-          class="space-y-4"
+          class="space-y-4 max-h-[65vh] overflow-y-auto pr-1"
         >
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <UFormField :label="t('patients.billingName')">
@@ -417,7 +417,7 @@ const canSave = computed(() => {
         <!-- Medical History Form -->
         <div
           v-else-if="section === 'medical'"
-          class="max-h-[60vh] overflow-y-auto"
+          class="max-h-[65vh] overflow-y-auto pr-1"
         >
           <MedicalHistoryForm
             v-if="medicalHistory"

--- a/backend/app/modules/patients/frontend/components/patient/PatientSectionEditModal.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientSectionEditModal.vue
@@ -52,6 +52,7 @@ const demographicsForm = reactive({
   email: '',
   date_of_birth: '',
   notes: '',
+  do_not_contact: false as boolean,
   gender: undefined as string | undefined,
   national_id: '',
   national_id_type: undefined as string | undefined,
@@ -117,6 +118,7 @@ function initializeForm() {
     demographicsForm.email = props.patient.email || ''
     demographicsForm.date_of_birth = props.patient.date_of_birth || ''
     demographicsForm.notes = props.patient.notes || ''
+    demographicsForm.do_not_contact = props.patient.do_not_contact ?? false
     demographicsForm.gender = props.patient.gender
     demographicsForm.national_id = props.patient.national_id || ''
     demographicsForm.national_id_type = props.patient.national_id_type
@@ -162,6 +164,7 @@ async function handleSave() {
         email: demographicsForm.email || null,
         date_of_birth: demographicsForm.date_of_birth || null,
         notes: demographicsForm.notes || null,
+        do_not_contact: demographicsForm.do_not_contact,
         gender: demographicsForm.gender || null,
         national_id: demographicsForm.national_id || null,
         national_id_type: demographicsForm.national_id_type || null,
@@ -335,6 +338,12 @@ const canSave = computed(() => {
               v-model="demographicsForm.notes"
               :rows="3"
             />
+          </UFormField>
+          <UFormField
+            :label="t('patients.doNotContact.label')"
+            :hint="t('patients.doNotContact.hint')"
+          >
+            <USwitch v-model="demographicsForm.do_not_contact" />
           </UFormField>
         </div>
 

--- a/backend/app/modules/patients/frontend/components/patient/PatientSummaryHero.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientSummaryHero.vue
@@ -176,6 +176,12 @@ const hasCriticalAlerts = computed(() =>
       </div>
     </UCard>
 
+    <!-- Action slot for sibling modules (e.g. recalls "Set recall"). -->
+    <ModuleSlot
+      name="patient.summary.actions"
+      :ctx="{ patient }"
+    />
+
     <!-- Clinical alerts banner -->
     <div
       v-if="alerts.length > 0"

--- a/backend/app/modules/patients/migrations/versions/pat_0002_add_do_not_contact.py
+++ b/backend/app/modules/patients/migrations/versions/pat_0002_add_do_not_contact.py
@@ -1,0 +1,42 @@
+"""patients: add do_not_contact flag.
+
+Issue #62 (recalls). Receptionists need a way to mark a patient as
+"do not contact" so they are excluded from the recalls call list and
+any future automated outreach. Lives on the patient record because
+it is operational identity (same level as ``status``), not a clinical
+preference.
+
+Revision ID: pat_0002
+Revises: pat_0001
+Create Date: 2026-05-01
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "pat_0002"
+down_revision: str | None = "pat_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "patients",
+        sa.Column(
+            "do_not_contact",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # Drop the server default so application code controls future inserts.
+    op.alter_column("patients", "do_not_contact", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("patients", "do_not_contact")

--- a/backend/app/modules/patients/models.py
+++ b/backend/app/modules/patients/models.py
@@ -13,7 +13,7 @@ from datetime import date
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from sqlalchemy import Date, ForeignKey, String, Text
+from sqlalchemy import Boolean, Date, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -39,6 +39,10 @@ class Patient(Base, TimestampMixin):
     date_of_birth: Mapped[date | None] = mapped_column(Date)
     notes: Mapped[str | None] = mapped_column(Text)
     status: Mapped[str] = mapped_column(String(20), default="active")  # active, archived
+    # Operational opt-out: when true, recalls / outreach modules must
+    # exclude the patient from active call lists and surface them in a
+    # ``needs_review`` bucket instead.
+    do_not_contact: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Extended demographics
     gender: Mapped[str | None] = mapped_column(String(20))  # male, female, other, prefer_not_say

--- a/backend/app/modules/patients/schemas.py
+++ b/backend/app/modules/patients/schemas.py
@@ -31,6 +31,7 @@ class PatientCreate(BaseModel):
     email: EmailStr | None = None
     date_of_birth: date | None = None
     notes: str | None = None
+    do_not_contact: bool = False
     billing_name: str | None = Field(default=None, max_length=200)
     billing_tax_id: str | None = Field(default=None, max_length=50)
     billing_address: BillingAddress | None = None
@@ -45,6 +46,7 @@ class PatientUpdate(BaseModel):
     date_of_birth: date | None = None
     notes: str | None = None
     status: str | None = None
+    do_not_contact: bool | None = None
     billing_name: str | None = Field(default=None, max_length=200)
     billing_tax_id: str | None = Field(default=None, max_length=50)
     billing_address: BillingAddress | None = None
@@ -61,6 +63,7 @@ class PatientResponse(BaseModel):
     date_of_birth: date | None
     notes: str | None
     status: str
+    do_not_contact: bool
     billing_name: str | None
     billing_tax_id: str | None
     billing_address: dict | None

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — recalls module
+
+## Unreleased
+
+- Initial release. Patient call-back workflow (issue #62).
+- Tables: `recalls`, `recall_contact_attempts`, `recall_settings`
+  on the `recalls` Alembic branch (`rec_0001`).
+- Endpoints under `/api/v1/recalls/*` — list, create (duplicate
+  guard), detail, snooze, cancel, mark-done, log-attempt, link
+  appointment, settings, dashboard stats, suggestions/next, CSV
+  export.
+- Events published: `recall.created`, `recall.completed`,
+  `recall.snoozed`, `recall.cancelled`. `recall.due` enum value
+  reserved for a future cron — not published in V1.
+- Events consumed: `appointment.scheduled` (auto-link),
+  `appointment.completed` (auto-close), `appointment.cancelled`
+  (revert), `treatment_plan.treatment_completed` (suggestion hook,
+  stateless), `patient.archived` (move active → needs_review).
+- Frontend layer registers slot entries in:
+  - `patient.summary.actions` — "Set recall" button
+  - `patient.summary.feed` — recall pill + recent history
+  - `odontogram.condition.actions` — per-treatment "Set recall"
+  - `appointment.completed.followup` — "Schedule recall?" prompt
+  - `dashboard.attention` — due/overdue/conversion widget
+  - `settings.sections` — reason-interval + category-map editor
+- Permissions: `recalls.{read,write,delete}`. Receptionist + dentist
+  + hygienist + assistant get read+write; admin gets `*`.
+- `installable=True`, `auto_install=True`, `removable=True`.
+  Round-trip uninstall test verifies all three tables drop cleanly.

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -25,6 +25,11 @@
   - `settings.sections` — reason-interval + category-map editor
 - Permissions: `recalls.{read,write,delete}`. Receptionist + dentist
   + hygienist + assistant get read+write; admin gets `*`.
+- Auto-link policy on `appointment.scheduled` is **conservative**:
+  fires only when the patient has exactly one matching active recall.
+  Two-plus candidates → no-op, reception links manually from the
+  call-list row. Avoids silent wrong-association across multiple
+  reasons (no reliable signal in agenda's free-text `treatment_type`).
 - `installable=True`, `auto_install=True`, `removable=True`.
   Round-trip uninstall test verifies all three tables drop cleanly.
 - Sidebar entry registered via `manifest.frontend.navigation`

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -27,3 +27,7 @@
   + hygienist + assistant get read+write; admin gets `*`.
 - `installable=True`, `auto_install=True`, `removable=True`.
   Round-trip uninstall test verifies all three tables drop cleanly.
+- Sidebar entry registered via `manifest.frontend.navigation`
+  (`/recalls`, icon `i-lucide-bell`, gated by `recalls.read`,
+  `order: 25` — between `Agenda` and `Planes de tratamiento`).
+  Host i18n adds `nav.recalls` for ES/EN.

--- a/backend/app/modules/recalls/CLAUDE.md
+++ b/backend/app/modules/recalls/CLAUDE.md
@@ -105,9 +105,14 @@ monthly call list. Mobile-first layout via `useBreakpoint`.
   `Patient.status="archived"` AND `Patient.do_not_contact=True`.
   Affected recalls go to the `needs_review` bucket (separate filter,
   not deleted).
-- **Auto-link is best-effort.** Reason match is not gated on agenda's
-  free-text `treatment_type`. Match policy: same patient + due_month
-  ≤ appointment month + status active.
+- **Auto-link is conservative — no-op when ambiguous.** Match policy:
+  same patient + due_month ≤ appointment month + status active +
+  no existing link. Reason match is not gated on agenda's free-text
+  `treatment_type`. When the patient has **two or more** active
+  recalls that match, the auto-link bails out and waits for an
+  explicit link via the "Agendar cita" row action (which passes
+  `recall_id`) or `POST /recalls/{id}/link-appointment`. Better one
+  miss than one wrong link — recall history is patient-trust-critical.
 
 ## Related ADRs
 

--- a/backend/app/modules/recalls/CLAUDE.md
+++ b/backend/app/modules/recalls/CLAUDE.md
@@ -1,0 +1,121 @@
+# Recalls module
+
+Patient call-back workflow. Receptionists mark a patient to be called
+in month *X*, work a monthly call list, log attempts, auto-link
+booked appointments. Foundation for a future outreach module that
+will subscribe to `recall.*` events with WhatsApp/SMS/email
+automation. Recalls itself never sends.
+
+Issue #62. Spec: `docs/features/recalls.md`.
+
+## Public API
+
+Routes mounted at `/api/v1/recalls/`.
+
+| Method | Path                              | Permission        |
+|--------|-----------------------------------|-------------------|
+| GET    | `/`                               | `recalls.read`    |
+| POST   | `/`                               | `recalls.write`   |
+| GET    | `/stats/dashboard`                | `recalls.read`    |
+| GET    | `/suggestions/next`               | `recalls.read`    |
+| GET    | `/settings`                       | `recalls.read`    |
+| PUT    | `/settings`                       | `recalls.write`   |
+| GET    | `/export.csv`                     | `recalls.read`    |
+| GET    | `/patients/{patient_id}`          | `recalls.read`    |
+| GET    | `/{id}`                           | `recalls.read`    |
+| PATCH  | `/{id}`                           | `recalls.write`   |
+| POST   | `/{id}/snooze`                    | `recalls.write`   |
+| POST   | `/{id}/cancel`                    | `recalls.write`   |
+| POST   | `/{id}/done`                      | `recalls.write`   |
+| POST   | `/{id}/attempts`                  | `recalls.write`   |
+| GET    | `/{id}/attempts`                  | `recalls.read`    |
+| POST   | `/{id}/link-appointment`          | `recalls.write`   |
+| DELETE | `/{id}`                           | `recalls.delete`  |
+
+## Dependencies
+
+`manifest.depends = ["patients", "agenda"]`.
+
+Treatment-plan integration is **event-driven only** — recalls reads
+the `treatment_category_key` snapshot field that treatment_plan added
+to its `treatment_plan.treatment_completed` payload. Recalls does
+NOT depend on treatment_plan or catalog: no imports, no FKs.
+
+## Permissions
+
+`recalls.read`, `recalls.write`, `recalls.delete`. Default role
+mapping grants read+write to admin, dentist, hygienist, assistant,
+receptionist; only admin gets delete.
+
+## Events emitted
+
+| Event              | When                                                 |
+|--------------------|------------------------------------------------------|
+| `recall.created`   | new recall row inserted (duplicate-guard fires = no event) |
+| `recall.due`       | reserved for future cron — not published in V1       |
+| `recall.completed` | recall transitions to `done`                         |
+| `recall.snoozed`   | recall snoozed N months                              |
+| `recall.cancelled` | recall cancelled (manual or via `patient.archived`)  |
+
+## Events consumed
+
+| Event                                | Handler                          | Effect |
+|--------------------------------------|----------------------------------|--------|
+| `appointment.scheduled`              | `on_appointment_scheduled`       | Auto-link a pending recall (same patient, due_month ≤ appt month) when `auto_link_on_appointment_scheduled` is on. |
+| `appointment.completed`              | `on_appointment_completed`       | Mark linked recall as `done`. |
+| `appointment.cancelled`              | `on_appointment_cancelled`       | Unlink, revert `contacted_scheduled` → `pending`. |
+| `treatment_plan.treatment_completed` | `on_treatment_plan_completed`    | Logging-only stub. Suggestion is pulled by the frontend via `GET /suggestions/next`; keeps state stateless and avoids stale dismissals. |
+| `patient.archived`                   | `on_patient_archived`            | Active recalls (`pending`/`contacted_no_answer`/`contacted_scheduled`) → `needs_review`. |
+
+## Frontend integration (slot registrations)
+
+Registered in `frontend/plugins/slots.client.ts`:
+
+- `patient.summary.actions` — "Set recall" button on patient hero.
+- `patient.summary.feed` — recall pill + recent history.
+- `odontogram.condition.actions` — per-treatment "Set recall".
+- `appointment.completed.followup` — close-out prompt (modal body).
+- `dashboard.attention` — due / overdue / conversion widget.
+- `settings.sections` — reason intervals + category map editor.
+
+The `/recalls` page (`pages/recalls/index.vue`) is the receptionist's
+monthly call list. Mobile-first layout via `useBreakpoint`.
+
+## Lifecycle
+
+- `installable=True`, `auto_install=True`, `removable=True`.
+- `uninstall()` (default no-op) + Alembic downgrade drop the three
+  tables. Round-trip uninstall test enforces this.
+- No backup-on-uninstall data dump in V1 — recall history is lost
+  on uninstall (documented in admin UI).
+
+## Gotchas
+
+- **No FKs to treatment_plan or catalog.** `linked_treatment_id`
+  is a nullable UUID without FK; `linked_treatment_category_key` is
+  a string snapshot. Required to keep the dependency contract.
+- **Multi-tenancy.** Every query filters by `clinic_id`. The
+  `RecallFilters` dataclass + `RecallService.list` always join
+  `Patient` to apply the do-not-contact + archived exclusion.
+- **Duplicate guard.** Creating a recall for `(patient, reason)`
+  that already has an `active` row updates the existing row instead
+  of inserting. The endpoint returns 201 either way; `recall.created`
+  is published only when a new row was actually inserted.
+- **Patient exclusions.** Active call list excludes
+  `Patient.status="archived"` AND `Patient.do_not_contact=True`.
+  Affected recalls go to the `needs_review` bucket (separate filter,
+  not deleted).
+- **Auto-link is best-effort.** Reason match is not gated on agenda's
+  free-text `treatment_type`. Match policy: same patient + due_month
+  ≤ appointment month + status active.
+
+## Related ADRs
+
+- `docs/adr/0001-modular-plugin-architecture.md`
+- `docs/adr/0002-per-module-alembic-branches.md`
+- `docs/adr/0003-event-bus-over-direct-imports.md`
+- `docs/adr/0005-relative-permissions.md`
+
+## CHANGELOG
+
+See `./CHANGELOG.md`.

--- a/backend/app/modules/recalls/__init__.py
+++ b/backend/app/modules/recalls/__init__.py
@@ -1,0 +1,74 @@
+"""Recalls module — patient call-back workflow.
+
+Issue #62. Optional, removable. Sibling to agenda + patients.
+
+The module owns the recall state machine + monthly call list +
+``recall_settings``. It consumes events from agenda, patients and
+treatment_plan; it never imports any of those modules' models or
+services. Treatment-plan integration goes through the enriched
+``treatment_plan.treatment_completed`` payload (``treatment_category_key``
+snapshot) so we keep the dependency at ``["patients", "agenda"]``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.plugins import BaseModule
+
+from .events import (
+    on_appointment_cancelled,
+    on_appointment_completed,
+    on_appointment_scheduled,
+    on_patient_archived,
+    on_treatment_plan_completed,
+)
+from .models import Recall, RecallContactAttempt, RecallSettings
+from .router import router
+
+
+class RecallsModule(BaseModule):
+    manifest = {
+        "name": "recalls",
+        "version": "0.1.0",
+        "summary": (
+            "Patient recalls: schedule call-backs, work the monthly call "
+            "list, log attempts, auto-link booked appointments."
+        ),
+        "author": "DentalPin Core Team",
+        "license": "BSL-1.1",
+        "category": "official",
+        "depends": ["patients", "agenda"],
+        "installable": True,
+        "auto_install": True,
+        "removable": True,
+        "role_permissions": {
+            "admin": ["*"],
+            "dentist": ["recalls.read", "recalls.write"],
+            "hygienist": ["recalls.read", "recalls.write"],
+            "assistant": ["recalls.read", "recalls.write"],
+            "receptionist": ["recalls.read", "recalls.write"],
+        },
+        "frontend": {"layer_path": "frontend"},
+    }
+
+    def get_models(self) -> list:
+        return [Recall, RecallContactAttempt, RecallSettings]
+
+    def get_router(self) -> APIRouter:
+        return router
+
+    def get_permissions(self) -> list[str]:
+        return ["recalls.read", "recalls.write", "recalls.delete"]
+
+    def get_event_handlers(self) -> dict:
+        return {
+            "appointment.scheduled": on_appointment_scheduled,
+            "appointment.completed": on_appointment_completed,
+            "appointment.cancelled": on_appointment_cancelled,
+            "treatment_plan.treatment_completed": on_treatment_plan_completed,
+            "patient.archived": on_patient_archived,
+        }
+
+    def get_tools(self) -> list:
+        return []

--- a/backend/app/modules/recalls/__init__.py
+++ b/backend/app/modules/recalls/__init__.py
@@ -44,10 +44,10 @@ class RecallsModule(BaseModule):
         "removable": True,
         "role_permissions": {
             "admin": ["*"],
-            "dentist": ["recalls.read", "recalls.write"],
-            "hygienist": ["recalls.read", "recalls.write"],
-            "assistant": ["recalls.read", "recalls.write"],
-            "receptionist": ["recalls.read", "recalls.write"],
+            "dentist": ["read", "write"],
+            "hygienist": ["read", "write"],
+            "assistant": ["read", "write"],
+            "receptionist": ["read", "write"],
         },
         "frontend": {
             "layer_path": "frontend",
@@ -70,7 +70,9 @@ class RecallsModule(BaseModule):
         return router
 
     def get_permissions(self) -> list[str]:
-        return ["recalls.read", "recalls.write", "recalls.delete"]
+        # Registry namespaces with module name → final perms are
+        # ``recalls.read`` / ``recalls.write`` / ``recalls.delete``.
+        return ["read", "write", "delete"]
 
     def get_event_handlers(self) -> dict:
         return {

--- a/backend/app/modules/recalls/__init__.py
+++ b/backend/app/modules/recalls/__init__.py
@@ -49,7 +49,18 @@ class RecallsModule(BaseModule):
             "assistant": ["recalls.read", "recalls.write"],
             "receptionist": ["recalls.read", "recalls.write"],
         },
-        "frontend": {"layer_path": "frontend"},
+        "frontend": {
+            "layer_path": "frontend",
+            "navigation": [
+                {
+                    "label": "nav.recalls",
+                    "icon": "i-lucide-bell",
+                    "to": "/recalls",
+                    "permission": "recalls.read",
+                    "order": 25,
+                },
+            ],
+        },
     }
 
     def get_models(self) -> list:

--- a/backend/app/modules/recalls/events.py
+++ b/backend/app/modules/recalls/events.py
@@ -1,0 +1,189 @@
+"""Recalls module event subscribers.
+
+Reacts to lifecycle events from ``patients``, ``agenda`` and
+``treatment_plan``. All cross-module data is consumed via event
+payloads — recalls never imports another module's models, except
+``Patient`` (which is in ``manifest.depends``) for read-side queries.
+
+Registered in :class:`~app.modules.recalls.RecallsModule.get_event_handlers`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+
+from app.database import async_session_maker
+
+from .models import Recall
+from .service import RecallService, RecallSettingsService
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_uuid(raw: Any) -> UUID | None:
+    if raw is None:
+        return None
+    if isinstance(raw, UUID):
+        return raw
+    try:
+        return UUID(str(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+async def on_appointment_scheduled(data: dict[str, Any]) -> None:
+    """Auto-link a pending recall to the new appointment when the
+    clinic's setting allows it.
+
+    Match policy (V1): same patient + the appointment date is on or
+    after the recall's ``due_month`` (which is day-1 of the target
+    month). Reason match is best-effort since agenda's
+    ``treatment_type`` is free-text — we don't gate on it.
+    """
+    appointment_id = _safe_uuid(data.get("appointment_id"))
+    clinic_id = _safe_uuid(data.get("clinic_id"))
+    patient_id = _safe_uuid(data.get("patient_id"))
+    start_time_raw = data.get("start_time")
+    if not (appointment_id and clinic_id and patient_id and start_time_raw):
+        return
+
+    try:
+        start_time = (
+            start_time_raw
+            if isinstance(start_time_raw, datetime)
+            else datetime.fromisoformat(str(start_time_raw))
+        )
+    except (TypeError, ValueError):
+        return
+
+    async with async_session_maker() as db:
+        try:
+            settings = await RecallSettingsService.get_or_create(db, clinic_id)
+            if not settings.auto_link_on_appointment_scheduled:
+                return
+            await RecallService.auto_link_for_appointment(
+                db,
+                clinic_id=clinic_id,
+                patient_id=patient_id,
+                appointment_id=appointment_id,
+                appointment_date=start_time.date(),
+            )
+            await db.commit()
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.error("recalls.on_appointment_scheduled failed: %s", exc, exc_info=True)
+            await db.rollback()
+
+
+async def on_appointment_completed(data: dict[str, Any]) -> None:
+    """If a recall was linked to the completed appointment, mark it done."""
+    appointment_id = _safe_uuid(data.get("appointment_id"))
+    clinic_id = _safe_uuid(data.get("clinic_id"))
+    if not (appointment_id and clinic_id):
+        return
+
+    async with async_session_maker() as db:
+        try:
+            result = await db.execute(
+                select(Recall).where(
+                    Recall.clinic_id == clinic_id,
+                    Recall.linked_appointment_id == appointment_id,
+                    Recall.status.in_(("contacted_scheduled", "pending")),
+                )
+            )
+            for recall in result.scalars().all():
+                await RecallService.mark_done(
+                    db,
+                    clinic_id=clinic_id,
+                    recall_id=recall.id,
+                    by_user=None,
+                    commit=False,
+                )
+            await db.commit()
+        except Exception as exc:
+            logger.error("recalls.on_appointment_completed failed: %s", exc, exc_info=True)
+            await db.rollback()
+
+
+async def on_appointment_cancelled(data: dict[str, Any]) -> None:
+    """Unlink the cancelled appointment from any recall and revert
+    the recall to ``pending`` so it shows up on the call list again.
+    """
+    appointment_id = _safe_uuid(data.get("appointment_id"))
+    clinic_id = _safe_uuid(data.get("clinic_id"))
+    if not (appointment_id and clinic_id):
+        return
+
+    async with async_session_maker() as db:
+        try:
+            result = await db.execute(
+                select(Recall).where(
+                    Recall.clinic_id == clinic_id,
+                    Recall.linked_appointment_id == appointment_id,
+                )
+            )
+            now = datetime.now(UTC)
+            for recall in result.scalars().all():
+                if recall.status in ("done", "cancelled"):
+                    continue
+                recall.linked_appointment_id = None
+                if recall.status == "contacted_scheduled":
+                    recall.status = "pending"
+                recall.updated_at = now
+            await db.commit()
+        except Exception as exc:
+            logger.error("recalls.on_appointment_cancelled failed: %s", exc, exc_info=True)
+            await db.rollback()
+
+
+async def on_treatment_plan_completed(data: dict[str, Any]) -> None:
+    """Reserved hook for future analytics. The actual suggestion is
+    pulled by the frontend via ``GET /recalls/suggestions/next``;
+    keeping the handler stateless avoids race conditions and stale
+    suggestion rows when the user dismisses a hint.
+
+    The handler still runs so module manifests / event catalogs stay
+    consistent and so we have a place to extend later (e.g. notify a
+    pro of upcoming auto-suggestions). For now it just logs.
+    """
+    if not data.get("treatment_category_key"):
+        return
+    logger.debug(
+        "recalls.on_treatment_plan_completed: clinic=%s patient=%s category=%s",
+        data.get("clinic_id"),
+        data.get("patient_id"),
+        data.get("treatment_category_key"),
+    )
+
+
+async def on_patient_archived(data: dict[str, Any]) -> None:
+    """Move active recalls to the ``needs_review`` bucket when the
+    patient is archived. Never deletes — the call list filter keeps
+    them out of the active queue while preserving history.
+    """
+    patient_id = _safe_uuid(data.get("patient_id"))
+    clinic_id = _safe_uuid(data.get("clinic_id"))
+    if not patient_id:
+        return
+
+    async with async_session_maker() as db:
+        try:
+            stmt = select(Recall).where(
+                Recall.patient_id == patient_id,
+                Recall.status.in_(("pending", "contacted_no_answer", "contacted_scheduled")),
+            )
+            if clinic_id:
+                stmt = stmt.where(Recall.clinic_id == clinic_id)
+            result = await db.execute(stmt)
+            now = datetime.now(UTC)
+            for recall in result.scalars().all():
+                recall.status = "needs_review"
+                recall.updated_at = now
+            await db.commit()
+        except Exception as exc:
+            logger.error("recalls.on_patient_archived failed: %s", exc, exc_info=True)
+            await db.rollback()

--- a/backend/app/modules/recalls/frontend/components/LogAttemptForm.vue
+++ b/backend/app/modules/recalls/frontend/components/LogAttemptForm.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type {
+  RecallChannel,
+  RecallOutcome,
+  RecallContactAttempt
+} from '../composables/useRecalls'
+
+interface Props {
+  recallId: string
+  defaultChannel?: RecallChannel
+  /** Default outcome — call list "no_answer" tap uses this. */
+  defaultOutcome?: RecallOutcome
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  defaultChannel: 'phone',
+  defaultOutcome: 'no_answer'
+})
+
+const emit = defineEmits<{
+  logged: [attempt: RecallContactAttempt]
+  cancel: []
+}>()
+
+const { t } = useI18n()
+const toast = useToast()
+const recallsApi = useRecalls()
+
+const channel = ref<RecallChannel>(props.defaultChannel)
+const outcome = ref<RecallOutcome>(props.defaultOutcome)
+const note = ref('')
+const isSubmitting = ref(false)
+
+const channelOptions = computed(() =>
+  (['phone', 'whatsapp', 'sms', 'email'] as RecallChannel[]).map(c => ({
+    value: c,
+    label: t(`recalls.channel.${c}`)
+  }))
+)
+const outcomeOptions = computed(() =>
+  (['no_answer', 'voicemail', 'scheduled', 'declined', 'wrong_number'] as RecallOutcome[]).map(o => ({
+    value: o,
+    label: t(`recalls.outcome.${o}`)
+  }))
+)
+
+async function submit() {
+  if (isSubmitting.value) return
+  isSubmitting.value = true
+  try {
+    const res = await recallsApi.logAttempt(props.recallId, {
+      channel: channel.value,
+      outcome: outcome.value,
+      note: note.value || null
+    })
+    emit('logged', res.data)
+  } catch {
+    toast.add({ title: t('common.error'), color: 'error' })
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <UFormField :label="t('recalls.logAttempt.channel')">
+      <USelectMenu
+        v-model="channel"
+        :items="channelOptions"
+        value-key="value"
+        label-key="label"
+      />
+    </UFormField>
+    <UFormField :label="t('recalls.logAttempt.outcome')">
+      <USelectMenu
+        v-model="outcome"
+        :items="outcomeOptions"
+        value-key="value"
+        label-key="label"
+      />
+    </UFormField>
+    <UFormField :label="t('recalls.logAttempt.note')">
+      <UTextarea
+        v-model="note"
+        :rows="2"
+        :maxlength="500"
+      />
+    </UFormField>
+
+    <div class="flex justify-end gap-2">
+      <UButton
+        color="neutral"
+        variant="ghost"
+        :disabled="isSubmitting"
+        @click="emit('cancel')"
+      >
+        {{ t('actions.cancel') }}
+      </UButton>
+      <UButton
+        color="primary"
+        :loading="isSubmitting"
+        @click="submit"
+      >
+        {{ t('recalls.logAttempt.submit') }}
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/MonthPickerDropdown.vue
+++ b/backend/app/modules/recalls/frontend/components/MonthPickerDropdown.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface Props {
+  /** ISO date string anchored to day 1 of the target month (YYYY-MM-01). */
+  modelValue: string
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const { locale } = useI18n()
+
+const open = ref(false)
+
+const currentDate = computed(() => {
+  const value = props.modelValue
+  // Tolerate YYYY-MM input from upstream pickers.
+  const iso = value.length === 7 ? `${value}-01` : value
+  const d = new Date(iso)
+  return isNaN(d.getTime()) ? new Date() : d
+})
+
+const viewYear = ref(currentDate.value.getFullYear())
+
+const monthLabels = computed(() => {
+  const fmt = new Intl.DateTimeFormat(locale.value, { month: 'short' })
+  return Array.from({ length: 12 }, (_, i) => fmt.format(new Date(2000, i, 1)))
+})
+
+const triggerLabel = computed(() =>
+  new Intl.DateTimeFormat(locale.value, {
+    year: 'numeric',
+    month: 'long'
+  }).format(currentDate.value)
+)
+
+const selectedYear = computed(() => currentDate.value.getFullYear())
+const selectedMonth = computed(() => currentDate.value.getMonth())
+
+function pick(monthIdx: number) {
+  const y = String(viewYear.value).padStart(4, '0')
+  const m = String(monthIdx + 1).padStart(2, '0')
+  emit('update:modelValue', `${y}-${m}-01`)
+  open.value = false
+}
+
+function shiftYear(delta: number) {
+  viewYear.value += delta
+}
+
+function goToday() {
+  const today = new Date()
+  viewYear.value = today.getFullYear()
+  pick(today.getMonth())
+}
+</script>
+
+<template>
+  <UPopover
+    v-model:open="open"
+    :ui="{ content: 'w-64' }"
+  >
+    <UButton
+      color="neutral"
+      variant="outline"
+      :label="triggerLabel"
+      icon="i-lucide-calendar"
+      trailing-icon="i-lucide-chevron-down"
+      class="w-full justify-between"
+    />
+    <template #content>
+      <div class="p-3 space-y-3">
+        <div class="flex items-center justify-between">
+          <UButton
+            icon="i-lucide-chevron-left"
+            size="xs"
+            variant="ghost"
+            color="neutral"
+            :aria-label="'Previous year'"
+            @click="shiftYear(-1)"
+          />
+          <span class="font-medium tnum">{{ viewYear }}</span>
+          <UButton
+            icon="i-lucide-chevron-right"
+            size="xs"
+            variant="ghost"
+            color="neutral"
+            :aria-label="'Next year'"
+            @click="shiftYear(1)"
+          />
+        </div>
+        <div class="grid grid-cols-3 gap-1">
+          <UButton
+            v-for="(label, i) in monthLabels"
+            :key="i"
+            :variant="
+              viewYear === selectedYear && i === selectedMonth ? 'solid' : 'soft'
+            "
+            :color="
+              viewYear === selectedYear && i === selectedMonth ? 'primary' : 'neutral'
+            "
+            size="sm"
+            class="capitalize justify-center"
+            :label="label"
+            @click="pick(i)"
+          />
+        </div>
+        <UButton
+          variant="link"
+          color="primary"
+          size="xs"
+          class="w-full justify-center"
+          @click="goToday"
+        >
+          {{ $t('recalls.filters.thisMonth') }}
+        </UButton>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/backend/app/modules/recalls/frontend/components/RecallCloseoutPrompt.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallCloseoutPrompt.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+// Slot entry into `appointment.completed.followup`. Receives an
+// `appointment` ctx with at least patient_id + treatment_type +
+// professional_id. Emits `done` to dismiss the host modal.
+interface Props {
+  appointment: {
+    id: string
+    patient_id?: string | null
+    professional_id?: string | null
+    treatment_type?: string | null
+  }
+}
+const props = defineProps<Props>()
+const emit = defineEmits<{ done: [] }>()
+
+const { t } = useI18n()
+const open = ref(false)
+
+const patientId = computed(() => props.appointment.patient_id ?? null)
+const canPrompt = computed(() => !!patientId.value)
+
+function openModal() {
+  open.value = true
+}
+
+function onSaved() {
+  open.value = false
+  emit('done')
+}
+
+function skip() {
+  emit('done')
+}
+</script>
+
+<template>
+  <div
+    v-if="canPrompt"
+    class="space-y-3"
+  >
+    <p class="text-default">
+      {{ t('recalls.closeoutPrompt.subtitle') }}
+    </p>
+    <div class="flex gap-2">
+      <UButton
+        color="primary"
+        icon="i-lucide-bell"
+        @click="openModal"
+      >
+        {{ t('recalls.setRecall') }}
+      </UButton>
+      <UButton
+        color="neutral"
+        variant="ghost"
+        @click="skip"
+      >
+        {{ t('recalls.closeoutPrompt.skip') }}
+      </UButton>
+    </div>
+
+    <SetRecallModal
+      v-if="patientId"
+      v-model:open="open"
+      :patient-id="patientId"
+      :initial-assigned-professional-id="appointment.professional_id ?? null"
+      @saved="onSaved"
+    />
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/RecallDashboardWidget.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallDashboardWidget.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import type { RecallDashboardStats } from '../composables/useRecalls'
+
+const { t } = useI18n()
+const recallsApi = useRecalls()
+
+const stats = ref<RecallDashboardStats | null>(null)
+const isLoading = ref(false)
+
+async function load() {
+  isLoading.value = true
+  try {
+    const res = await recallsApi.dashboardStats()
+    stats.value = res.data
+  } catch {
+    stats.value = null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(load)
+
+const conversionPct = computed(() =>
+  stats.value ? Math.round(stats.value.conversion_rate * 100) : 0
+)
+</script>
+
+<template>
+  <UCard
+    v-if="stats || isLoading"
+    :ui="{ body: 'p-3' }"
+  >
+    <template #header>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <UIcon
+            name="i-lucide-bell"
+            class="w-4 h-4 text-default"
+          />
+          <span class="font-medium">{{ t('recalls.dashboard.title') }}</span>
+        </div>
+        <NuxtLink
+          to="/recalls"
+          class="text-primary-accent hover:underline text-caption"
+        >
+          {{ t('recalls.callList') }} →
+        </NuxtLink>
+      </div>
+    </template>
+
+    <USkeleton
+      v-if="isLoading || !stats"
+      class="h-16 w-full"
+    />
+
+    <div
+      v-else
+      class="grid grid-cols-2 gap-2 sm:grid-cols-4 text-center"
+    >
+      <div>
+        <div class="text-h2 text-default tnum">
+          {{ stats.due_this_week }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.due_this_week') }}
+        </div>
+      </div>
+      <div>
+        <div class="text-h2 text-default tnum">
+          {{ stats.overdue }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.overdue') }}
+        </div>
+      </div>
+      <div>
+        <div class="text-h2 text-default tnum">
+          {{ stats.scheduled_this_month }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.scheduled_this_month') }}
+        </div>
+      </div>
+      <div>
+        <div class="text-h2 text-default tnum">
+          {{ conversionPct }}%
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.conversion_rate') }}
+        </div>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/backend/app/modules/recalls/frontend/components/RecallList.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallList.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { Recall } from '../composables/useRecalls'
+
+interface Props {
+  items: Recall[]
+  isLoading: boolean
+}
+defineProps<Props>()
+
+const emit = defineEmits<{ changed: [recall: Recall] }>()
+const { t } = useI18n()
+</script>
+
+<template>
+  <div>
+    <USkeleton
+      v-if="isLoading"
+      class="h-32 w-full"
+    />
+    <div
+      v-else-if="items.length === 0"
+      class="rounded-token-md border border-default bg-default p-6 text-center text-subtle"
+    >
+      {{ t('recalls.noRecallsThisMonth') }}
+    </div>
+    <ul
+      v-else
+      class="space-y-2"
+    >
+      <li
+        v-for="recall in items"
+        :key="recall.id"
+      >
+        <RecallRow
+          :recall="recall"
+          @changed="emit('changed', $event)"
+        />
+      </li>
+    </ul>
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/RecallRow.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallRow.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Recall } from '../composables/useRecalls'
+
+interface Props { recall: Recall }
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  changed: [recall: Recall]
+  delete: [recall: Recall]
+}>()
+
+const { t, locale } = useI18n()
+const toast = useToast()
+const recallsApi = useRecalls()
+
+const logOpen = ref(false)
+const snoozeOpen = ref(false)
+const snoozeMonths = ref(3)
+const isBusy = ref(false)
+
+const patient = computed(() => props.recall.patient ?? null)
+
+const callable = computed(
+  () =>
+    !!patient.value?.phone &&
+    !patient.value?.do_not_contact &&
+    patient.value?.status !== 'archived'
+)
+
+const phoneHref = computed(() =>
+  patient.value?.phone ? `tel:${patient.value.phone}` : undefined
+)
+
+const monthLabel = computed(() => {
+  const date = new Date(props.recall.due_month)
+  return new Intl.DateTimeFormat(locale.value, {
+    year: 'numeric',
+    month: 'long'
+  }).format(date)
+})
+
+async function quickNoAnswer() {
+  if (isBusy.value) return
+  isBusy.value = true
+  try {
+    await recallsApi.logAttempt(props.recall.id, {
+      channel: 'phone',
+      outcome: 'no_answer'
+    })
+    const updated = await recallsApi.get(props.recall.id)
+    emit('changed', updated.data)
+  } catch {
+    toast.add({ title: t('common.error'), color: 'error' })
+  } finally {
+    isBusy.value = false
+  }
+}
+
+async function bookAppointment() {
+  await navigateTo(
+    `/appointments?patient_id=${props.recall.patient_id}&recall_id=${props.recall.id}`
+  )
+}
+
+async function snooze() {
+  if (isBusy.value) return
+  isBusy.value = true
+  try {
+    const res = await recallsApi.snooze(props.recall.id, snoozeMonths.value)
+    snoozeOpen.value = false
+    emit('changed', res.data)
+  } catch {
+    toast.add({ title: t('common.error'), color: 'error' })
+  } finally {
+    isBusy.value = false
+  }
+}
+
+async function cancelRecall() {
+  if (isBusy.value) return
+  isBusy.value = true
+  try {
+    const res = await recallsApi.cancel(props.recall.id)
+    emit('changed', res.data)
+  } finally {
+    isBusy.value = false
+  }
+}
+
+async function markDone() {
+  if (isBusy.value) return
+  isBusy.value = true
+  try {
+    const res = await recallsApi.markDone(props.recall.id)
+    emit('changed', res.data)
+  } finally {
+    isBusy.value = false
+  }
+}
+
+const priorityChipColour = computed<'error' | 'info' | 'neutral'>(() => {
+  switch (props.recall.priority) {
+    case 'high': return 'error'
+    case 'normal': return 'info'
+    default: return 'neutral'
+  }
+})
+
+async function onAttemptLogged() {
+  logOpen.value = false
+  const updated = await recallsApi.get(props.recall.id)
+  emit('changed', updated.data)
+}
+</script>
+
+<template>
+  <div
+    class="rounded-token-md border border-default bg-default p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3"
+  >
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2 flex-wrap">
+        <NuxtLink
+          v-if="patient"
+          :to="`/patients/${patient.id}`"
+          class="font-medium text-default hover:underline"
+        >
+          {{ patient.first_name }} {{ patient.last_name }}
+        </NuxtLink>
+        <UBadge
+          :color="priorityChipColour"
+          variant="subtle"
+          size="xs"
+        >
+          {{ t(`recalls.priority.${recall.priority}`) }}
+        </UBadge>
+        <UBadge
+          variant="soft"
+          size="xs"
+        >
+          {{ t(`recalls.reasons.${recall.reason}`) }}
+        </UBadge>
+        <UBadge
+          variant="soft"
+          color="neutral"
+          size="xs"
+        >
+          {{ t(`recalls.status.${recall.status}`) }}
+        </UBadge>
+      </div>
+      <div class="text-caption text-subtle mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+        <span>{{ monthLabel }}</span>
+        <span v-if="patient?.phone">📞 {{ patient.phone }}</span>
+        <span v-if="recall.contact_attempt_count > 0">
+          {{ recall.contact_attempt_count }} {{ t('recalls.actions.logAttempt') }}
+        </span>
+      </div>
+      <p
+        v-if="recall.reason_note"
+        class="text-sm text-subtle mt-1 line-clamp-2"
+      >
+        {{ recall.reason_note }}
+      </p>
+    </div>
+
+    <div class="flex gap-1 sm:gap-2 flex-wrap">
+      <UButton
+        v-if="callable"
+        :href="phoneHref"
+        icon="i-lucide-phone"
+        size="sm"
+        color="primary"
+        variant="soft"
+      >
+        {{ t('recalls.actions.call') }}
+      </UButton>
+      <UButton
+        icon="i-lucide-phone-off"
+        size="sm"
+        variant="ghost"
+        color="neutral"
+        :loading="isBusy"
+        :title="t('recalls.actions.noAnswer')"
+        @click="quickNoAnswer"
+      />
+      <UButton
+        icon="i-lucide-list-plus"
+        size="sm"
+        variant="ghost"
+        color="neutral"
+        :title="t('recalls.actions.logAttempt')"
+        @click="logOpen = true"
+      />
+      <UButton
+        icon="i-lucide-calendar-plus"
+        size="sm"
+        variant="ghost"
+        color="neutral"
+        :title="t('recalls.actions.book')"
+        @click="bookAppointment"
+      />
+      <UDropdownMenu
+        :items="[
+          {
+            label: t('recalls.actions.snooze'),
+            icon: 'i-lucide-clock',
+            onSelect: () => { snoozeOpen = true }
+          },
+          {
+            label: t('recalls.actions.markDone'),
+            icon: 'i-lucide-check',
+            onSelect: () => markDone()
+          },
+          {
+            label: t('recalls.actions.cancel'),
+            icon: 'i-lucide-x',
+            color: 'error',
+            onSelect: () => cancelRecall()
+          }
+        ]"
+      >
+        <UButton
+          icon="i-lucide-more-vertical"
+          size="sm"
+          variant="ghost"
+          color="neutral"
+        />
+      </UDropdownMenu>
+    </div>
+
+    <UModal
+      :open="logOpen"
+      :title="t('recalls.actions.logAttempt')"
+      @update:open="(v: boolean) => { logOpen = v }"
+    >
+      <template #body>
+        <div class="p-4">
+          <LogAttemptForm
+            :recall-id="recall.id"
+            @logged="onAttemptLogged"
+            @cancel="logOpen = false"
+          />
+        </div>
+      </template>
+    </UModal>
+
+    <UModal
+      :open="snoozeOpen"
+      :title="t('recalls.snoozePrompt')"
+      @update:open="(v: boolean) => { snoozeOpen = v }"
+    >
+      <template #body>
+        <div class="p-4">
+          <UInput
+            v-model.number="snoozeMonths"
+            type="number"
+            min="1"
+            max="24"
+          />
+        </div>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-2 p-2">
+          <UButton
+            color="neutral"
+            variant="ghost"
+            @click="snoozeOpen = false"
+          >
+            {{ t('actions.cancel') }}
+          </UButton>
+          <UButton
+            color="primary"
+            :loading="isBusy"
+            @click="snooze"
+          >
+            {{ t('recalls.actions.snooze') }}
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import type { RecallSettings } from '../composables/useRecalls'
+
+const { t } = useI18n()
+const toast = useToast()
+const recallsApi = useRecalls()
+
+const settings = ref<RecallSettings | null>(null)
+const isLoading = ref(false)
+const isSaving = ref(false)
+
+const reasons = ['hygiene', 'checkup', 'ortho_review', 'implant_review', 'post_op', 'treatment_followup', 'other'] as const
+
+async function load() {
+  isLoading.value = true
+  try {
+    const res = await recallsApi.getSettings()
+    settings.value = res.data
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(load)
+
+async function save() {
+  if (!settings.value || isSaving.value) return
+  isSaving.value = true
+  try {
+    const res = await recallsApi.updateSettings({
+      reason_intervals: settings.value.reason_intervals,
+      category_to_reason: settings.value.category_to_reason,
+      auto_suggest_on_treatment_completed: settings.value.auto_suggest_on_treatment_completed,
+      auto_link_on_appointment_scheduled: settings.value.auto_link_on_appointment_scheduled
+    })
+    settings.value = res.data
+    toast.add({ title: t('recalls.settings.saved'), color: 'success' })
+  } catch {
+    toast.add({ title: t('common.error'), color: 'error' })
+  } finally {
+    isSaving.value = false
+  }
+}
+
+function ensureInterval(reason: string) {
+  if (!settings.value) return
+  if (typeof settings.value.reason_intervals[reason] !== 'number') {
+    settings.value.reason_intervals[reason] = 6
+  }
+}
+
+watch(settings, () => {
+  if (!settings.value) return
+  for (const r of reasons) ensureInterval(r)
+}, { deep: true })
+
+const categoryRows = computed(() => {
+  if (!settings.value) return []
+  return Object.entries(settings.value.category_to_reason).map(([key, reason]) => ({ key, reason }))
+})
+
+const newCategoryKey = ref('')
+const newCategoryReason = ref<string>('hygiene')
+
+function addCategory() {
+  if (!settings.value || !newCategoryKey.value) return
+  settings.value.category_to_reason = {
+    ...settings.value.category_to_reason,
+    [newCategoryKey.value]: newCategoryReason.value
+  }
+  newCategoryKey.value = ''
+}
+
+function removeCategory(key: string) {
+  if (!settings.value) return
+  const next = { ...settings.value.category_to_reason }
+  delete next[key]
+  settings.value.category_to_reason = next
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div>
+      <h2 class="text-h2">
+        {{ t('recalls.settings.title') }}
+      </h2>
+      <p class="text-subtle">
+        {{ t('recalls.settings.description') }}
+      </p>
+    </div>
+
+    <USkeleton
+      v-if="isLoading || !settings"
+      class="h-32 w-full"
+    />
+
+    <template v-else>
+      <UCard>
+        <template #header>
+          <h3 class="text-h3">
+            {{ t('recalls.settings.intervals') }}
+          </h3>
+        </template>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <UFormField
+            v-for="r in reasons"
+            :key="r"
+            :label="t(`recalls.reasons.${r}`)"
+          >
+            <UInput
+              v-model.number="settings.reason_intervals[r]"
+              type="number"
+              min="0"
+              max="60"
+            />
+          </UFormField>
+        </div>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <h3 class="text-h3">
+            {{ t('recalls.settings.categoryMap') }}
+          </h3>
+        </template>
+        <ul class="divide-y divide-default">
+          <li
+            v-for="row in categoryRows"
+            :key="row.key"
+            class="flex items-center justify-between gap-3 py-2"
+          >
+            <span class="font-mono text-sm">{{ row.key }}</span>
+            <span class="text-subtle">→</span>
+            <span class="flex-1">{{ t(`recalls.reasons.${row.reason}`) }}</span>
+            <UButton
+              icon="i-lucide-trash-2"
+              variant="ghost"
+              color="error"
+              size="xs"
+              @click="removeCategory(row.key)"
+            />
+          </li>
+        </ul>
+        <div class="flex gap-2 mt-3">
+          <UInput
+            v-model="newCategoryKey"
+            placeholder="catalog category key"
+            class="flex-1"
+          />
+          <USelectMenu
+            v-model="newCategoryReason"
+            :items="reasons.map(r => ({ value: r, label: t(`recalls.reasons.${r}`) }))"
+            value-key="value"
+            label-key="label"
+          />
+          <UButton
+            icon="i-lucide-plus"
+            color="primary"
+            variant="soft"
+            :disabled="!newCategoryKey"
+            @click="addCategory"
+          />
+        </div>
+      </UCard>
+
+      <UCard>
+        <div class="space-y-3">
+          <UFormField :label="t('recalls.settings.autoSuggest')">
+            <USwitch v-model="settings.auto_suggest_on_treatment_completed" />
+          </UFormField>
+          <UFormField :label="t('recalls.settings.autoLink')">
+            <USwitch v-model="settings.auto_link_on_appointment_scheduled" />
+          </UFormField>
+        </div>
+      </UCard>
+
+      <div class="flex justify-end">
+        <UButton
+          color="primary"
+          :loading="isSaving"
+          @click="save"
+        >
+          {{ t('recalls.actions.save') }}
+        </UButton>
+      </div>
+    </template>
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/RecallSummaryFeed.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSummaryFeed.vue
@@ -2,10 +2,11 @@
 import { computed, ref, onMounted } from 'vue'
 import type { Recall } from '../composables/useRecalls'
 
-interface Props {
-  patient: { id: string }
-}
-const props = defineProps<Props>()
+// Slot entry into `patient.summary.feed`. `<ModuleSlot>` passes the
+// slot ctx as a single `ctx` prop.
+const props = defineProps<{
+  ctx: { patient: { id: string } }
+}>()
 
 const { t, locale } = useI18n()
 const recallsApi = useRecalls()
@@ -14,9 +15,14 @@ const recalls = ref<Recall[]>([])
 const isLoading = ref(false)
 
 async function load() {
+  const patientId = props.ctx?.patient?.id
+  if (!patientId) {
+    recalls.value = []
+    return
+  }
   isLoading.value = true
   try {
-    const res = await recallsApi.listForPatient(props.patient.id)
+    const res = await recallsApi.listForPatient(patientId)
     recalls.value = res.data
   } catch {
     recalls.value = []
@@ -112,7 +118,7 @@ function statusColour(status: Recall['status']): 'success' | 'info' | 'warning' 
     </ul>
     <div class="pt-2">
       <NuxtLink
-        :to="`/recalls?patient_id=${patient.id}`"
+        :to="`/recalls?patient_id=${props.ctx.patient.id}`"
         class="text-primary-accent hover:underline text-caption"
       >
         {{ t('recalls.viewAll') }} →

--- a/backend/app/modules/recalls/frontend/components/RecallSummaryFeed.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSummaryFeed.vue
@@ -1,41 +1,29 @@
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import type { Recall } from '../composables/useRecalls'
 
 // Slot entry into `patient.summary.feed`. `<ModuleSlot>` passes the
-// slot ctx as a single `ctx` prop.
+// slot ctx as a single `ctx` prop. Reads from the shared
+// per-patient state so we don't double-fetch the recall list with
+// `SetRecallButton`.
 const props = defineProps<{
   ctx: { patient: { id: string } }
 }>()
 
 const { t, locale } = useI18n()
-const recallsApi = useRecalls()
 
-const recalls = ref<Recall[]>([])
-const isLoading = ref(false)
-
-async function load() {
-  const patientId = props.ctx?.patient?.id
-  if (!patientId) {
-    recalls.value = []
-    return
-  }
-  isLoading.value = true
-  try {
-    const res = await recallsApi.listForPatient(patientId)
-    recalls.value = res.data
-  } catch {
-    recalls.value = []
-  } finally {
-    isLoading.value = false
-  }
-}
-
-onMounted(load)
-
-const nextRecall = computed(() =>
-  recalls.value.find(r => ['pending', 'contacted_no_answer', 'contacted_scheduled'].includes(r.status))
+const patientRecalls = computed(() =>
+  props.ctx?.patient?.id ? usePatientRecalls(props.ctx.patient.id) : null
 )
+
+const recalls = computed<Recall[]>(() => patientRecalls.value?.recalls.value ?? [])
+const isLoading = computed(() => patientRecalls.value?.isLoading.value ?? false)
+
+onMounted(() => {
+  patientRecalls.value?.ensureLoaded()
+})
+
+const nextRecall = computed(() => patientRecalls.value?.nextActiveRecall.value ?? null)
 
 const recentHistory = computed(() => recalls.value.slice(0, 5))
 

--- a/backend/app/modules/recalls/frontend/components/RecallSummaryFeed.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSummaryFeed.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from 'vue'
+import type { Recall } from '../composables/useRecalls'
+
+interface Props {
+  patient: { id: string }
+}
+const props = defineProps<Props>()
+
+const { t, locale } = useI18n()
+const recallsApi = useRecalls()
+
+const recalls = ref<Recall[]>([])
+const isLoading = ref(false)
+
+async function load() {
+  isLoading.value = true
+  try {
+    const res = await recallsApi.listForPatient(props.patient.id)
+    recalls.value = res.data
+  } catch {
+    recalls.value = []
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(load)
+
+const nextRecall = computed(() =>
+  recalls.value.find(r => ['pending', 'contacted_no_answer', 'contacted_scheduled'].includes(r.status))
+)
+
+const recentHistory = computed(() => recalls.value.slice(0, 5))
+
+function formatMonth(iso: string): string {
+  const date = new Date(iso)
+  return new Intl.DateTimeFormat(locale.value, { year: 'numeric', month: 'long' }).format(date)
+}
+
+function statusColour(status: Recall['status']): 'success' | 'info' | 'warning' | 'neutral' | 'error' {
+  switch (status) {
+    case 'done': return 'success'
+    case 'contacted_scheduled': return 'info'
+    case 'pending':
+    case 'contacted_no_answer': return 'warning'
+    case 'cancelled':
+    case 'contacted_declined':
+    case 'needs_review': return 'neutral'
+    default: return 'neutral'
+  }
+}
+</script>
+
+<template>
+  <UCard
+    v-if="recalls.length > 0 || isLoading"
+    :ui="{ body: 'p-3' }"
+  >
+    <template #header>
+      <div class="flex items-center gap-2">
+        <UIcon
+          name="i-lucide-bell"
+          class="w-4 h-4 text-subtle"
+        />
+        <span class="text-caption uppercase tracking-wide text-subtle">
+          {{ t('recalls.history') }}
+        </span>
+      </div>
+    </template>
+
+    <USkeleton
+      v-if="isLoading"
+      class="h-12 w-full"
+    />
+
+    <div
+      v-else-if="nextRecall"
+      class="mb-2"
+    >
+      <UBadge
+        color="warning"
+        variant="subtle"
+        size="sm"
+      >
+        {{ t('recalls.pillNext', {
+          month: formatMonth(nextRecall.due_month),
+          reason: t(`recalls.reasons.${nextRecall.reason}`)
+        }) }}
+      </UBadge>
+    </div>
+
+    <ul class="divide-y divide-default text-sm">
+      <li
+        v-for="r in recentHistory"
+        :key="r.id"
+        class="flex items-center justify-between py-1.5 gap-3"
+      >
+        <div class="min-w-0 truncate">
+          <span class="text-default">{{ formatMonth(r.due_month) }}</span>
+          <span class="text-subtle"> · </span>
+          <span class="text-subtle">{{ t(`recalls.reasons.${r.reason}`) }}</span>
+        </div>
+        <UBadge
+          :color="statusColour(r.status)"
+          variant="soft"
+          size="xs"
+        >
+          {{ t(`recalls.status.${r.status}`) }}
+        </UBadge>
+      </li>
+    </ul>
+    <div class="pt-2">
+      <NuxtLink
+        :to="`/recalls?patient_id=${patient.id}`"
+        class="text-primary-accent hover:underline text-caption"
+      >
+        {{ t('recalls.viewAll') }} →
+      </NuxtLink>
+    </div>
+  </UCard>
+</template>

--- a/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
@@ -1,20 +1,59 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 // Slot entry into `patient.summary.actions`. `<ModuleSlot>` passes
 // the slot ctx as a single `ctx` prop; we destructure the patient
-// from it here.
+// from it here. We read ``do_not_contact`` to hide the CTA and
+// show the opt-out banner instead — receptionists must never
+// schedule a recall against a patient flagged as no-contact.
 const props = defineProps<{
-  ctx: { patient: { id: string } }
+  ctx: {
+    patient: {
+      id: string
+      do_not_contact?: boolean
+      status?: string
+    }
+  }
 }>()
 
 const { t } = useI18n()
 const open = ref(false)
+
+const patient = computed(() => props.ctx?.patient)
+const doNotContact = computed(() => patient.value?.do_not_contact === true)
+const isArchived = computed(() => patient.value?.status === 'archived')
+const canSchedule = computed(
+  () => !!patient.value?.id && !doNotContact.value && !isArchived.value
+)
 </script>
 
 <template>
-  <div v-if="props.ctx?.patient?.id">
+  <div v-if="patient?.id">
+    <!-- Opt-out banner: replaces the CTA when the patient is flagged
+         do_not_contact (and reuses the same surface for archived). -->
+    <div
+      v-if="doNotContact"
+      class="alert-surface-warning rounded-token-md px-3 py-2 flex items-start gap-2"
+      role="status"
+    >
+      <UIcon
+        name="i-lucide-phone-off"
+        class="w-4 h-4 mt-0.5 shrink-0"
+        :style="{ color: 'var(--color-warning-accent)' }"
+        aria-hidden="true"
+      />
+      <div class="text-sm leading-snug">
+        <p class="font-medium text-default">
+          {{ t('patients.doNotContact.badge') }}
+        </p>
+        <p class="text-subtle text-caption mt-0.5">
+          {{ t('recalls.doNotContact.cannotSchedule') }}
+        </p>
+      </div>
+    </div>
+
     <UButton
+      v-else-if="canSchedule"
       color="primary"
       variant="soft"
       icon="i-lucide-bell"
@@ -26,8 +65,9 @@ const open = ref(false)
     </UButton>
 
     <SetRecallModal
+      v-if="canSchedule"
       v-model:open="open"
-      :patient-id="props.ctx.patient.id"
+      :patient-id="patient.id"
     />
   </div>
 </template>

--- a/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-// Slot entry rendered into `patient.summary.actions`. Receives a
-// `patient` ctx prop set by `<ModuleSlot>` in `PatientSummaryHero`.
-interface Props {
-  patient: { id: string }
-}
-defineProps<Props>()
+// Slot entry into `patient.summary.actions`. `<ModuleSlot>` passes
+// the slot ctx as a single `ctx` prop; we destructure the patient
+// from it here.
+const props = defineProps<{
+  ctx: { patient: { id: string } }
+}>()
 
 const { t } = useI18n()
 const open = ref(false)
 </script>
 
 <template>
-  <div>
+  <div v-if="props.ctx?.patient?.id">
     <UButton
       color="primary"
       variant="soft"
@@ -27,7 +27,7 @@ const open = ref(false)
 
     <SetRecallModal
       v-model:open="open"
-      :patient-id="patient.id"
+      :patient-id="props.ctx.patient.id"
     />
   </div>
 </template>

--- a/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+// Slot entry rendered into `patient.summary.actions`. Receives a
+// `patient` ctx prop set by `<ModuleSlot>` in `PatientSummaryHero`.
+interface Props {
+  patient: { id: string }
+}
+defineProps<Props>()
+
+const { t } = useI18n()
+const open = ref(false)
+</script>
+
+<template>
+  <div>
+    <UButton
+      color="primary"
+      variant="soft"
+      icon="i-lucide-bell"
+      size="sm"
+      class="w-full"
+      @click="open = true"
+    >
+      {{ t('recalls.setRecall') }}
+    </UButton>
+
+    <SetRecallModal
+      v-model:open="open"
+      :patient-id="patient.id"
+    />
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallButton.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 // Slot entry into `patient.summary.actions`. `<ModuleSlot>` passes
-// the slot ctx as a single `ctx` prop; we destructure the patient
-// from it here. We read ``do_not_contact`` to hide the CTA and
-// show the opt-out banner instead — receptionists must never
-// schedule a recall against a patient flagged as no-contact.
+// the slot ctx as a single `ctx` prop. Reads `do_not_contact` to
+// hide the CTA + show the opt-out banner instead — receptionists
+// must never schedule a recall against a patient flagged as
+// no-contact.
 const props = defineProps<{
   ctx: {
     patient: {
@@ -16,7 +16,7 @@ const props = defineProps<{
   }
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const open = ref(false)
 
 const patient = computed(() => props.ctx?.patient)
@@ -25,11 +25,44 @@ const isArchived = computed(() => patient.value?.status === 'archived')
 const canSchedule = computed(
   () => !!patient.value?.id && !doNotContact.value && !isArchived.value
 )
+
+// Shared per-patient list — same useState that `RecallSummaryFeed`
+// reads, so the page fires one fetch and both surfaces stay in sync.
+const patientRecalls = computed(() =>
+  patient.value?.id ? usePatientRecalls(patient.value.id) : null
+)
+const nextRecall = computed(() => patientRecalls.value?.nextActiveRecall.value ?? null)
+
+onMounted(() => {
+  patientRecalls.value?.ensureLoaded()
+})
+
+function formatMonth(iso: string): string {
+  return new Intl.DateTimeFormat(locale.value, {
+    year: 'numeric',
+    month: 'long'
+  }).format(new Date(iso))
+}
+
+function statusColour(status: string): 'success' | 'info' | 'warning' | 'neutral' {
+  switch (status) {
+    case 'contacted_scheduled': return 'info'
+    case 'pending':
+    case 'contacted_no_answer': return 'warning'
+    default: return 'neutral'
+  }
+}
+
+async function onSaved() {
+  // Refresh the shared list so the inline card + summary feed both
+  // pick up the new / updated recall without a page reload.
+  await patientRecalls.value?.refresh()
+}
 </script>
 
 <template>
   <div v-if="patient?.id">
-    <!-- Opt-out banner: replaces the CTA when the patient is flagged
+    <!-- Opt-out banner replaces the CTA when the patient is flagged
          do_not_contact (and reuses the same surface for archived). -->
     <div
       v-if="doNotContact"
@@ -52,22 +85,55 @@ const canSchedule = computed(
       </div>
     </div>
 
-    <UButton
-      v-else-if="canSchedule"
-      color="primary"
-      variant="soft"
-      icon="i-lucide-bell"
-      size="sm"
-      class="w-full"
-      @click="open = true"
-    >
-      {{ t('recalls.setRecall') }}
-    </UButton>
+    <template v-else-if="canSchedule">
+      <UButton
+        color="primary"
+        variant="soft"
+        icon="i-lucide-bell"
+        size="sm"
+        class="w-full"
+        @click="open = true"
+      >
+        {{ t('recalls.setRecall') }}
+      </UButton>
+
+      <!-- Inline active-recall card. Only renders when an active
+           recall exists; otherwise the slot just shows the CTA. -->
+      <NuxtLink
+        v-if="nextRecall"
+        :to="`/recalls?patient_id=${patient.id}`"
+        class="block mt-2 rounded-token-md border border-default bg-default hover:bg-elevated px-3 py-2 transition-colors"
+      >
+        <div class="flex items-center gap-2">
+          <UIcon
+            name="i-lucide-bell-ring"
+            class="w-4 h-4 text-primary-accent shrink-0"
+          />
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium text-default truncate">
+              {{ formatMonth(nextRecall.due_month) }} ·
+              {{ t(`recalls.reasons.${nextRecall.reason}`) }}
+            </p>
+            <p class="text-caption text-subtle">
+              {{ t('recalls.activeRecallHint') }}
+            </p>
+          </div>
+          <UBadge
+            :color="statusColour(nextRecall.status)"
+            variant="subtle"
+            size="xs"
+          >
+            {{ t(`recalls.status.${nextRecall.status}`) }}
+          </UBadge>
+        </div>
+      </NuxtLink>
+    </template>
 
     <SetRecallModal
       v-if="canSchedule"
       v-model:open="open"
       :patient-id="patient.id"
+      @saved="onSaved"
     />
   </div>
 </template>

--- a/backend/app/modules/recalls/frontend/components/SetRecallFromTreatmentButton.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallFromTreatmentButton.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { RecallReason } from '../composables/useRecalls'
+
+// Slot entry into `odontogram.condition.actions`. Ctx shape varies
+// across hosts (treatment-plan rows, odontogram diagnosis list); we
+// only read what's needed here and tolerate missing fields.
+interface Props {
+  patient?: { id: string }
+  patientId?: string
+  treatment?: {
+    id?: string
+    catalog_item?: { category?: { key?: string } } | null
+  }
+}
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const open = ref(false)
+
+const patientId = computed(() => props.patient?.id ?? props.patientId ?? null)
+const treatmentId = computed(() => props.treatment?.id ?? null)
+const treatmentCategoryKey = computed(
+  () => props.treatment?.catalog_item?.category?.key ?? null
+)
+
+const reason = computed<RecallReason>(() => {
+  // Keep in sync with backend `DEFAULT_CATEGORY_TO_REASON`.
+  switch (treatmentCategoryKey.value) {
+    case 'preventivo': return 'hygiene'
+    case 'ortodoncia': return 'ortho_review'
+    case 'cirugia': return 'post_op'
+    case 'implantes': return 'implant_review'
+    default: return 'treatment_followup'
+  }
+})
+
+function onClick() {
+  if (!patientId.value) return
+  open.value = true
+}
+</script>
+
+<template>
+  <div v-if="patientId">
+    <UButton
+      icon="i-lucide-bell-plus"
+      size="xs"
+      color="neutral"
+      variant="ghost"
+      :title="t('recalls.setRecall')"
+      @click="onClick"
+    />
+    <SetRecallModal
+      v-model:open="open"
+      :patient-id="patientId"
+      :initial-reason="reason"
+      :initial-treatment-id="treatmentId"
+      :initial-treatment-category-key="treatmentCategoryKey"
+    />
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/components/SetRecallFromTreatmentButton.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallFromTreatmentButton.vue
@@ -1,31 +1,29 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { RecallReason } from '../composables/useRecalls'
 
-// Slot entry into `odontogram.condition.actions`. Ctx shape varies
-// across hosts (treatment-plan rows, odontogram diagnosis list); we
-// only read what's needed here and tolerate missing fields.
-interface Props {
-  patient?: { id: string }
-  patientId?: string
-  treatment?: {
-    id?: string
-    catalog_item?: { category?: { key?: string } } | null
+// Slot entry into `odontogram.condition.actions`. Host ctx (per
+// `clinical_notes.TreatmentNoteButton`) is
+// ``{ treatmentId, toothNumber?, status? }`` — patient_id isn't in
+// the ctx, so we fetch it lazily on click via the treatment API.
+const props = defineProps<{
+  ctx: {
+    treatmentId?: string
+    toothNumber?: number | null
+    status?: string
   }
-}
-const props = defineProps<Props>()
+}>()
 
 const { t } = useI18n()
-const open = ref(false)
+const api = useApi()
 
-const patientId = computed(() => props.patient?.id ?? props.patientId ?? null)
-const treatmentId = computed(() => props.treatment?.id ?? null)
-const treatmentCategoryKey = computed(
-  () => props.treatment?.catalog_item?.category?.key ?? null
-)
+const open = ref(false)
+const patientId = ref<string | null>(null)
+const treatmentCategoryKey = ref<string | null>(null)
+
+const treatmentId = computed(() => props.ctx?.treatmentId ?? null)
 
 const reason = computed<RecallReason>(() => {
-  // Keep in sync with backend `DEFAULT_CATEGORY_TO_REASON`.
   switch (treatmentCategoryKey.value) {
     case 'preventivo': return 'hygiene'
     case 'ortodoncia': return 'ortho_review'
@@ -35,14 +33,27 @@ const reason = computed<RecallReason>(() => {
   }
 })
 
-function onClick() {
-  if (!patientId.value) return
-  open.value = true
+async function onClick() {
+  if (!treatmentId.value) return
+  // Resolve patient + category key from the treatment row before
+  // opening the modal. Done lazily so the slot button itself stays
+  // cheap on the diagnosis sidebar.
+  try {
+    const res = await api.get<{
+      data: { patient_id: string, catalog_item?: { category?: { key?: string } } | null }
+    }>(`/api/v1/odontogram/treatments/${treatmentId.value}`)
+    patientId.value = res.data.patient_id
+    treatmentCategoryKey.value = res.data.catalog_item?.category?.key ?? null
+    open.value = true
+  } catch {
+    // Endpoint may not exist on every host; fail silent rather than
+    // leaving an obviously broken button.
+  }
 }
 </script>
 
 <template>
-  <div v-if="patientId">
+  <div v-if="treatmentId">
     <UButton
       icon="i-lucide-bell-plus"
       size="xs"
@@ -52,6 +63,7 @@ function onClick() {
       @click="onClick"
     />
     <SetRecallModal
+      v-if="patientId"
       v-model:open="open"
       :patient-id="patientId"
       :initial-reason="reason"

--- a/backend/app/modules/recalls/frontend/components/SetRecallModal.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { RecallReason, RecallPriority, Recall } from '../composables/useRecalls'
 
 interface Props {
@@ -25,7 +25,7 @@ const emit = defineEmits<{
   'saved': [recall: Recall]
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const toast = useToast()
 const recallsApi = useRecalls()
 
@@ -40,12 +40,18 @@ const assignedProfessionalId = ref<string | null>(props.initialAssignedProfessio
 function defaultDueMonth(): string {
   const today = new Date()
   // Next month, day 1.
-  const year = today.getFullYear()
-  const month = today.getMonth() + 2  // +1 next month, +1 because Date is 0-indexed when re-creating
-  const d = new Date(year, month - 1, 1)
+  const d = new Date(today.getFullYear(), today.getMonth() + 1, 1)
   const yyyy = d.getFullYear()
   const mm = String(d.getMonth() + 1).padStart(2, '0')
   return `${yyyy}-${mm}-01`
+}
+
+function shiftMonths(offset: number) {
+  const today = new Date()
+  const d = new Date(today.getFullYear(), today.getMonth() + offset, 1)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  dueMonth.value = `${yyyy}-${mm}-01`
 }
 
 watch(() => props.open, (v) => {
@@ -58,17 +64,51 @@ watch(() => props.open, (v) => {
   assignedProfessionalId.value = props.initialAssignedProfessionalId ?? null
 })
 
-const reasonOptions = computed(() =>
-  (['hygiene', 'checkup', 'ortho_review', 'implant_review', 'post_op', 'treatment_followup', 'other'] as RecallReason[])
-    .map(r => ({ value: r, label: t(`recalls.reasons.${r}`) }))
-)
+interface ReasonMeta {
+  value: RecallReason
+  label: string
+  icon: string
+}
 
-const priorityOptions = computed(() =>
-  (['low', 'normal', 'high'] as RecallPriority[]).map(p => ({
-    value: p,
-    label: t(`recalls.priority.${p}`)
-  }))
-)
+const reasons = computed<ReasonMeta[]>(() => [
+  { value: 'hygiene', label: t('recalls.reasons.hygiene'), icon: 'i-lucide-sparkles' },
+  { value: 'checkup', label: t('recalls.reasons.checkup'), icon: 'i-lucide-stethoscope' },
+  { value: 'ortho_review', label: t('recalls.reasons.ortho_review'), icon: 'i-lucide-smile' },
+  { value: 'implant_review', label: t('recalls.reasons.implant_review'), icon: 'i-lucide-anchor' },
+  { value: 'post_op', label: t('recalls.reasons.post_op'), icon: 'i-lucide-bandage' },
+  { value: 'treatment_followup', label: t('recalls.reasons.treatment_followup'), icon: 'i-lucide-clipboard-check' },
+  { value: 'other', label: t('recalls.reasons.other'), icon: 'i-lucide-more-horizontal' }
+])
+
+const priorities = computed(() => [
+  { value: 'low' as RecallPriority, label: t('recalls.priority.low'), color: 'neutral' as const },
+  { value: 'normal' as RecallPriority, label: t('recalls.priority.normal'), color: 'info' as const },
+  { value: 'high' as RecallPriority, label: t('recalls.priority.high'), color: 'error' as const }
+])
+
+const dueMonthLabel = computed(() => {
+  const iso = dueMonth.value.length === 7 ? `${dueMonth.value}-01` : dueMonth.value
+  const d = new Date(iso)
+  return new Intl.DateTimeFormat(locale.value, {
+    year: 'numeric',
+    month: 'long'
+  }).format(d)
+})
+
+const monthShortcuts = computed(() => [
+  { offset: 1, label: '+1m' },
+  { offset: 3, label: '+3m' },
+  { offset: 6, label: '+6m' },
+  { offset: 12, label: '+12m' }
+])
+
+function isShortcutActive(offset: number): boolean {
+  const today = new Date()
+  const target = new Date(today.getFullYear(), today.getMonth() + offset, 1)
+  const yyyy = target.getFullYear()
+  const mm = String(target.getMonth() + 1).padStart(2, '0')
+  return dueMonth.value === `${yyyy}-${mm}-01`
+}
 
 async function save() {
   if (isSubmitting.value) return
@@ -110,53 +150,124 @@ function close() {
   <UModal
     :open="open"
     :title="t('recalls.modal.title')"
+    :description="t('recalls.modal.subtitle')"
+    :ui="{ content: 'sm:max-w-lg' }"
     @update:open="(v: boolean) => emit('update:open', v)"
   >
     <template #body>
-      <div class="space-y-3 p-4">
-        <UFormField :label="t('recalls.modal.reason')">
-          <USelectMenu
-            v-model="reason"
-            :items="reasonOptions"
-            value-key="value"
-            label-key="label"
-          />
-        </UFormField>
+      <div class="space-y-5 p-4 sm:p-5">
+        <!-- Step 1: Reason — visual chips, primary thumb-friendly target -->
+        <section>
+          <label class="block text-caption uppercase tracking-wide text-subtle mb-2">
+            {{ t('recalls.modal.reason') }}
+          </label>
+          <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <button
+              v-for="r in reasons"
+              :key="r.value"
+              type="button"
+              :aria-pressed="reason === r.value"
+              class="flex items-center gap-2 px-3 py-2 rounded-token-md border text-sm text-left transition-colors"
+              :class="reason === r.value
+                ? 'border-primary bg-primary/10 text-primary-accent'
+                : 'border-default bg-default hover:bg-elevated text-default'"
+              @click="reason = r.value"
+            >
+              <UIcon
+                :name="r.icon"
+                class="w-4 h-4 shrink-0"
+              />
+              <span class="truncate">{{ r.label }}</span>
+            </button>
+          </div>
+        </section>
 
-        <UFormField :label="t('recalls.modal.month')">
-          <UInput
-            v-model="dueMonth"
-            type="month"
-          />
-        </UFormField>
+        <!-- Step 2: When — month picker + quick shortcuts -->
+        <section>
+          <label class="block text-caption uppercase tracking-wide text-subtle mb-2">
+            {{ t('recalls.modal.when') }}
+          </label>
+          <div class="flex flex-wrap items-center gap-2 mb-2">
+            <UButton
+              v-for="s in monthShortcuts"
+              :key="s.offset"
+              size="xs"
+              :color="isShortcutActive(s.offset) ? 'primary' : 'neutral'"
+              :variant="isShortcutActive(s.offset) ? 'soft' : 'outline'"
+              @click="shiftMonths(s.offset)"
+            >
+              {{ s.label }}
+            </UButton>
+          </div>
+          <MonthPickerDropdown v-model="dueMonth" />
+          <p class="text-caption text-subtle mt-1.5">
+            {{ t('recalls.modal.targetMonth') }}: <span class="text-default font-medium">{{ dueMonthLabel }}</span>
+          </p>
 
-        <UFormField :label="t('recalls.modal.preciseDate')">
-          <UInput
-            v-model="dueDate"
-            type="date"
-          />
-        </UFormField>
+          <details class="mt-3 group">
+            <summary class="flex items-center gap-1 text-caption text-subtle cursor-pointer hover:text-default select-none">
+              <UIcon
+                name="i-lucide-chevron-right"
+                class="w-3.5 h-3.5 transition-transform group-open:rotate-90"
+              />
+              {{ t('recalls.modal.preciseDate') }}
+            </summary>
+            <div class="mt-2">
+              <UInput
+                v-model="dueDate"
+                type="date"
+                class="w-full"
+              />
+            </div>
+          </details>
+        </section>
 
-        <UFormField :label="t('recalls.modal.priority')">
-          <USelectMenu
-            v-model="priority"
-            :items="priorityOptions"
-            value-key="value"
-            label-key="label"
-          />
-        </UFormField>
+        <!-- Step 3: Priority — segmented control -->
+        <section>
+          <label class="block text-caption uppercase tracking-wide text-subtle mb-2">
+            {{ t('recalls.modal.priority') }}
+          </label>
+          <div class="inline-flex rounded-token-md border border-default bg-default p-0.5 w-full">
+            <button
+              v-for="p in priorities"
+              :key="p.value"
+              type="button"
+              class="flex-1 px-3 py-1.5 rounded text-sm font-medium transition-colors"
+              :class="priority === p.value
+                ? 'bg-primary/15 text-primary-accent'
+                : 'text-subtle hover:text-default'"
+              :aria-pressed="priority === p.value"
+              @click="priority = p.value"
+            >
+              {{ p.label }}
+            </button>
+          </div>
+        </section>
 
-        <UFormField :label="t('recalls.modal.note')">
+        <!-- Step 4: Note — optional context -->
+        <section>
+          <label class="block text-caption uppercase tracking-wide text-subtle mb-2">
+            {{ t('recalls.modal.note') }}
+            <span class="lowercase font-normal text-dimmed">· {{ t('recalls.modal.optional') }}</span>
+          </label>
           <UTextarea
             v-model="note"
             :rows="3"
             :maxlength="500"
+            :placeholder="t('recalls.modal.notePlaceholder')"
+            class="w-full"
           />
-        </UFormField>
+          <p
+            v-if="note.length > 400"
+            class="text-caption text-dimmed mt-1 text-right tnum"
+          >
+            {{ note.length }} / 500
+          </p>
+        </section>
       </div>
     </template>
     <template #footer>
-      <div class="flex justify-end gap-2 p-2">
+      <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 p-3">
         <UButton
           color="neutral"
           variant="ghost"
@@ -167,6 +278,7 @@ function close() {
         </UButton>
         <UButton
           color="primary"
+          icon="i-lucide-bell"
           :loading="isSubmitting"
           @click="save"
         >

--- a/backend/app/modules/recalls/frontend/components/SetRecallModal.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallModal.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { RecallReason, RecallPriority, Recall } from '../composables/useRecalls'
+
+interface Props {
+  open: boolean
+  patientId: string
+  /** Pre-fill from a treatment-plan / odontogram action. */
+  initialReason?: RecallReason
+  initialNote?: string
+  initialPriority?: RecallPriority
+  initialAssignedProfessionalId?: string | null
+  initialDueMonth?: string  // YYYY-MM-01
+  initialTreatmentId?: string | null
+  initialTreatmentCategoryKey?: string | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  initialReason: 'hygiene',
+  initialPriority: 'normal'
+})
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'saved': [recall: Recall]
+}>()
+
+const { t } = useI18n()
+const toast = useToast()
+const recallsApi = useRecalls()
+
+const isSubmitting = ref(false)
+const reason = ref<RecallReason>(props.initialReason)
+const priority = ref<RecallPriority>(props.initialPriority)
+const dueMonth = ref<string>(props.initialDueMonth ?? defaultDueMonth())
+const dueDate = ref<string>('')
+const note = ref<string>(props.initialNote ?? '')
+const assignedProfessionalId = ref<string | null>(props.initialAssignedProfessionalId ?? null)
+
+function defaultDueMonth(): string {
+  const today = new Date()
+  // Next month, day 1.
+  const year = today.getFullYear()
+  const month = today.getMonth() + 2  // +1 next month, +1 because Date is 0-indexed when re-creating
+  const d = new Date(year, month - 1, 1)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  return `${yyyy}-${mm}-01`
+}
+
+watch(() => props.open, (v) => {
+  if (!v) return
+  reason.value = props.initialReason
+  priority.value = props.initialPriority
+  dueMonth.value = props.initialDueMonth ?? defaultDueMonth()
+  dueDate.value = ''
+  note.value = props.initialNote ?? ''
+  assignedProfessionalId.value = props.initialAssignedProfessionalId ?? null
+})
+
+const reasonOptions = computed(() =>
+  (['hygiene', 'checkup', 'ortho_review', 'implant_review', 'post_op', 'treatment_followup', 'other'] as RecallReason[])
+    .map(r => ({ value: r, label: t(`recalls.reasons.${r}`) }))
+)
+
+const priorityOptions = computed(() =>
+  (['low', 'normal', 'high'] as RecallPriority[]).map(p => ({
+    value: p,
+    label: t(`recalls.priority.${p}`)
+  }))
+)
+
+async function save() {
+  if (isSubmitting.value) return
+  isSubmitting.value = true
+  try {
+    const month = dueMonth.value || defaultDueMonth()
+    const monthDay1 = month.length === 7 ? `${month}-01` : month
+    const res = await recallsApi.create({
+      patient_id: props.patientId,
+      due_month: monthDay1,
+      due_date: dueDate.value || null,
+      reason: reason.value,
+      reason_note: note.value || null,
+      priority: priority.value,
+      assigned_professional_id: assignedProfessionalId.value || null,
+      linked_treatment_id: props.initialTreatmentId ?? null,
+      linked_treatment_category_key: props.initialTreatmentCategoryKey ?? null
+    })
+    toast.add({ title: t('common.success'), color: 'success' })
+    emit('saved', res.data)
+    emit('update:open', false)
+  } catch (err: unknown) {
+    toast.add({
+      title: t('common.error'),
+      description: (err as { data?: { detail?: string } })?.data?.detail ?? '',
+      color: 'error'
+    })
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+function close() {
+  emit('update:open', false)
+}
+</script>
+
+<template>
+  <UModal
+    :open="open"
+    :title="t('recalls.modal.title')"
+    @update:open="(v: boolean) => emit('update:open', v)"
+  >
+    <template #body>
+      <div class="space-y-3 p-4">
+        <UFormField :label="t('recalls.modal.reason')">
+          <USelectMenu
+            v-model="reason"
+            :items="reasonOptions"
+            value-key="value"
+            label-key="label"
+          />
+        </UFormField>
+
+        <UFormField :label="t('recalls.modal.month')">
+          <UInput
+            v-model="dueMonth"
+            type="month"
+          />
+        </UFormField>
+
+        <UFormField :label="t('recalls.modal.preciseDate')">
+          <UInput
+            v-model="dueDate"
+            type="date"
+          />
+        </UFormField>
+
+        <UFormField :label="t('recalls.modal.priority')">
+          <USelectMenu
+            v-model="priority"
+            :items="priorityOptions"
+            value-key="value"
+            label-key="label"
+          />
+        </UFormField>
+
+        <UFormField :label="t('recalls.modal.note')">
+          <UTextarea
+            v-model="note"
+            :rows="3"
+            :maxlength="500"
+          />
+        </UFormField>
+      </div>
+    </template>
+    <template #footer>
+      <div class="flex justify-end gap-2 p-2">
+        <UButton
+          color="neutral"
+          variant="ghost"
+          :disabled="isSubmitting"
+          @click="close"
+        >
+          {{ t('actions.cancel') }}
+        </UButton>
+        <UButton
+          color="primary"
+          :loading="isSubmitting"
+          @click="save"
+        >
+          {{ t('recalls.actions.save') }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/backend/app/modules/recalls/frontend/composables/useRecalls.ts
+++ b/backend/app/modules/recalls/frontend/composables/useRecalls.ts
@@ -273,3 +273,73 @@ export function useRecallActions(recall: Ref<Recall | null>) {
     )
   }
 }
+
+// --- Per-patient shared state ----------------------------------------------
+
+/**
+ * Shared per-patient recall list. Both `SetRecallButton` (action +
+ * inline next-recall card on the patient hero) and
+ * `RecallSummaryFeed` (recent-history card on the summary feed)
+ * read from the same `useState` slot so the patient page only fires
+ * one ``GET /api/v1/recalls/patients/:id`` per visit.
+ *
+ * Pure host plumbing — no cross-module imports beyond the host's
+ * `useState`. ``manifest.depends`` stays at ``["patients", "agenda"]``.
+ */
+export function usePatientRecalls(patientId: string) {
+  const stateKey = `recalls:patient:${patientId}`
+  const recalls = useState<Recall[]>(stateKey, () => [])
+  const isLoading = useState<boolean>(`${stateKey}:loading`, () => false)
+  const loaded = useState<boolean>(`${stateKey}:loaded`, () => false)
+  const api = useRecalls()
+
+  async function refresh() {
+    if (!patientId) {
+      recalls.value = []
+      return
+    }
+    isLoading.value = true
+    try {
+      const res = await api.listForPatient(patientId)
+      recalls.value = res.data
+      loaded.value = true
+    } catch {
+      recalls.value = []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Idempotent — only fetches the first time per (page, patient). */
+  async function ensureLoaded() {
+    if (loaded.value || isLoading.value) return
+    await refresh()
+  }
+
+  const activeRecalls = computed(() =>
+    recalls.value.filter(r =>
+      ['pending', 'contacted_no_answer', 'contacted_scheduled'].includes(r.status)
+    )
+  )
+
+  // Most-due active recall (smallest due_month wins; tiebreaker on
+  // creation order) — what the patient hero pins under the CTA.
+  const nextActiveRecall = computed(() => {
+    const active = [...activeRecalls.value]
+    active.sort((a, b) => {
+      if (a.due_month !== b.due_month) return a.due_month < b.due_month ? -1 : 1
+      return a.created_at < b.created_at ? -1 : 1
+    })
+    return active[0] ?? null
+  })
+
+  return {
+    recalls,
+    isLoading,
+    loaded,
+    refresh,
+    ensureLoaded,
+    activeRecalls,
+    nextActiveRecall
+  }
+}

--- a/backend/app/modules/recalls/frontend/composables/useRecalls.ts
+++ b/backend/app/modules/recalls/frontend/composables/useRecalls.ts
@@ -1,0 +1,275 @@
+import type { Ref } from 'vue'
+
+// Mirror of the backend literal types — kept narrow so the call-list
+// UI stays type-safe even though the host has no shared types file
+// for the recalls module.
+export type RecallReason =
+  | 'hygiene'
+  | 'checkup'
+  | 'ortho_review'
+  | 'implant_review'
+  | 'post_op'
+  | 'treatment_followup'
+  | 'other'
+
+export type RecallStatus =
+  | 'pending'
+  | 'contacted_no_answer'
+  | 'contacted_scheduled'
+  | 'contacted_declined'
+  | 'done'
+  | 'cancelled'
+  | 'needs_review'
+
+export type RecallPriority = 'low' | 'normal' | 'high'
+
+export type RecallChannel = 'phone' | 'whatsapp' | 'sms' | 'email'
+
+export type RecallOutcome =
+  | 'no_answer'
+  | 'voicemail'
+  | 'scheduled'
+  | 'declined'
+  | 'wrong_number'
+
+export interface PatientBriefForRecall {
+  id: string
+  first_name: string
+  last_name: string
+  phone?: string | null
+  email?: string | null
+  do_not_contact: boolean
+  status: string
+}
+
+export interface RecallContactAttempt {
+  id: string
+  recall_id: string
+  attempted_at: string
+  attempted_by: string
+  channel: RecallChannel
+  outcome: RecallOutcome
+  note?: string | null
+}
+
+export interface Recall {
+  id: string
+  clinic_id: string
+  patient_id: string
+  due_month: string  // ISO date (day-1)
+  due_date?: string | null
+  reason: RecallReason
+  reason_note?: string | null
+  priority: RecallPriority
+  status: RecallStatus
+  recommended_by?: string | null
+  assigned_professional_id?: string | null
+  last_contact_attempt_at?: string | null
+  contact_attempt_count: number
+  linked_appointment_id?: string | null
+  linked_treatment_id?: string | null
+  linked_treatment_category_key?: string | null
+  completed_at?: string | null
+  created_at: string
+  updated_at: string
+  patient?: PatientBriefForRecall
+  attempts?: RecallContactAttempt[]
+}
+
+export interface RecallCreatePayload {
+  patient_id: string
+  due_month: string  // YYYY-MM-01
+  due_date?: string | null
+  reason: RecallReason
+  reason_note?: string | null
+  priority?: RecallPriority
+  assigned_professional_id?: string | null
+  linked_treatment_id?: string | null
+  linked_treatment_category_key?: string | null
+}
+
+export interface RecallUpdatePayload {
+  due_month?: string | null
+  due_date?: string | null
+  reason?: RecallReason
+  reason_note?: string | null
+  priority?: RecallPriority
+  assigned_professional_id?: string | null
+}
+
+export interface AttemptCreatePayload {
+  channel: RecallChannel
+  outcome: RecallOutcome
+  note?: string | null
+  linked_appointment_id?: string | null
+}
+
+export interface RecallSettings {
+  clinic_id: string
+  reason_intervals: Record<string, number>
+  category_to_reason: Record<string, string>
+  auto_suggest_on_treatment_completed: boolean
+  auto_link_on_appointment_scheduled: boolean
+  updated_at: string
+}
+
+export interface RecallDashboardStats {
+  due_this_week: number
+  due_this_month: number
+  overdue: number
+  scheduled_this_month: number
+  completed_this_month: number
+  conversion_rate: number
+}
+
+export interface RecallSuggestion {
+  patient_id: string
+  reason: RecallReason
+  due_month: string
+  interval_months: number
+  treatment_category_key?: string | null
+  treatment_id?: string | null
+  matched_setting: boolean
+}
+
+interface ApiOk<T> { data: T }
+interface ApiPaged<T> { data: T[]; total: number; page: number; page_size: number }
+
+export interface RecallListFilters {
+  month?: string  // ISO date (any day)
+  reason?: RecallReason
+  professional_id?: string
+  status?: RecallStatus
+  priority?: RecallPriority
+  overdue?: boolean
+  patient_id?: string
+  page?: number
+  page_size?: number
+}
+
+export function useRecalls() {
+  const api = useApi()
+
+  async function list(filters: RecallListFilters = {}): Promise<ApiPaged<Recall>> {
+    const qs = new URLSearchParams()
+    for (const [k, v] of Object.entries(filters)) {
+      if (v === undefined || v === null || v === '') continue
+      qs.append(k, String(v))
+    }
+    const url = `/api/v1/recalls/${qs.toString() ? `?${qs.toString()}` : ''}`
+    return await api.get<ApiPaged<Recall>>(url)
+  }
+
+  async function get(id: string): Promise<ApiOk<Recall>> {
+    return await api.get<ApiOk<Recall>>(`/api/v1/recalls/${id}`)
+  }
+
+  async function listForPatient(patientId: string): Promise<ApiOk<Recall[]>> {
+    return await api.get<ApiOk<Recall[]>>(`/api/v1/recalls/patients/${patientId}`)
+  }
+
+  async function create(payload: RecallCreatePayload): Promise<ApiOk<Recall>> {
+    return await api.post<ApiOk<Recall>>('/api/v1/recalls/', payload)
+  }
+
+  async function update(id: string, payload: RecallUpdatePayload): Promise<ApiOk<Recall>> {
+    return await api.patch<ApiOk<Recall>>(`/api/v1/recalls/${id}`, payload)
+  }
+
+  async function snooze(id: string, months: number, note?: string): Promise<ApiOk<Recall>> {
+    return await api.post<ApiOk<Recall>>(`/api/v1/recalls/${id}/snooze`, {
+      months,
+      reason_note: note ?? null
+    })
+  }
+
+  async function cancel(id: string, note?: string): Promise<ApiOk<Recall>> {
+    return await api.post<ApiOk<Recall>>(`/api/v1/recalls/${id}/cancel`, {
+      note: note ?? null
+    })
+  }
+
+  async function markDone(id: string): Promise<ApiOk<Recall>> {
+    return await api.post<ApiOk<Recall>>(`/api/v1/recalls/${id}/done`, {})
+  }
+
+  async function logAttempt(id: string, payload: AttemptCreatePayload): Promise<ApiOk<RecallContactAttempt>> {
+    return await api.post<ApiOk<RecallContactAttempt>>(
+      `/api/v1/recalls/${id}/attempts`,
+      payload
+    )
+  }
+
+  async function linkAppointment(id: string, appointmentId: string): Promise<ApiOk<Recall>> {
+    return await api.post<ApiOk<Recall>>(`/api/v1/recalls/${id}/link-appointment`, {
+      appointment_id: appointmentId
+    })
+  }
+
+  async function suggestNext(params: {
+    patient_id: string
+    treatment_category_key?: string | null
+    treatment_id?: string | null
+  }): Promise<ApiOk<RecallSuggestion | null>> {
+    const qs = new URLSearchParams()
+    qs.append('patient_id', params.patient_id)
+    if (params.treatment_category_key) qs.append('treatment_category_key', params.treatment_category_key)
+    if (params.treatment_id) qs.append('treatment_id', params.treatment_id)
+    return await api.get<ApiOk<RecallSuggestion | null>>(
+      `/api/v1/recalls/suggestions/next?${qs.toString()}`
+    )
+  }
+
+  async function getSettings(): Promise<ApiOk<RecallSettings>> {
+    return await api.get<ApiOk<RecallSettings>>('/api/v1/recalls/settings')
+  }
+
+  async function updateSettings(payload: Partial<RecallSettings>): Promise<ApiOk<RecallSettings>> {
+    return await api.put<ApiOk<RecallSettings>>('/api/v1/recalls/settings', payload)
+  }
+
+  async function dashboardStats(): Promise<ApiOk<RecallDashboardStats>> {
+    return await api.get<ApiOk<RecallDashboardStats>>('/api/v1/recalls/stats/dashboard')
+  }
+
+  function exportCsvUrl(filters: RecallListFilters = {}): string {
+    const qs = new URLSearchParams()
+    for (const [k, v] of Object.entries(filters)) {
+      if (v === undefined || v === null || v === '') continue
+      qs.append(k, String(v))
+    }
+    const base = '/api/v1/recalls/export.csv'
+    return qs.toString() ? `${base}?${qs.toString()}` : base
+  }
+
+  return {
+    list,
+    get,
+    listForPatient,
+    create,
+    update,
+    snooze,
+    cancel,
+    markDone,
+    logAttempt,
+    linkAppointment,
+    suggestNext,
+    getSettings,
+    updateSettings,
+    dashboardStats,
+    exportCsvUrl
+  }
+}
+
+export type UseRecallsReturn = ReturnType<typeof useRecalls>
+
+// Utility for callers that already have a reactive recall ref.
+export function useRecallActions(recall: Ref<Recall | null>) {
+  const recalls = useRecalls()
+  return {
+    recalls,
+    isCallable: computed(
+      () => !!recall.value?.patient?.phone && !recall.value?.patient?.do_not_contact
+    )
+  }
+}

--- a/backend/app/modules/recalls/frontend/i18n/locales/en.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/en.json
@@ -10,7 +10,8 @@
       "status": "Status",
       "priority": "Priority",
       "overdue": "Show overdue",
-      "any": "Any"
+      "any": "Any",
+      "thisMonth": "This month"
     },
     "counters": {
       "due_this_week": "Due this week",

--- a/backend/app/modules/recalls/frontend/i18n/locales/en.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/en.json
@@ -85,6 +85,7 @@
     "doNotContact": {
       "cannotSchedule": "This patient is flagged \"Do not contact\". Recalls cannot be scheduled. Update the demographics preference to re-enable contact."
     },
+    "activeRecallHint": "Active recall · tap to manage",
     "logAttempt": {
       "channel": "Channel",
       "outcome": "Outcome",

--- a/backend/app/modules/recalls/frontend/i18n/locales/en.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/en.json
@@ -1,0 +1,118 @@
+{
+  "recalls": {
+    "title": "Recalls",
+    "callList": "Call list",
+    "noRecallsThisMonth": "No pending recalls this month",
+    "filters": {
+      "month": "Month",
+      "reason": "Reason",
+      "professional": "Professional",
+      "status": "Status",
+      "priority": "Priority",
+      "overdue": "Show overdue",
+      "any": "Any"
+    },
+    "counters": {
+      "due_this_week": "Due this week",
+      "due_this_month": "Due this month",
+      "overdue": "Overdue",
+      "scheduled_this_month": "Scheduled this month",
+      "completed_this_month": "Completed this month",
+      "conversion_rate": "Conversion"
+    },
+    "setRecall": "Set recall",
+    "setRecallShort": "Recall",
+    "history": "Recall history",
+    "viewAll": "View all",
+    "pillNext": "Next recall: {month} · {reason}",
+    "pillNone": "No active recall",
+    "reasons": {
+      "hygiene": "Hygiene",
+      "checkup": "Check-up",
+      "ortho_review": "Ortho review",
+      "implant_review": "Implant review",
+      "post_op": "Post-op",
+      "treatment_followup": "Treatment follow-up",
+      "other": "Other"
+    },
+    "priority": {
+      "low": "Low",
+      "normal": "Normal",
+      "high": "High"
+    },
+    "status": {
+      "pending": "Pending",
+      "contacted_no_answer": "No answer",
+      "contacted_scheduled": "Scheduled",
+      "contacted_declined": "Declined",
+      "done": "Done",
+      "cancelled": "Cancelled",
+      "needs_review": "Needs review"
+    },
+    "actions": {
+      "call": "Call",
+      "logAttempt": "Log attempt",
+      "noAnswer": "No answer",
+      "book": "Book appointment",
+      "snooze": "Snooze",
+      "cancel": "Cancel",
+      "markDone": "Mark done",
+      "exportCsv": "Export CSV",
+      "save": "Save"
+    },
+    "closeoutPrompt": {
+      "title": "Schedule a recall?",
+      "subtitle": "The patient just finished — when should we call them back?",
+      "skip": "Not now"
+    },
+    "modal": {
+      "title": "Set recall",
+      "patient": "Patient",
+      "reason": "Reason",
+      "month": "Target month",
+      "preciseDate": "Specific day (optional)",
+      "priority": "Priority",
+      "assigned": "Assigned professional",
+      "note": "Internal note",
+      "duplicateGuard": "A pending recall already exists for this patient and reason. It will be updated."
+    },
+    "logAttempt": {
+      "channel": "Channel",
+      "outcome": "Outcome",
+      "note": "Note",
+      "submit": "Log attempt"
+    },
+    "channel": {
+      "phone": "Phone",
+      "whatsapp": "WhatsApp",
+      "sms": "SMS",
+      "email": "Email"
+    },
+    "outcome": {
+      "no_answer": "No answer",
+      "voicemail": "Voicemail",
+      "scheduled": "Appointment scheduled",
+      "declined": "Declined",
+      "wrong_number": "Wrong number"
+    },
+    "snoozePrompt": "Snooze for how many months?",
+    "settings": {
+      "title": "Recalls",
+      "description": "Default intervals + treatment-category mapping",
+      "intervals": "Default intervals (months)",
+      "categoryMap": "Treatment → reason",
+      "autoSuggest": "Suggest a recall when a treatment is completed",
+      "autoLink": "Link a scheduled appointment to a pending recall",
+      "saved": "Settings saved"
+    },
+    "dashboard": {
+      "title": "Recalls"
+    },
+    "suggestion": {
+      "title": "Suggested recall",
+      "body": "After this treatment we suggest a recall in {month} ({reason}).",
+      "create": "Create recall",
+      "dismiss": "Dismiss"
+    }
+  }
+}

--- a/backend/app/modules/recalls/frontend/i18n/locales/en.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/en.json
@@ -68,13 +68,18 @@
     },
     "modal": {
       "title": "Set recall",
+      "subtitle": "Flag the patient for a future call-back",
       "patient": "Patient",
       "reason": "Reason",
+      "when": "When",
       "month": "Target month",
-      "preciseDate": "Specific day (optional)",
+      "targetMonth": "Target month",
+      "preciseDate": "Pick a specific day",
       "priority": "Priority",
       "assigned": "Assigned professional",
       "note": "Internal note",
+      "notePlaceholder": "Optional detail (e.g. 'Review filling on 47')",
+      "optional": "optional",
       "duplicateGuard": "A pending recall already exists for this patient and reason. It will be updated."
     },
     "logAttempt": {

--- a/backend/app/modules/recalls/frontend/i18n/locales/en.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/en.json
@@ -82,6 +82,9 @@
       "optional": "optional",
       "duplicateGuard": "A pending recall already exists for this patient and reason. It will be updated."
     },
+    "doNotContact": {
+      "cannotSchedule": "This patient is flagged \"Do not contact\". Recalls cannot be scheduled. Update the demographics preference to re-enable contact."
+    },
     "logAttempt": {
       "channel": "Channel",
       "outcome": "Outcome",

--- a/backend/app/modules/recalls/frontend/i18n/locales/es.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/es.json
@@ -82,6 +82,9 @@
       "optional": "opcional",
       "duplicateGuard": "Ya existe un recordatorio pendiente para este paciente con este motivo. Se actualizará."
     },
+    "doNotContact": {
+      "cannotSchedule": "Este paciente está marcado como «No contactar». No se pueden programar recordatorios. Cambia la preferencia en sus datos demográficos si quieres reactivar el contacto."
+    },
     "logAttempt": {
       "channel": "Canal",
       "outcome": "Resultado",

--- a/backend/app/modules/recalls/frontend/i18n/locales/es.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/es.json
@@ -85,6 +85,7 @@
     "doNotContact": {
       "cannotSchedule": "Este paciente está marcado como «No contactar». No se pueden programar recordatorios. Cambia la preferencia en sus datos demográficos si quieres reactivar el contacto."
     },
+    "activeRecallHint": "Recordatorio activo · pulsa para gestionarlo",
     "logAttempt": {
       "channel": "Canal",
       "outcome": "Resultado",

--- a/backend/app/modules/recalls/frontend/i18n/locales/es.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/es.json
@@ -10,7 +10,8 @@
       "status": "Estado",
       "priority": "Prioridad",
       "overdue": "Mostrar atrasados",
-      "any": "Todos"
+      "any": "Todos",
+      "thisMonth": "Mes actual"
     },
     "counters": {
       "due_this_week": "Vencen esta semana",

--- a/backend/app/modules/recalls/frontend/i18n/locales/es.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/es.json
@@ -68,13 +68,18 @@
     },
     "modal": {
       "title": "Programar recordatorio",
+      "subtitle": "Marca al paciente para una llamada futura",
       "patient": "Paciente",
       "reason": "Motivo",
+      "when": "Cuándo",
       "month": "Mes objetivo",
-      "preciseDate": "Día concreto (opcional)",
+      "targetMonth": "Mes objetivo",
+      "preciseDate": "Elegir día concreto",
       "priority": "Prioridad",
       "assigned": "Profesional asignado",
       "note": "Nota interna",
+      "notePlaceholder": "Detalle opcional (p. ej. 'Revisar empaste 47')",
+      "optional": "opcional",
       "duplicateGuard": "Ya existe un recordatorio pendiente para este paciente con este motivo. Se actualizará."
     },
     "logAttempt": {

--- a/backend/app/modules/recalls/frontend/i18n/locales/es.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/es.json
@@ -1,0 +1,118 @@
+{
+  "recalls": {
+    "title": "Recordatorios",
+    "callList": "Lista de llamadas",
+    "noRecallsThisMonth": "No hay recordatorios pendientes este mes",
+    "filters": {
+      "month": "Mes",
+      "reason": "Motivo",
+      "professional": "Profesional",
+      "status": "Estado",
+      "priority": "Prioridad",
+      "overdue": "Mostrar atrasados",
+      "any": "Todos"
+    },
+    "counters": {
+      "due_this_week": "Vencen esta semana",
+      "due_this_month": "Vencen este mes",
+      "overdue": "Atrasados",
+      "scheduled_this_month": "Citados este mes",
+      "completed_this_month": "Completados este mes",
+      "conversion_rate": "Conversión"
+    },
+    "setRecall": "Programar recordatorio",
+    "setRecallShort": "Recordatorio",
+    "history": "Historial de recordatorios",
+    "viewAll": "Ver todos",
+    "pillNext": "Próximo recordatorio: {month} · {reason}",
+    "pillNone": "Sin recordatorio activo",
+    "reasons": {
+      "hygiene": "Higiene",
+      "checkup": "Revisión",
+      "ortho_review": "Revisión ortodoncia",
+      "implant_review": "Revisión implante",
+      "post_op": "Postoperatorio",
+      "treatment_followup": "Seguimiento de tratamiento",
+      "other": "Otro"
+    },
+    "priority": {
+      "low": "Baja",
+      "normal": "Normal",
+      "high": "Alta"
+    },
+    "status": {
+      "pending": "Pendiente",
+      "contacted_no_answer": "No contesta",
+      "contacted_scheduled": "Citado",
+      "contacted_declined": "Rechazado",
+      "done": "Completado",
+      "cancelled": "Cancelado",
+      "needs_review": "Revisar"
+    },
+    "actions": {
+      "call": "Llamar",
+      "logAttempt": "Registrar intento",
+      "noAnswer": "No contesta",
+      "book": "Agendar cita",
+      "snooze": "Posponer",
+      "cancel": "Cancelar",
+      "markDone": "Marcar como hecho",
+      "exportCsv": "Exportar CSV",
+      "save": "Guardar"
+    },
+    "closeoutPrompt": {
+      "title": "¿Programar un recordatorio?",
+      "subtitle": "El paciente acaba de finalizar la cita — ¿cuándo deberíamos llamarle?",
+      "skip": "Ahora no"
+    },
+    "modal": {
+      "title": "Programar recordatorio",
+      "patient": "Paciente",
+      "reason": "Motivo",
+      "month": "Mes objetivo",
+      "preciseDate": "Día concreto (opcional)",
+      "priority": "Prioridad",
+      "assigned": "Profesional asignado",
+      "note": "Nota interna",
+      "duplicateGuard": "Ya existe un recordatorio pendiente para este paciente con este motivo. Se actualizará."
+    },
+    "logAttempt": {
+      "channel": "Canal",
+      "outcome": "Resultado",
+      "note": "Nota",
+      "submit": "Registrar intento"
+    },
+    "channel": {
+      "phone": "Teléfono",
+      "whatsapp": "WhatsApp",
+      "sms": "SMS",
+      "email": "Email"
+    },
+    "outcome": {
+      "no_answer": "No contesta",
+      "voicemail": "Buzón de voz",
+      "scheduled": "Cita agendada",
+      "declined": "Rechaza",
+      "wrong_number": "Número incorrecto"
+    },
+    "snoozePrompt": "Posponer ¿cuántos meses?",
+    "settings": {
+      "title": "Recordatorios",
+      "description": "Intervalos por motivo y mapeo de tratamientos",
+      "intervals": "Intervalos por defecto (meses)",
+      "categoryMap": "Tratamiento → motivo",
+      "autoSuggest": "Sugerir recordatorio al completar un tratamiento",
+      "autoLink": "Vincular cita al recordatorio existente al agendar",
+      "saved": "Configuración guardada"
+    },
+    "dashboard": {
+      "title": "Recordatorios"
+    },
+    "suggestion": {
+      "title": "Recordatorio sugerido",
+      "body": "Tras este tratamiento sugerimos un recordatorio en {month} ({reason}).",
+      "create": "Crear recordatorio",
+      "dismiss": "Descartar"
+    }
+  }
+}

--- a/backend/app/modules/recalls/frontend/nuxt.config.ts
+++ b/backend/app/modules/recalls/frontend/nuxt.config.ts
@@ -1,0 +1,17 @@
+// Nuxt layer for the `recalls` module.
+//
+// Components live under ./components with no folder-prefix naming so
+// they auto-resolve across layers. The i18n block makes
+// @nuxtjs/i18n merge our `recalls.*` keys into the host es/en.
+export default defineNuxtConfig({
+  components: [
+    { path: './components', pathPrefix: false }
+  ],
+  i18n: {
+    locales: [
+      { code: 'en', file: 'en.json' },
+      { code: 'es', file: 'es.json' }
+    ],
+    langDir: 'locales'
+  }
+})

--- a/backend/app/modules/recalls/frontend/pages/recalls/index.vue
+++ b/backend/app/modules/recalls/frontend/pages/recalls/index.vue
@@ -14,11 +14,18 @@ if (!can('recalls.read')) {
   await navigateTo('/')
 }
 
+// Sentinel for "Any" — Reka UI's SelectItem rejects empty-string
+// values (reserves them for the placeholder state). We round-trip
+// this token through the dropdown and normalise to undefined on the
+// API call. Same pattern used by `AppointmentModal` for unassigned
+// cabinets (#51).
+const ANY = '__any__'
+
 // Filters from query string.
 const month = ref<string>(String(route.query.month ?? defaultMonthIso()))
-const reason = ref<RecallReason | ''>((route.query.reason as RecallReason) ?? '')
-const status = ref<RecallStatus | ''>((route.query.status as RecallStatus) ?? 'pending')
-const priority = ref<RecallPriority | ''>((route.query.priority as RecallPriority) ?? '')
+const reason = ref<RecallReason | typeof ANY>((route.query.reason as RecallReason) ?? ANY)
+const status = ref<RecallStatus | typeof ANY>((route.query.status as RecallStatus) ?? 'pending')
+const priority = ref<RecallPriority | typeof ANY>((route.query.priority as RecallPriority) ?? ANY)
 const overdue = ref<boolean>(route.query.overdue === 'true')
 const patientId = ref<string | undefined>((route.query.patient_id as string) || undefined)
 
@@ -43,7 +50,7 @@ function defaultMonthIso(): string {
 }
 
 const reasonOptions = computed(() => [
-  { value: '', label: t('recalls.filters.any') },
+  { value: ANY, label: t('recalls.filters.any') },
   ...(['hygiene', 'checkup', 'ortho_review', 'implant_review', 'post_op', 'treatment_followup', 'other'] as RecallReason[]).map(r => ({
     value: r,
     label: t(`recalls.reasons.${r}`)
@@ -51,7 +58,7 @@ const reasonOptions = computed(() => [
 ])
 
 const statusOptions = computed(() => [
-  { value: '', label: t('recalls.filters.any') },
+  { value: ANY, label: t('recalls.filters.any') },
   ...(['pending', 'contacted_no_answer', 'contacted_scheduled', 'contacted_declined', 'done', 'cancelled', 'needs_review'] as RecallStatus[]).map(s => ({
     value: s,
     label: t(`recalls.status.${s}`)
@@ -59,7 +66,7 @@ const statusOptions = computed(() => [
 ])
 
 const priorityOptions = computed(() => [
-  { value: '', label: t('recalls.filters.any') },
+  { value: ANY, label: t('recalls.filters.any') },
   ...(['low', 'normal', 'high'] as RecallPriority[]).map(p => ({
     value: p,
     label: t(`recalls.priority.${p}`)
@@ -71,9 +78,9 @@ async function load() {
   try {
     const filters: Record<string, unknown> = {
       month: month.value || undefined,
-      reason: reason.value || undefined,
-      status: status.value || undefined,
-      priority: priority.value || undefined,
+      reason: reason.value === ANY ? undefined : reason.value || undefined,
+      status: status.value === ANY ? undefined : status.value || undefined,
+      priority: priority.value === ANY ? undefined : priority.value || undefined,
       overdue: overdue.value || undefined,
       patient_id: patientId.value,
       page: page.value,
@@ -98,9 +105,9 @@ watch([month, reason, status, priority, overdue, patientId], () => {
   router.replace({
     query: {
       ...(month.value ? { month: month.value } : {}),
-      ...(reason.value ? { reason: reason.value } : {}),
-      ...(status.value ? { status: status.value } : {}),
-      ...(priority.value ? { priority: priority.value } : {}),
+      ...(reason.value && reason.value !== ANY ? { reason: reason.value } : {}),
+      ...(status.value && status.value !== ANY ? { status: status.value } : {}),
+      ...(priority.value && priority.value !== ANY ? { priority: priority.value } : {}),
       ...(overdue.value ? { overdue: 'true' } : {}),
       ...(patientId.value ? { patient_id: patientId.value } : {})
     }
@@ -129,9 +136,9 @@ async function downloadCsv() {
   try {
     const url = config.public.apiBaseUrl + recallsApi.exportCsvUrl({
       month: month.value || undefined,
-      reason: reason.value || undefined,
-      status: status.value || undefined,
-      priority: priority.value || undefined,
+      reason: reason.value === ANY ? undefined : reason.value || undefined,
+      status: status.value === ANY ? undefined : status.value || undefined,
+      priority: priority.value === ANY ? undefined : priority.value || undefined,
       overdue: overdue.value || undefined
     })
     const res = await fetch(url, {

--- a/backend/app/modules/recalls/frontend/pages/recalls/index.vue
+++ b/backend/app/modules/recalls/frontend/pages/recalls/index.vue
@@ -118,13 +118,41 @@ function onChanged(updated: Recall) {
 }
 
 const conversionPct = computed(() => stats.value ? Math.round(stats.value.conversion_rate * 100) : 0)
-const csvUrl = computed(() => recallsApi.exportCsvUrl({
-  month: month.value || undefined,
-  reason: reason.value || undefined,
-  status: status.value || undefined,
-  priority: priority.value || undefined,
-  overdue: overdue.value || undefined
-}))
+
+const auth = useAuth()
+const config = useRuntimeConfig()
+const isExporting = ref(false)
+
+async function downloadCsv() {
+  if (isExporting.value) return
+  isExporting.value = true
+  try {
+    const url = config.public.apiBaseUrl + recallsApi.exportCsvUrl({
+      month: month.value || undefined,
+      reason: reason.value || undefined,
+      status: status.value || undefined,
+      priority: priority.value || undefined,
+      overdue: overdue.value || undefined
+    })
+    const res = await fetch(url, {
+      headers: auth.accessToken.value
+        ? { Authorization: `Bearer ${auth.accessToken.value}` }
+        : {}
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const blob = await res.blob()
+    const blobUrl = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = blobUrl
+    a.download = 'recalls.csv'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(blobUrl)
+  } finally {
+    isExporting.value = false
+  }
+}
 </script>
 
 <template>
@@ -134,10 +162,11 @@ const csvUrl = computed(() => recallsApi.exportCsvUrl({
         {{ t('recalls.callList') }}
       </h1>
       <UButton
-        :href="csvUrl"
         icon="i-lucide-download"
         size="sm"
         variant="soft"
+        :loading="isExporting"
+        @click="downloadCsv"
       >
         {{ t('recalls.actions.exportCsv') }}
       </UButton>

--- a/backend/app/modules/recalls/frontend/pages/recalls/index.vue
+++ b/backend/app/modules/recalls/frontend/pages/recalls/index.vue
@@ -219,10 +219,7 @@ async function downloadCsv() {
 
     <section class="grid grid-cols-2 sm:grid-cols-5 gap-2">
       <UFormField :label="t('recalls.filters.month')">
-        <UInput
-          v-model="month"
-          type="month"
-        />
+        <MonthPickerDropdown v-model="month" />
       </UFormField>
       <UFormField :label="t('recalls.filters.reason')">
         <USelectMenu

--- a/backend/app/modules/recalls/frontend/pages/recalls/index.vue
+++ b/backend/app/modules/recalls/frontend/pages/recalls/index.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type { Recall, RecallStatus, RecallReason, RecallPriority } from '../../composables/useRecalls'
+
+definePageMeta({ middleware: ['auth'] })
+
+const { t, locale } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const recallsApi = useRecalls()
+const { can } = usePermissions()
+
+if (!can('recalls.read')) {
+  await navigateTo('/')
+}
+
+// Filters from query string.
+const month = ref<string>(String(route.query.month ?? defaultMonthIso()))
+const reason = ref<RecallReason | ''>((route.query.reason as RecallReason) ?? '')
+const status = ref<RecallStatus | ''>((route.query.status as RecallStatus) ?? 'pending')
+const priority = ref<RecallPriority | ''>((route.query.priority as RecallPriority) ?? '')
+const overdue = ref<boolean>(route.query.overdue === 'true')
+const patientId = ref<string | undefined>((route.query.patient_id as string) || undefined)
+
+const stats = ref<{
+  due_this_week: number
+  due_this_month: number
+  overdue: number
+  scheduled_this_month: number
+  completed_this_month: number
+  conversion_rate: number
+} | null>(null)
+
+const items = ref<Recall[]>([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = ref(50)
+const isLoading = ref(false)
+
+function defaultMonthIso(): string {
+  const today = new Date()
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-01`
+}
+
+const reasonOptions = computed(() => [
+  { value: '', label: t('recalls.filters.any') },
+  ...(['hygiene', 'checkup', 'ortho_review', 'implant_review', 'post_op', 'treatment_followup', 'other'] as RecallReason[]).map(r => ({
+    value: r,
+    label: t(`recalls.reasons.${r}`)
+  }))
+])
+
+const statusOptions = computed(() => [
+  { value: '', label: t('recalls.filters.any') },
+  ...(['pending', 'contacted_no_answer', 'contacted_scheduled', 'contacted_declined', 'done', 'cancelled', 'needs_review'] as RecallStatus[]).map(s => ({
+    value: s,
+    label: t(`recalls.status.${s}`)
+  }))
+])
+
+const priorityOptions = computed(() => [
+  { value: '', label: t('recalls.filters.any') },
+  ...(['low', 'normal', 'high'] as RecallPriority[]).map(p => ({
+    value: p,
+    label: t(`recalls.priority.${p}`)
+  }))
+])
+
+async function load() {
+  isLoading.value = true
+  try {
+    const filters: Record<string, unknown> = {
+      month: month.value || undefined,
+      reason: reason.value || undefined,
+      status: status.value || undefined,
+      priority: priority.value || undefined,
+      overdue: overdue.value || undefined,
+      patient_id: patientId.value,
+      page: page.value,
+      page_size: pageSize.value
+    }
+    const [list, dash] = await Promise.all([
+      recallsApi.list(filters),
+      recallsApi.dashboardStats()
+    ])
+    items.value = list.data
+    total.value = list.total
+    stats.value = dash.data
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(load)
+
+watch([month, reason, status, priority, overdue, patientId], () => {
+  page.value = 1
+  router.replace({
+    query: {
+      ...(month.value ? { month: month.value } : {}),
+      ...(reason.value ? { reason: reason.value } : {}),
+      ...(status.value ? { status: status.value } : {}),
+      ...(priority.value ? { priority: priority.value } : {}),
+      ...(overdue.value ? { overdue: 'true' } : {}),
+      ...(patientId.value ? { patient_id: patientId.value } : {})
+    }
+  })
+  load()
+})
+
+function onChanged(updated: Recall) {
+  const idx = items.value.findIndex(r => r.id === updated.id)
+  if (idx >= 0) items.value[idx] = { ...items.value[idx], ...updated }
+  // Refresh stats on any state change.
+  recallsApi.dashboardStats().then(res => {
+    stats.value = res.data
+  }).catch(() => { /* ignore */ })
+}
+
+const conversionPct = computed(() => stats.value ? Math.round(stats.value.conversion_rate * 100) : 0)
+const csvUrl = computed(() => recallsApi.exportCsvUrl({
+  month: month.value || undefined,
+  reason: reason.value || undefined,
+  status: status.value || undefined,
+  priority: priority.value || undefined,
+  overdue: overdue.value || undefined
+}))
+</script>
+
+<template>
+  <div class="container mx-auto p-4 space-y-4">
+    <header class="flex items-center justify-between gap-2 flex-wrap">
+      <h1 class="text-h1">
+        {{ t('recalls.callList') }}
+      </h1>
+      <UButton
+        :href="csvUrl"
+        icon="i-lucide-download"
+        size="sm"
+        variant="soft"
+      >
+        {{ t('recalls.actions.exportCsv') }}
+      </UButton>
+    </header>
+
+    <section
+      v-if="stats"
+      class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center"
+    >
+      <UCard :ui="{ body: 'p-2' }">
+        <div class="text-h2 tnum">
+          {{ stats.due_this_week }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.due_this_week') }}
+        </div>
+      </UCard>
+      <UCard :ui="{ body: 'p-2' }">
+        <div class="text-h2 tnum">
+          {{ stats.overdue }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.overdue') }}
+        </div>
+      </UCard>
+      <UCard :ui="{ body: 'p-2' }">
+        <div class="text-h2 tnum">
+          {{ stats.scheduled_this_month }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.scheduled_this_month') }}
+        </div>
+      </UCard>
+      <UCard :ui="{ body: 'p-2' }">
+        <div class="text-h2 tnum">
+          {{ conversionPct }}%
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('recalls.counters.conversion_rate') }}
+        </div>
+      </UCard>
+    </section>
+
+    <section class="grid grid-cols-2 sm:grid-cols-5 gap-2">
+      <UFormField :label="t('recalls.filters.month')">
+        <UInput
+          v-model="month"
+          type="month"
+        />
+      </UFormField>
+      <UFormField :label="t('recalls.filters.reason')">
+        <USelectMenu
+          v-model="reason"
+          :items="reasonOptions"
+          value-key="value"
+          label-key="label"
+        />
+      </UFormField>
+      <UFormField :label="t('recalls.filters.status')">
+        <USelectMenu
+          v-model="status"
+          :items="statusOptions"
+          value-key="value"
+          label-key="label"
+        />
+      </UFormField>
+      <UFormField :label="t('recalls.filters.priority')">
+        <USelectMenu
+          v-model="priority"
+          :items="priorityOptions"
+          value-key="value"
+          label-key="label"
+        />
+      </UFormField>
+      <UFormField :label="t('recalls.filters.overdue')">
+        <USwitch v-model="overdue" />
+      </UFormField>
+    </section>
+
+    <RecallList
+      :items="items"
+      :is-loading="isLoading"
+      @changed="onChanged"
+    />
+  </div>
+</template>

--- a/backend/app/modules/recalls/frontend/plugins/settings.client.ts
+++ b/backend/app/modules/recalls/frontend/plugins/settings.client.ts
@@ -1,0 +1,24 @@
+/**
+ * Registers the recalls settings page on the host registry. Mounted
+ * as a card under ``/settings/clinical`` and as a full page at
+ * ``/settings/clinical/recalls`` via the host's dynamic category
+ * route.
+ *
+ * Same boundary as schedules — `~~` reaches the frontend host shell,
+ * not another module. Recalls' depends stay at ``["patients", "agenda"]``.
+ */
+import { registerSettingsPage } from '~~/app/composables/useSettingsRegistry'
+
+export default defineNuxtPlugin(() => {
+  registerSettingsPage({
+    path: 'recalls',
+    category: 'clinical',
+    labelKey: 'recalls.settings.title',
+    descriptionKey: 'recalls.settings.description',
+    icon: 'i-lucide-bell',
+    permission: 'recalls.read',
+    component: () => import('../components/RecallSettingsPanel.vue'),
+    searchKeywords: ['recordatorio', 'recall', 'llamada', 'callback', 'motivo', 'intervalo'],
+    order: 40
+  })
+})

--- a/backend/app/modules/recalls/frontend/plugins/slots.client.ts
+++ b/backend/app/modules/recalls/frontend/plugins/slots.client.ts
@@ -49,14 +49,8 @@ export default defineNuxtPlugin(() => {
     order: 30
   })
 
-  // Settings — reason intervals + category map editor.
-  registerSlot('settings.sections', {
-    id: 'recalls.settings.section',
-    component: defineAsyncComponent(() => import('../components/RecallSettingsPanel.vue')),
-    permission: 'recalls.write',
-    labelKey: 'recalls.settings.title',
-    descriptionKey: 'recalls.settings.description',
-    category: 'clinical',
-    order: 40
-  })
+  // Settings page is registered via the host settings registry —
+  // see `./settings.client.ts`. No `settings.sections` entry here so
+  // the panel only renders on its own page (avoids the inline-card
+  // duplication on `/settings/clinical`).
 })

--- a/backend/app/modules/recalls/frontend/plugins/slots.client.ts
+++ b/backend/app/modules/recalls/frontend/plugins/slots.client.ts
@@ -1,0 +1,62 @@
+import { defineAsyncComponent } from 'vue'
+import { registerSlot } from '~~/app/composables/useModuleSlots'
+
+/**
+ * Slot registrations for the `recalls` module.
+ *
+ * Hosts (`patients`, `agenda`, `odontogram`) expose stable slot names
+ * and never import this module. The slot registry is the only contract.
+ */
+export default defineNuxtPlugin(() => {
+  // Patient summary hero — "Set recall" action button.
+  registerSlot('patient.summary.actions', {
+    id: 'recalls.patient.set-recall',
+    component: defineAsyncComponent(() => import('../components/SetRecallButton.vue')),
+    permission: 'recalls.write',
+    order: 20
+  })
+
+  // Patient summary feed — pill + recent recall history.
+  registerSlot('patient.summary.feed', {
+    id: 'recalls.patient.feed',
+    component: defineAsyncComponent(() => import('../components/RecallSummaryFeed.vue')),
+    permission: 'recalls.read',
+    order: 30
+  })
+
+  // Per-treatment "Set recall" action (odontogram diagnosis row +
+  // treatment-plan items).
+  registerSlot('odontogram.condition.actions', {
+    id: 'recalls.plan-item.set-recall',
+    component: defineAsyncComponent(() => import('../components/SetRecallFromTreatmentButton.vue')),
+    permission: 'recalls.write',
+    order: 30
+  })
+
+  // Post-completion follow-up prompt rendered by AppointmentQuickActions.
+  registerSlot('appointment.completed.followup', {
+    id: 'recalls.appointment.closeout-prompt',
+    component: defineAsyncComponent(() => import('../components/RecallCloseoutPrompt.vue')),
+    permission: 'recalls.write',
+    order: 10
+  })
+
+  // Dashboard widget — counters strip.
+  registerSlot('dashboard.attention', {
+    id: 'recalls.dashboard.due-overdue',
+    component: defineAsyncComponent(() => import('../components/RecallDashboardWidget.vue')),
+    permission: 'recalls.read',
+    order: 30
+  })
+
+  // Settings — reason intervals + category map editor.
+  registerSlot('settings.sections', {
+    id: 'recalls.settings.section',
+    component: defineAsyncComponent(() => import('../components/RecallSettingsPanel.vue')),
+    permission: 'recalls.write',
+    labelKey: 'recalls.settings.title',
+    descriptionKey: 'recalls.settings.description',
+    category: 'clinical',
+    order: 40
+  })
+})

--- a/backend/app/modules/recalls/migrations/versions/rec_0001_initial.py
+++ b/backend/app/modules/recalls/migrations/versions/rec_0001_initial.py
@@ -20,9 +20,13 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision: str = "rec_0001"
-down_revision: str | None = None
+# Chain off the foundational core revision that creates ``clinics`` +
+# ``users``. The cross-branch FKs to ``patients`` and ``appointments``
+# are declared via ``depends_on`` so those tables exist regardless of
+# branch ordering when starting from a clean DB.
+down_revision: str | None = "0001"
 branch_labels: str | Sequence[str] | None = ("recalls",)
-depends_on: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = ("pat_0001", "ag_0001")
 
 
 def upgrade() -> None:

--- a/backend/app/modules/recalls/migrations/versions/rec_0001_initial.py
+++ b/backend/app/modules/recalls/migrations/versions/rec_0001_initial.py
@@ -1,0 +1,156 @@
+"""recalls: initial schema.
+
+Tables:
+    - ``recalls`` — patient call-back rows.
+    - ``recall_contact_attempts`` — append-only attempt log.
+    - ``recall_settings`` — per-clinic configuration.
+
+Lives on its own Alembic branch (``recalls``) per ADR 0002.
+
+Revision ID: rec_0001
+Revises:
+Create Date: 2026-05-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "rec_0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = ("recalls",)
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "recalls",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("clinic_id", sa.UUID(), nullable=False),
+        sa.Column("patient_id", sa.UUID(), nullable=False),
+        sa.Column("due_month", sa.Date(), nullable=False),
+        sa.Column("due_date", sa.Date(), nullable=True),
+        sa.Column("reason", sa.String(length=40), nullable=False),
+        sa.Column("reason_note", sa.Text(), nullable=True),
+        sa.Column("priority", sa.String(length=10), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("recommended_by", sa.UUID(), nullable=True),
+        sa.Column("assigned_professional_id", sa.UUID(), nullable=True),
+        sa.Column("last_contact_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("contact_attempt_count", sa.Integer(), nullable=False),
+        sa.Column("linked_appointment_id", sa.UUID(), nullable=True),
+        sa.Column("linked_treatment_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "linked_treatment_category_key", sa.String(length=80), nullable=True
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["clinic_id"], ["clinics.id"]),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"]),
+        sa.ForeignKeyConstraint(["recommended_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["assigned_professional_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(
+            ["linked_appointment_id"], ["appointments.id"]
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_recalls_clinic_id"), "recalls", ["clinic_id"])
+    op.create_index(op.f("ix_recalls_patient_id"), "recalls", ["patient_id"])
+    op.create_index(op.f("ix_recalls_due_month"), "recalls", ["due_month"])
+    op.create_index(op.f("ix_recalls_status"), "recalls", ["status"])
+    op.create_index(
+        "ix_recalls_clinic_due_month_status",
+        "recalls",
+        ["clinic_id", "due_month", "status"],
+    )
+    op.create_index(
+        "ix_recalls_clinic_patient_reason_status",
+        "recalls",
+        ["clinic_id", "patient_id", "reason", "status"],
+    )
+
+    op.create_table(
+        "recall_contact_attempts",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("recall_id", sa.UUID(), nullable=False),
+        sa.Column("clinic_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "attempted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("attempted_by", sa.UUID(), nullable=False),
+        sa.Column("channel", sa.String(length=20), nullable=False),
+        sa.Column("outcome", sa.String(length=30), nullable=False),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["recall_id"], ["recalls.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["clinic_id"], ["clinics.id"]),
+        sa.ForeignKeyConstraint(["attempted_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_recall_contact_attempts_recall_id"),
+        "recall_contact_attempts",
+        ["recall_id"],
+    )
+    op.create_index(
+        op.f("ix_recall_contact_attempts_clinic_id"),
+        "recall_contact_attempts",
+        ["clinic_id"],
+    )
+
+    op.create_table(
+        "recall_settings",
+        sa.Column("clinic_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "reason_intervals",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "category_to_reason",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "auto_suggest_on_treatment_completed", sa.Boolean(), nullable=False
+        ),
+        sa.Column(
+            "auto_link_on_appointment_scheduled", sa.Boolean(), nullable=False
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["clinic_id"], ["clinics.id"]),
+        sa.PrimaryKeyConstraint("clinic_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("recall_settings")
+    op.drop_index(
+        op.f("ix_recall_contact_attempts_clinic_id"),
+        table_name="recall_contact_attempts",
+    )
+    op.drop_index(
+        op.f("ix_recall_contact_attempts_recall_id"),
+        table_name="recall_contact_attempts",
+    )
+    op.drop_table("recall_contact_attempts")
+    op.drop_index("ix_recalls_clinic_patient_reason_status", table_name="recalls")
+    op.drop_index("ix_recalls_clinic_due_month_status", table_name="recalls")
+    op.drop_index(op.f("ix_recalls_status"), table_name="recalls")
+    op.drop_index(op.f("ix_recalls_due_month"), table_name="recalls")
+    op.drop_index(op.f("ix_recalls_patient_id"), table_name="recalls")
+    op.drop_index(op.f("ix_recalls_clinic_id"), table_name="recalls")
+    op.drop_table("recalls")

--- a/backend/app/modules/recalls/migrations/versions/rec_0001_initial.py
+++ b/backend/app/modules/recalls/migrations/versions/rec_0001_initial.py
@@ -43,9 +43,7 @@ def upgrade() -> None:
         sa.Column("contact_attempt_count", sa.Integer(), nullable=False),
         sa.Column("linked_appointment_id", sa.UUID(), nullable=True),
         sa.Column("linked_treatment_id", sa.UUID(), nullable=True),
-        sa.Column(
-            "linked_treatment_category_key", sa.String(length=80), nullable=True
-        ),
+        sa.Column("linked_treatment_category_key", sa.String(length=80), nullable=True),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
@@ -53,9 +51,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["patient_id"], ["patients.id"]),
         sa.ForeignKeyConstraint(["recommended_by"], ["users.id"]),
         sa.ForeignKeyConstraint(["assigned_professional_id"], ["users.id"]),
-        sa.ForeignKeyConstraint(
-            ["linked_appointment_id"], ["appointments.id"]
-        ),
+        sa.ForeignKeyConstraint(["linked_appointment_id"], ["appointments.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(op.f("ix_recalls_clinic_id"), "recalls", ["clinic_id"])
@@ -88,9 +84,7 @@ def upgrade() -> None:
         sa.Column("channel", sa.String(length=20), nullable=False),
         sa.Column("outcome", sa.String(length=30), nullable=False),
         sa.Column("note", sa.Text(), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["recall_id"], ["recalls.id"], ondelete="CASCADE"
-        ),
+        sa.ForeignKeyConstraint(["recall_id"], ["recalls.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["clinic_id"], ["clinics.id"]),
         sa.ForeignKeyConstraint(["attempted_by"], ["users.id"]),
         sa.PrimaryKeyConstraint("id"),
@@ -119,12 +113,8 @@ def upgrade() -> None:
             postgresql.JSONB(astext_type=sa.Text()),
             nullable=False,
         ),
-        sa.Column(
-            "auto_suggest_on_treatment_completed", sa.Boolean(), nullable=False
-        ),
-        sa.Column(
-            "auto_link_on_appointment_scheduled", sa.Boolean(), nullable=False
-        ),
+        sa.Column("auto_suggest_on_treatment_completed", sa.Boolean(), nullable=False),
+        sa.Column("auto_link_on_appointment_scheduled", sa.Boolean(), nullable=False),
         sa.Column(
             "updated_at",
             sa.DateTime(timezone=True),

--- a/backend/app/modules/recalls/models.py
+++ b/backend/app/modules/recalls/models.py
@@ -97,23 +97,15 @@ class Recall(Base, TimestampMixin):
     reason: Mapped[str] = mapped_column(String(40), nullable=False)
     reason_note: Mapped[str | None] = mapped_column(Text)
     priority: Mapped[str] = mapped_column(String(10), nullable=False, default="normal")
-    status: Mapped[str] = mapped_column(
-        String(30), nullable=False, default="pending", index=True
-    )
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="pending", index=True)
 
-    recommended_by: Mapped[UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id")
-    )
+    recommended_by: Mapped[UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
     assigned_professional_id: Mapped[UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id")
     )
 
-    last_contact_attempt_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True)
-    )
-    contact_attempt_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0
-    )
+    last_contact_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    contact_attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     linked_appointment_id: Mapped[UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("appointments.id")
@@ -192,9 +184,7 @@ class RecallSettings(Base):
         UUID(as_uuid=True), ForeignKey("clinics.id"), primary_key=True
     )
     reason_intervals: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
-    category_to_reason: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, default=dict
-    )
+    category_to_reason: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     auto_suggest_on_treatment_completed: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True
     )

--- a/backend/app/modules/recalls/models.py
+++ b/backend/app/modules/recalls/models.py
@@ -1,0 +1,228 @@
+"""Recalls module — patient call-back data model.
+
+Three tables:
+
+* ``recalls`` — one row per scheduled call-back.
+* ``recall_contact_attempts`` — append-only attempt log per recall.
+* ``recall_settings`` — one row per clinic, holding the reason
+  intervals + treatment-category → reason map + automation toggles.
+
+Cross-module FKs are restricted to ``patients.id`` and
+``appointments.id`` because those are the only modules in
+``manifest.depends``. Treatment-plan / catalog references are stored
+as snapshots (string + nullable UUID without FK).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    pass
+
+
+# Enum-as-string values are documented here, not enforced at the DB
+# level (matches the rest of the codebase — see ``Patient.status``).
+
+REASONS = (
+    "hygiene",
+    "checkup",
+    "ortho_review",
+    "implant_review",
+    "post_op",
+    "treatment_followup",
+    "other",
+)
+
+PRIORITIES = ("low", "normal", "high")
+
+STATUSES = (
+    "pending",
+    "contacted_no_answer",
+    "contacted_scheduled",
+    "contacted_declined",
+    "done",
+    "cancelled",
+    "needs_review",
+)
+
+CHANNELS = ("phone", "whatsapp", "sms", "email")
+
+OUTCOMES = (
+    "no_answer",
+    "voicemail",
+    "scheduled",
+    "declined",
+    "wrong_number",
+)
+
+
+class Recall(Base, TimestampMixin):
+    """Patient call-back row."""
+
+    __tablename__ = "recalls"
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    clinic_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("clinics.id"), nullable=False, index=True
+    )
+    patient_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("patients.id"), nullable=False, index=True
+    )
+
+    # Always day-1 of the target month so monthly buckets index cheaply.
+    due_month: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    # Optional precise day inside the month, when the dentist wants more
+    # granularity (e.g. "the day she comes back from holidays").
+    due_date: Mapped[date | None] = mapped_column(Date)
+
+    reason: Mapped[str] = mapped_column(String(40), nullable=False)
+    reason_note: Mapped[str | None] = mapped_column(Text)
+    priority: Mapped[str] = mapped_column(String(10), nullable=False, default="normal")
+    status: Mapped[str] = mapped_column(
+        String(30), nullable=False, default="pending", index=True
+    )
+
+    recommended_by: Mapped[UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id")
+    )
+    assigned_professional_id: Mapped[UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id")
+    )
+
+    last_contact_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True)
+    )
+    contact_attempt_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0
+    )
+
+    linked_appointment_id: Mapped[UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("appointments.id")
+    )
+    # No FK — treatment_plan is not in manifest.depends. Snapshot only.
+    linked_treatment_id: Mapped[UUID | None] = mapped_column(UUID(as_uuid=True))
+    # Snapshot of the catalog category that drove the suggestion (e.g.
+    # ``preventivo``). Used by the call list to label the recall and by
+    # auto-link logic to match scheduled appointments.
+    linked_treatment_category_key: Mapped[str | None] = mapped_column(String(80))
+
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        Index(
+            "ix_recalls_clinic_due_month_status",
+            "clinic_id",
+            "due_month",
+            "status",
+        ),
+        Index(
+            "ix_recalls_clinic_patient_reason_status",
+            "clinic_id",
+            "patient_id",
+            "reason",
+            "status",
+        ),
+    )
+
+
+class RecallContactAttempt(Base):
+    """One row per outbound contact attempt for a recall.
+
+    Append-only — never updated, never soft-deleted. ``attempted_at`` is
+    server-set so the log is monotonic regardless of client clock skew.
+    """
+
+    __tablename__ = "recall_contact_attempts"
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    recall_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("recalls.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    clinic_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("clinics.id"), nullable=False, index=True
+    )
+    attempted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    attempted_by: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    channel: Mapped[str] = mapped_column(String(20), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(30), nullable=False)
+    note: Mapped[str | None] = mapped_column(Text)
+
+
+class RecallSettings(Base):
+    """Per-clinic recall configuration.
+
+    JSONB columns hold:
+
+    * ``reason_intervals`` — ``{reason: months}`` (e.g. ``{"hygiene": 6}``).
+    * ``category_to_reason`` — ``{catalog_category_key: reason}`` (e.g.
+      ``{"preventivo": "hygiene"}``).
+
+    Lazy-created on first read by ``RecallSettingsService``.
+    """
+
+    __tablename__ = "recall_settings"
+
+    clinic_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("clinics.id"), primary_key=True
+    )
+    reason_intervals: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    category_to_reason: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict
+    )
+    auto_suggest_on_treatment_completed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True
+    )
+    auto_link_on_appointment_scheduled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+# Default mapping seeded into ``RecallSettings`` rows on first read.
+DEFAULT_REASON_INTERVALS: dict[str, int] = {
+    "hygiene": 6,
+    "checkup": 12,
+    "ortho_review": 1,
+    "implant_review": 6,
+    "post_op": 1,
+    "treatment_followup": 3,
+    "other": 3,
+}
+
+DEFAULT_CATEGORY_TO_REASON: dict[str, str] = {
+    "preventivo": "hygiene",
+    "ortodoncia": "ortho_review",
+    "cirugia": "post_op",
+    "implantes": "implant_review",
+}

--- a/backend/app/modules/recalls/router.py
+++ b/backend/app/modules/recalls/router.py
@@ -1,0 +1,411 @@
+"""Recalls HTTP surface — mounted at ``/api/v1/recalls/``.
+
+All endpoints filter by ``clinic_id`` from the request context.
+Permissions: ``recalls.{read,write,delete}``.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.dependencies import (
+    ClinicContext,
+    get_clinic_context,
+    require_permission,
+)
+from app.core.schemas import ApiResponse, PaginatedApiResponse
+from app.database import get_db
+
+from .schemas import (
+    AttemptCreate,
+    AttemptResponse,
+    PatientBriefForRecall,
+    RecallCancelRequest,
+    RecallCreate,
+    RecallDashboardStats,
+    RecallDetailResponse,
+    RecallLinkAppointmentRequest,
+    RecallResponse,
+    RecallSettingsResponse,
+    RecallSettingsUpdate,
+    RecallSnoozeRequest,
+    RecallSuggestion,
+    RecallUpdate,
+)
+from .schemas import (
+    Status as RecallStatusLiteral,
+)
+from .service import (
+    RecallFilters,
+    RecallService,
+    RecallSettingsService,
+)
+
+router = APIRouter()
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _serialise(recall) -> RecallResponse:
+    payload = RecallResponse.model_validate(recall)
+    if getattr(recall, "patient", None) is not None:
+        payload.patient = PatientBriefForRecall.model_validate(recall.patient)
+    return payload
+
+
+# --- List + create --------------------------------------------------------
+
+
+@router.get("/", response_model=PaginatedApiResponse[RecallResponse])
+async def list_recalls(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    month: date | None = Query(default=None, description="Any day in target month"),
+    reason: str | None = None,
+    professional_id: UUID | None = None,
+    status_filter: RecallStatusLiteral | None = Query(default=None, alias="status"),
+    priority: str | None = None,
+    overdue: bool = False,
+    patient_id: UUID | None = None,
+    include_archived_patients: bool = False,
+    include_do_not_contact: bool = False,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+) -> PaginatedApiResponse[RecallResponse]:
+    filters = RecallFilters(
+        month=month,
+        reason=reason,
+        professional_id=professional_id,
+        status=status_filter,
+        priority=priority,
+        overdue=overdue,
+        patient_id=patient_id,
+        include_archived_patients=include_archived_patients,
+        include_do_not_contact=include_do_not_contact,
+    )
+    items, total = await RecallService.list(
+        db, ctx.clinic_id, filters, page=page, page_size=page_size
+    )
+    return PaginatedApiResponse(
+        data=[_serialise(r) for r in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.post(
+    "/",
+    response_model=ApiResponse[RecallResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_recall(
+    data: RecallCreate,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallResponse]:
+    recall, _created = await RecallService.create(
+        db,
+        clinic_id=ctx.clinic_id,
+        data=data.model_dump(),
+        recommended_by=ctx.user_id,
+    )
+    await db.commit()
+    return ApiResponse(data=_serialise(recall))
+
+
+@router.get("/stats/dashboard", response_model=ApiResponse[RecallDashboardStats])
+async def get_dashboard_stats(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallDashboardStats]:
+    stats = await RecallService.dashboard_stats(db, ctx.clinic_id)
+    return ApiResponse(data=RecallDashboardStats(**stats))
+
+
+@router.get("/suggestions/next", response_model=ApiResponse[RecallSuggestion | None])
+async def suggest_next_recall(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    patient_id: UUID = Query(...),
+    treatment_category_key: str | None = Query(default=None),
+    treatment_id: UUID | None = Query(default=None),
+) -> ApiResponse[RecallSuggestion | None]:
+    suggestion = await RecallService.suggest_next_for_treatment(
+        db,
+        clinic_id=ctx.clinic_id,
+        patient_id=patient_id,
+        treatment_category_key=treatment_category_key,
+        treatment_id=treatment_id,
+    )
+    if not suggestion:
+        return ApiResponse(data=None)
+    return ApiResponse(data=RecallSuggestion(**suggestion))
+
+
+@router.get("/settings", response_model=ApiResponse[RecallSettingsResponse])
+async def get_settings(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallSettingsResponse]:
+    settings = await RecallSettingsService.get_or_create(db, ctx.clinic_id)
+    await db.commit()
+    return ApiResponse(data=RecallSettingsResponse.model_validate(settings))
+
+
+@router.put("/settings", response_model=ApiResponse[RecallSettingsResponse])
+async def update_settings(
+    data: RecallSettingsUpdate,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallSettingsResponse]:
+    settings = await RecallSettingsService.update(
+        db, ctx.clinic_id, data.model_dump(exclude_unset=True)
+    )
+    await db.commit()
+    return ApiResponse(data=RecallSettingsResponse.model_validate(settings))
+
+
+@router.get("/export.csv")
+async def export_csv(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    month: date | None = Query(default=None),
+    reason: str | None = None,
+    status_filter: RecallStatusLiteral | None = Query(default=None, alias="status"),
+    priority: str | None = None,
+    overdue: bool = False,
+    professional_id: UUID | None = None,
+) -> StreamingResponse:
+    filters = RecallFilters(
+        month=month,
+        reason=reason,
+        status=status_filter,
+        priority=priority,
+        overdue=overdue,
+        professional_id=professional_id,
+    )
+    rows = await RecallService.export_rows(db, ctx.clinic_id, filters)
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "due_month",
+            "patient",
+            "phone",
+            "reason",
+            "priority",
+            "status",
+            "attempts",
+            "professional",
+            "note",
+        ]
+    )
+    for recall, patient in rows:
+        writer.writerow(
+            [
+                recall.due_month.isoformat(),
+                f"{patient.first_name} {patient.last_name}".strip(),
+                patient.phone or "",
+                recall.reason,
+                recall.priority,
+                recall.status,
+                recall.contact_attempt_count,
+                str(recall.assigned_professional_id or ""),
+                (recall.reason_note or "").replace("\n", " "),
+            ]
+        )
+    buf.seek(0)
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=recalls.csv"},
+    )
+
+
+@router.get("/patients/{patient_id}", response_model=ApiResponse[list[RecallResponse]])
+async def list_patient_recalls(
+    patient_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[list[RecallResponse]]:
+    items = await RecallService.list_for_patient(db, ctx.clinic_id, patient_id)
+    return ApiResponse(data=[RecallResponse.model_validate(r) for r in items])
+
+
+# --- Per-id surface ------------------------------------------------------
+
+
+@router.get("/{recall_id}", response_model=ApiResponse[RecallDetailResponse])
+async def get_recall(
+    recall_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallDetailResponse]:
+    recall, attempts = await RecallService.get_with_attempts(db, ctx.clinic_id, recall_id)
+    if not recall:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recall not found")
+    payload = RecallDetailResponse.model_validate(recall)
+    payload.attempts = [AttemptResponse.model_validate(a) for a in attempts]
+    return ApiResponse(data=payload)
+
+
+@router.patch("/{recall_id}", response_model=ApiResponse[RecallResponse])
+async def update_recall(
+    recall_id: UUID,
+    data: RecallUpdate,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallResponse]:
+    recall = await RecallService.update(
+        db, ctx.clinic_id, recall_id, data.model_dump(exclude_unset=True)
+    )
+    if not recall:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    await db.commit()
+    return ApiResponse(data=RecallResponse.model_validate(recall))
+
+
+@router.post("/{recall_id}/snooze", response_model=ApiResponse[RecallResponse])
+async def snooze_recall(
+    recall_id: UUID,
+    data: RecallSnoozeRequest,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallResponse]:
+    recall = await RecallService.snooze(
+        db,
+        ctx.clinic_id,
+        recall_id,
+        months=data.months,
+        reason_note=data.reason_note,
+        by_user=ctx.user_id,
+    )
+    if not recall:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    await db.commit()
+    return ApiResponse(data=RecallResponse.model_validate(recall))
+
+
+@router.post("/{recall_id}/cancel", response_model=ApiResponse[RecallResponse])
+async def cancel_recall(
+    recall_id: UUID,
+    data: RecallCancelRequest,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallResponse]:
+    recall = await RecallService.cancel(
+        db,
+        ctx.clinic_id,
+        recall_id,
+        note=data.note,
+        by_user=ctx.user_id,
+    )
+    if not recall:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    await db.commit()
+    return ApiResponse(data=RecallResponse.model_validate(recall))
+
+
+@router.post("/{recall_id}/done", response_model=ApiResponse[RecallResponse])
+async def mark_recall_done(
+    recall_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallResponse]:
+    recall = await RecallService.mark_done(db, ctx.clinic_id, recall_id, by_user=ctx.user_id)
+    if not recall:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    await db.commit()
+    return ApiResponse(data=RecallResponse.model_validate(recall))
+
+
+@router.post(
+    "/{recall_id}/attempts",
+    response_model=ApiResponse[AttemptResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def log_attempt(
+    recall_id: UUID,
+    data: AttemptCreate,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[AttemptResponse]:
+    if not ctx.user_id:
+        raise HTTPException(status_code=400, detail="user_id required to log attempt")
+    result = await RecallService.log_attempt(
+        db,
+        ctx.clinic_id,
+        recall_id,
+        attempt_data=data.model_dump(),
+        by_user=ctx.user_id,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    _, attempt = result
+    await db.commit()
+    return ApiResponse(data=AttemptResponse.model_validate(attempt))
+
+
+@router.get("/{recall_id}/attempts", response_model=ApiResponse[list[AttemptResponse]])
+async def list_attempts(
+    recall_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[list[AttemptResponse]]:
+    attempts = await RecallService.list_attempts(db, ctx.clinic_id, recall_id)
+    return ApiResponse(data=[AttemptResponse.model_validate(a) for a in attempts])
+
+
+@router.post("/{recall_id}/link-appointment", response_model=ApiResponse[RecallResponse])
+async def link_appointment(
+    recall_id: UUID,
+    data: RecallLinkAppointmentRequest,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[RecallResponse]:
+    recall = await RecallService.link_appointment(db, ctx.clinic_id, recall_id, data.appointment_id)
+    if not recall:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    await db.commit()
+    return ApiResponse(data=RecallResponse.model_validate(recall))
+
+
+@router.delete("/{recall_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_recall(
+    recall_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("recalls.delete"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    recall = await RecallService.get(db, ctx.clinic_id, recall_id)
+    if not recall:
+        raise HTTPException(status_code=404, detail="Recall not found")
+    await db.delete(recall)
+    await db.commit()
+    return None

--- a/backend/app/modules/recalls/schemas.py
+++ b/backend/app/modules/recalls/schemas.py
@@ -1,0 +1,203 @@
+"""Pydantic schemas for the recalls module."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# --- Enum literals (mirrors ``models.REASONS`` etc.) ----------------------
+
+Reason = Literal[
+    "hygiene",
+    "checkup",
+    "ortho_review",
+    "implant_review",
+    "post_op",
+    "treatment_followup",
+    "other",
+]
+
+Priority = Literal["low", "normal", "high"]
+
+Status = Literal[
+    "pending",
+    "contacted_no_answer",
+    "contacted_scheduled",
+    "contacted_declined",
+    "done",
+    "cancelled",
+    "needs_review",
+]
+
+Channel = Literal["phone", "whatsapp", "sms", "email"]
+
+Outcome = Literal[
+    "no_answer",
+    "voicemail",
+    "scheduled",
+    "declined",
+    "wrong_number",
+]
+
+
+# --- Recall CRUD -----------------------------------------------------------
+
+
+class RecallCreate(BaseModel):
+    patient_id: UUID
+    due_month: date  # caller passes day-1 of target month; service normalises
+    due_date: date | None = None
+    reason: Reason
+    reason_note: str | None = None
+    priority: Priority = "normal"
+    assigned_professional_id: UUID | None = None
+    linked_treatment_id: UUID | None = None
+    linked_treatment_category_key: str | None = Field(default=None, max_length=80)
+
+
+class RecallUpdate(BaseModel):
+    due_month: date | None = None
+    due_date: date | None = None
+    reason: Reason | None = None
+    reason_note: str | None = None
+    priority: Priority | None = None
+    assigned_professional_id: UUID | None = None
+
+
+class RecallSnoozeRequest(BaseModel):
+    months: int = Field(ge=1, le=24)
+    reason_note: str | None = None
+
+
+class RecallCancelRequest(BaseModel):
+    note: str | None = None
+
+
+class RecallLinkAppointmentRequest(BaseModel):
+    appointment_id: UUID
+
+
+class AttemptCreate(BaseModel):
+    channel: Channel
+    outcome: Outcome
+    note: str | None = None
+    # When the receptionist books an appointment in the same gesture as
+    # logging the attempt, this lets the call-list UI close the loop in
+    # one server round-trip.
+    linked_appointment_id: UUID | None = None
+
+
+# --- Response shapes -------------------------------------------------------
+
+
+class PatientBriefForRecall(BaseModel):
+    id: UUID
+    first_name: str
+    last_name: str
+    phone: str | None = None
+    email: str | None = None
+    do_not_contact: bool = False
+    status: str
+
+    class Config:
+        from_attributes = True
+
+
+class AttemptResponse(BaseModel):
+    id: UUID
+    recall_id: UUID
+    attempted_at: datetime
+    attempted_by: UUID
+    channel: Channel
+    outcome: Outcome
+    note: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class RecallResponse(BaseModel):
+    id: UUID
+    clinic_id: UUID
+    patient_id: UUID
+    due_month: date
+    due_date: date | None = None
+    reason: Reason
+    reason_note: str | None = None
+    priority: Priority
+    status: Status
+    recommended_by: UUID | None = None
+    assigned_professional_id: UUID | None = None
+    last_contact_attempt_at: datetime | None = None
+    contact_attempt_count: int
+    linked_appointment_id: UUID | None = None
+    linked_treatment_id: UUID | None = None
+    linked_treatment_category_key: str | None = None
+    completed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+    patient: PatientBriefForRecall | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class RecallDetailResponse(RecallResponse):
+    attempts: list[AttemptResponse] = []
+
+
+# --- Suggestions -----------------------------------------------------------
+
+
+class RecallSuggestion(BaseModel):
+    """A non-binding suggestion the UI surfaces in the patient feed.
+
+    The ``recalls`` module never auto-creates from suggestions — the
+    user clicks "create" to commit. Returned by
+    ``GET /api/v1/recalls/suggestions/next``.
+    """
+
+    patient_id: UUID
+    reason: Reason
+    due_month: date
+    interval_months: int
+    treatment_category_key: str | None = None
+    treatment_id: UUID | None = None
+    matched_setting: bool
+
+
+# --- Settings --------------------------------------------------------------
+
+
+class RecallSettingsResponse(BaseModel):
+    clinic_id: UUID
+    reason_intervals: dict[str, int]
+    category_to_reason: dict[str, str]
+    auto_suggest_on_treatment_completed: bool
+    auto_link_on_appointment_scheduled: bool
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class RecallSettingsUpdate(BaseModel):
+    reason_intervals: dict[str, int] | None = None
+    category_to_reason: dict[str, str] | None = None
+    auto_suggest_on_treatment_completed: bool | None = None
+    auto_link_on_appointment_scheduled: bool | None = None
+
+
+# --- Stats -----------------------------------------------------------------
+
+
+class RecallDashboardStats(BaseModel):
+    due_this_week: int
+    due_this_month: int
+    overdue: int
+    scheduled_this_month: int
+    completed_this_month: int
+    conversion_rate: float  # 0.0 - 1.0

--- a/backend/app/modules/recalls/seed.py
+++ b/backend/app/modules/recalls/seed.py
@@ -149,9 +149,7 @@ async def seed_recalls_demo(
     await RecallSettingsService.get_or_create(db, clinic_id)
 
     patients_res = await db.execute(
-        select(Patient)
-        .where(Patient.clinic_id == clinic_id)
-        .order_by(Patient.created_at)
+        select(Patient).where(Patient.clinic_id == clinic_id).order_by(Patient.created_at)
     )
     patient_list = list(patients_res.scalars().all())
 
@@ -191,12 +189,17 @@ async def seed_recalls_demo(
         if scenario["status"] == "done":
             completed_at = now - timedelta(days=5 + (i % 10))
 
-        professional_id = dentist_id if scenario["reason"] in (
-            "post_op",
-            "implant_review",
-            "ortho_review",
-            "treatment_followup",
-        ) else hygienist_id
+        professional_id = (
+            dentist_id
+            if scenario["reason"]
+            in (
+                "post_op",
+                "implant_review",
+                "ortho_review",
+                "treatment_followup",
+            )
+            else hygienist_id
+        )
 
         recall = Recall(
             clinic_id=clinic_id,
@@ -211,9 +214,7 @@ async def seed_recalls_demo(
             assigned_professional_id=professional_id,
             contact_attempt_count=scenario["attempts"],
             last_contact_attempt_at=(
-                now - timedelta(days=2 + (i % 5))
-                if scenario["attempts"] > 0
-                else None
+                now - timedelta(days=2 + (i % 5)) if scenario["attempts"] > 0 else None
             ),
             completed_at=completed_at,
             created_at=created_at,

--- a/backend/app/modules/recalls/seed.py
+++ b/backend/app/modules/recalls/seed.py
@@ -1,0 +1,258 @@
+"""Demo seed for the recalls module.
+
+Generates a realistic monthly call list across the seeded patients:
+mix of statuses (pending / no answer / scheduled / done / needs
+review / cancelled), reasons, priorities, and a sprinkle of contact
+attempts so the receptionist UX has something to work through on a
+fresh demo. Lazily seeds ``RecallSettings`` with the documented
+defaults (already handled by the service, so we just call it once).
+
+Idempotent for the given clinic: wipes the clinic's recalls +
+attempts, then repopulates. ``recall.*`` events are NOT published
+during seeding — listeners would re-seed off-cycle data.
+
+Only invoked by ``backend/scripts/seed_demo.py`` after patients +
+appointments exist (recalls reference both).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.agenda.models import Appointment
+from app.modules.patients.models import Patient
+
+from .models import Recall, RecallContactAttempt
+from .service import RecallSettingsService
+
+
+def _normalize_due_month(d: date) -> date:
+    return date(d.year, d.month, 1)
+
+
+def _add_months(d: date, months: int) -> date:
+    base = _normalize_due_month(d)
+    total = base.year * 12 + (base.month - 1) + months
+    year, month = divmod(total, 12)
+    return date(year, month + 1, 1)
+
+
+# Eight scenario templates, cycled across patients. Together they
+# cover every status the call-list filters can show, plus enough
+# reasons and priorities for the dashboard counters to be non-trivial.
+_SCENARIOS = (
+    {
+        "key": "pending_due_this_month_hygiene",
+        "month_offset": 0,
+        "reason": "hygiene",
+        "priority": "normal",
+        "status": "pending",
+        "attempts": 0,
+        "note": "Recordatorio de higiene anual.",
+    },
+    {
+        "key": "no_answer_overdue_checkup",
+        "month_offset": -1,
+        "reason": "checkup",
+        "priority": "normal",
+        "status": "contacted_no_answer",
+        "attempts": 2,
+        "note": "Revisión anual; no contesta al teléfono fijo.",
+    },
+    {
+        "key": "scheduled_postop_high",
+        "month_offset": 0,
+        "reason": "post_op",
+        "priority": "high",
+        "status": "contacted_scheduled",
+        "attempts": 1,
+        "note": "Postoperatorio de cirugía 36; cita confirmada.",
+    },
+    {
+        "key": "done_last_month_hygiene",
+        "month_offset": -1,
+        "reason": "hygiene",
+        "priority": "normal",
+        "status": "done",
+        "attempts": 1,
+        "note": "Higiene completada en visita previa.",
+    },
+    {
+        "key": "pending_next_month_ortho",
+        "month_offset": 1,
+        "reason": "ortho_review",
+        "priority": "normal",
+        "status": "pending",
+        "attempts": 0,
+        "note": "Revisión mensual de ortodoncia.",
+    },
+    {
+        "key": "needs_review_implant",
+        "month_offset": -2,
+        "reason": "implant_review",
+        "priority": "high",
+        "status": "needs_review",
+        "attempts": 0,
+        "note": "Revisión de implante 46; revisar contacto.",
+    },
+    {
+        "key": "cancelled_treatment_followup",
+        "month_offset": -1,
+        "reason": "treatment_followup",
+        "priority": "low",
+        "status": "cancelled",
+        "attempts": 1,
+        "note": "Paciente declina seguimiento.",
+    },
+    {
+        "key": "pending_three_months_implant",
+        "month_offset": 3,
+        "reason": "implant_review",
+        "priority": "normal",
+        "status": "pending",
+        "attempts": 0,
+        "note": "Control de implante a los 3 meses.",
+    },
+)
+
+
+_ATTEMPT_NOTES = (
+    "Llamada al móvil sin respuesta.",
+    "Buzón de voz; mensaje dejado.",
+    "Indica que llamemos la próxima semana.",
+    "Acuerda agendar tras revisar agenda laboral.",
+)
+
+
+async def seed_recalls_demo(
+    db: AsyncSession,
+    clinic_id: UUID,
+    dentist_id: UUID,
+    hygienist_id: UUID,
+    receptionist_id: UUID,
+) -> dict[str, int]:
+    """Populate the recalls module for the demo clinic.
+
+    Returns ``{<status>: count}`` plus a top-level ``total`` for the
+    summary line printed by ``seed_demo.py``.
+    """
+    # Wipe — attempts cascade via FK ondelete=CASCADE.
+    await db.execute(delete(Recall).where(Recall.clinic_id == clinic_id))
+    await db.flush()
+
+    # Lazy-seed settings (idempotent — fetches the row or inserts the
+    # documented defaults).
+    await RecallSettingsService.get_or_create(db, clinic_id)
+
+    patients_res = await db.execute(
+        select(Patient)
+        .where(Patient.clinic_id == clinic_id)
+        .order_by(Patient.created_at)
+    )
+    patient_list = list(patients_res.scalars().all())
+
+    # Map patient -> earliest scheduled appointment (used to give
+    # ``contacted_scheduled`` recalls a real linked_appointment_id when
+    # one exists; falls back to None otherwise).
+    appt_res = await db.execute(
+        select(Appointment)
+        .where(Appointment.clinic_id == clinic_id)
+        .order_by(Appointment.start_time)
+    )
+    appt_by_patient: dict[UUID, UUID] = {}
+    for appt in appt_res.scalars().all():
+        if appt.patient_id and appt.patient_id not in appt_by_patient:
+            appt_by_patient[appt.patient_id] = appt.id
+
+    today = date.today()
+    now = datetime.now(UTC)
+
+    stats: dict[str, int] = {
+        "pending": 0,
+        "contacted_no_answer": 0,
+        "contacted_scheduled": 0,
+        "done": 0,
+        "cancelled": 0,
+        "needs_review": 0,
+        "attempts": 0,
+        "total": 0,
+    }
+
+    for i, patient in enumerate(patient_list):
+        scenario = _SCENARIOS[i % len(_SCENARIOS)]
+        due_month = _add_months(today, scenario["month_offset"])
+        created_at = now - timedelta(days=14 + (i % 21))
+
+        completed_at = None
+        if scenario["status"] == "done":
+            completed_at = now - timedelta(days=5 + (i % 10))
+
+        professional_id = dentist_id if scenario["reason"] in (
+            "post_op",
+            "implant_review",
+            "ortho_review",
+            "treatment_followup",
+        ) else hygienist_id
+
+        recall = Recall(
+            clinic_id=clinic_id,
+            patient_id=patient.id,
+            due_month=due_month,
+            due_date=None,
+            reason=scenario["reason"],
+            reason_note=scenario["note"],
+            priority=scenario["priority"],
+            status=scenario["status"],
+            recommended_by=dentist_id,
+            assigned_professional_id=professional_id,
+            contact_attempt_count=scenario["attempts"],
+            last_contact_attempt_at=(
+                now - timedelta(days=2 + (i % 5))
+                if scenario["attempts"] > 0
+                else None
+            ),
+            completed_at=completed_at,
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        if scenario["status"] == "contacted_scheduled":
+            recall.linked_appointment_id = appt_by_patient.get(patient.id)
+
+        db.add(recall)
+        await db.flush()  # need recall.id to attach attempts
+
+        # Attempts: one per N declared by the scenario, channels +
+        # outcomes mixed so the call-list shows variety.
+        for k in range(scenario["attempts"]):
+            channel = "phone" if k == 0 else ("whatsapp" if k == 1 else "sms")
+            outcome = (
+                "scheduled"
+                if scenario["status"] == "contacted_scheduled" and k == scenario["attempts"] - 1
+                else (
+                    "declined"
+                    if scenario["status"] == "cancelled"
+                    else ("voicemail" if k == 1 else "no_answer")
+                )
+            )
+            db.add(
+                RecallContactAttempt(
+                    recall_id=recall.id,
+                    clinic_id=clinic_id,
+                    attempted_by=receptionist_id,
+                    channel=channel,
+                    outcome=outcome,
+                    attempted_at=now - timedelta(days=k + 1, hours=2 * k),
+                    note=_ATTEMPT_NOTES[(i + k) % len(_ATTEMPT_NOTES)],
+                )
+            )
+            stats["attempts"] += 1
+
+        stats[scenario["status"]] += 1
+        stats["total"] += 1
+
+    await db.flush()
+    return stats

--- a/backend/app/modules/recalls/service.py
+++ b/backend/app/modules/recalls/service.py
@@ -1,0 +1,649 @@
+"""Recalls module service layer.
+
+Static-method classes — routers stay thin, business logic lives here.
+Multi-tenancy is mandatory: every query filters by ``clinic_id``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.events import event_bus
+from app.core.events.types import EventType
+from app.modules.patients.models import Patient
+
+from .models import (
+    DEFAULT_CATEGORY_TO_REASON,
+    DEFAULT_REASON_INTERVALS,
+    Recall,
+    RecallContactAttempt,
+    RecallSettings,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Status sets used in multiple queries.
+ACTIVE_STATUSES = ("pending", "contacted_no_answer", "contacted_scheduled")
+OPEN_STATUSES = ACTIVE_STATUSES + ("needs_review",)
+TERMINAL_STATUSES = ("done", "cancelled")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_due_month(d: date) -> date:
+    """Always day-1 of the month — keeps the index selective."""
+    return date(d.year, d.month, 1)
+
+
+def _add_months(d: date, months: int) -> date:
+    """Add N calendar months to a day-1 date, returning a day-1 date."""
+    base = _normalize_due_month(d)
+    total = base.year * 12 + (base.month - 1) + months
+    year, month = divmod(total, 12)
+    return date(year, month + 1, 1)
+
+
+def _build_event_payload(recall: Recall) -> dict[str, Any]:
+    return {
+        "recall_id": str(recall.id),
+        "clinic_id": str(recall.clinic_id),
+        "patient_id": str(recall.patient_id),
+        "reason": recall.reason,
+        "due_month": recall.due_month.isoformat(),
+        "priority": recall.priority,
+        "status": recall.status,
+    }
+
+
+@dataclass
+class RecallFilters:
+    month: date | None = None  # any day in target month, normalised internally
+    reason: str | None = None
+    professional_id: UUID | None = None
+    status: str | None = None
+    priority: str | None = None
+    overdue: bool = False  # status active + due_month < current month
+    patient_id: UUID | None = None
+    include_archived_patients: bool = False  # surfaces needs_review bucket
+    include_do_not_contact: bool = False
+
+
+# ---------------------------------------------------------------------------
+# RecallService
+# ---------------------------------------------------------------------------
+
+
+class RecallService:
+    """Business logic for ``recalls`` and ``recall_contact_attempts``."""
+
+    # --- Read ----------------------------------------------------------------
+
+    @staticmethod
+    async def list(
+        db: AsyncSession,
+        clinic_id: UUID,
+        filters: RecallFilters,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> tuple[list[Recall], int]:
+        stmt = (
+            select(Recall, Patient)
+            .join(Patient, Patient.id == Recall.patient_id)
+            .where(Recall.clinic_id == clinic_id)
+        )
+
+        if not filters.include_archived_patients:
+            stmt = stmt.where(Patient.status != "archived")
+        if not filters.include_do_not_contact:
+            stmt = stmt.where(Patient.do_not_contact.is_(False))
+
+        if filters.month:
+            month = _normalize_due_month(filters.month)
+            stmt = stmt.where(Recall.due_month == month)
+
+        if filters.reason:
+            stmt = stmt.where(Recall.reason == filters.reason)
+        if filters.priority:
+            stmt = stmt.where(Recall.priority == filters.priority)
+        if filters.professional_id:
+            stmt = stmt.where(Recall.assigned_professional_id == filters.professional_id)
+        if filters.patient_id:
+            stmt = stmt.where(Recall.patient_id == filters.patient_id)
+        if filters.status:
+            stmt = stmt.where(Recall.status == filters.status)
+        if filters.overdue:
+            current_month = _normalize_due_month(date.today())
+            stmt = stmt.where(
+                and_(
+                    Recall.due_month < current_month,
+                    Recall.status.in_(ACTIVE_STATUSES),
+                )
+            )
+
+        # Total count over the same filters.
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total_result = await db.execute(count_stmt)
+        total = int(total_result.scalar_one() or 0)
+
+        priority_order = case(
+            (Recall.priority == "high", 0),
+            (Recall.priority == "normal", 1),
+            (Recall.priority == "low", 2),
+            else_=3,
+        )
+        stmt = (
+            stmt.order_by(priority_order, Recall.due_month, Recall.created_at)
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        result = await db.execute(stmt)
+        rows = result.all()
+        items: list[Recall] = []
+        for recall, patient in rows:
+            # Attach patient brief without a relationship — the API layer
+            # serialises ``patient`` from the column we set here.
+            recall.patient = patient  # type: ignore[attr-defined]
+            items.append(recall)
+        return items, total
+
+    @staticmethod
+    async def get(db: AsyncSession, clinic_id: UUID, recall_id: UUID) -> Recall | None:
+        stmt = select(Recall).where(Recall.id == recall_id, Recall.clinic_id == clinic_id)
+        result = await db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_with_attempts(
+        db: AsyncSession, clinic_id: UUID, recall_id: UUID
+    ) -> tuple[Recall | None, list[RecallContactAttempt]]:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None, []
+        result = await db.execute(
+            select(RecallContactAttempt)
+            .where(RecallContactAttempt.recall_id == recall.id)
+            .order_by(RecallContactAttempt.attempted_at.desc())
+        )
+        return recall, list(result.scalars().all())
+
+    @staticmethod
+    async def list_attempts(
+        db: AsyncSession, clinic_id: UUID, recall_id: UUID
+    ) -> list[RecallContactAttempt]:
+        result = await db.execute(
+            select(RecallContactAttempt)
+            .where(
+                RecallContactAttempt.clinic_id == clinic_id,
+                RecallContactAttempt.recall_id == recall_id,
+            )
+            .order_by(RecallContactAttempt.attempted_at.desc())
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_for_patient(
+        db: AsyncSession, clinic_id: UUID, patient_id: UUID, limit: int = 50
+    ) -> list[Recall]:
+        result = await db.execute(
+            select(Recall)
+            .where(Recall.clinic_id == clinic_id, Recall.patient_id == patient_id)
+            .order_by(Recall.due_month.desc(), Recall.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    # --- Duplicate guard helper ---------------------------------------------
+
+    @staticmethod
+    async def find_pending_for(
+        db: AsyncSession, clinic_id: UUID, patient_id: UUID, reason: str
+    ) -> Recall | None:
+        result = await db.execute(
+            select(Recall).where(
+                Recall.clinic_id == clinic_id,
+                Recall.patient_id == patient_id,
+                Recall.reason == reason,
+                Recall.status.in_(ACTIVE_STATUSES),
+            )
+        )
+        return result.scalars().first()
+
+    # --- Write ---------------------------------------------------------------
+
+    @staticmethod
+    async def create(
+        db: AsyncSession,
+        clinic_id: UUID,
+        data: dict[str, Any],
+        recommended_by: UUID | None,
+    ) -> tuple[Recall, bool]:
+        """Create or update-the-existing-pending row for the patient.
+
+        Returns ``(recall, created)`` — ``created`` is False when the
+        duplicate guard updated an existing row instead of inserting.
+        Publishes ``recall.created`` only when ``created`` is True.
+        """
+        existing = await RecallService.find_pending_for(
+            db, clinic_id, data["patient_id"], data["reason"]
+        )
+        normalised_due_month = _normalize_due_month(data["due_month"])
+
+        if existing:
+            existing.due_month = normalised_due_month
+            existing.due_date = data.get("due_date")
+            existing.priority = data.get("priority", existing.priority)
+            existing.reason_note = data.get("reason_note")
+            existing.assigned_professional_id = data.get("assigned_professional_id")
+            existing.linked_treatment_id = data.get("linked_treatment_id")
+            existing.linked_treatment_category_key = data.get("linked_treatment_category_key")
+            await db.flush()
+            return existing, False
+
+        recall = Recall(
+            clinic_id=clinic_id,
+            patient_id=data["patient_id"],
+            due_month=normalised_due_month,
+            due_date=data.get("due_date"),
+            reason=data["reason"],
+            reason_note=data.get("reason_note"),
+            priority=data.get("priority", "normal"),
+            status="pending",
+            recommended_by=recommended_by,
+            assigned_professional_id=data.get("assigned_professional_id"),
+            contact_attempt_count=0,
+            linked_treatment_id=data.get("linked_treatment_id"),
+            linked_treatment_category_key=data.get("linked_treatment_category_key"),
+        )
+        db.add(recall)
+        await db.flush()
+        event_bus.publish(EventType.RECALL_CREATED, _build_event_payload(recall))
+        return recall, True
+
+    @staticmethod
+    async def update(
+        db: AsyncSession,
+        clinic_id: UUID,
+        recall_id: UUID,
+        data: dict[str, Any],
+    ) -> Recall | None:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None
+        if "due_month" in data and data["due_month"]:
+            recall.due_month = _normalize_due_month(data["due_month"])
+        if "due_date" in data:
+            recall.due_date = data["due_date"]
+        if "reason" in data and data["reason"]:
+            recall.reason = data["reason"]
+        if "reason_note" in data:
+            recall.reason_note = data["reason_note"]
+        if "priority" in data and data["priority"]:
+            recall.priority = data["priority"]
+        if "assigned_professional_id" in data:
+            recall.assigned_professional_id = data["assigned_professional_id"]
+        await db.flush()
+        return recall
+
+    @staticmethod
+    async def snooze(
+        db: AsyncSession,
+        clinic_id: UUID,
+        recall_id: UUID,
+        months: int,
+        reason_note: str | None,
+        by_user: UUID | None,
+    ) -> Recall | None:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None
+        recall.due_month = _add_months(recall.due_month, months)
+        if reason_note:
+            stamp = (
+                datetime.now(UTC).strftime("%Y-%m-%d")
+                + " ("
+                + (str(by_user) if by_user else "system")
+                + "): "
+            )
+            recall.reason_note = (
+                (recall.reason_note + "\n" if recall.reason_note else "")
+                + stamp
+                + f"snoozed +{months}mo · {reason_note}"
+            )
+        if recall.status not in ("done", "cancelled"):
+            recall.status = "pending"
+        await db.flush()
+        payload = _build_event_payload(recall)
+        payload["snoozed_months"] = months
+        event_bus.publish(EventType.RECALL_SNOOZED, payload)
+        return recall
+
+    @staticmethod
+    async def cancel(
+        db: AsyncSession,
+        clinic_id: UUID,
+        recall_id: UUID,
+        note: str | None,
+        by_user: UUID | None,
+    ) -> Recall | None:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None
+        recall.status = "cancelled"
+        if note:
+            recall.reason_note = (
+                recall.reason_note + "\n" if recall.reason_note else ""
+            ) + f"cancelled: {note}"
+        await db.flush()
+        event_bus.publish(EventType.RECALL_CANCELLED, _build_event_payload(recall))
+        return recall
+
+    @staticmethod
+    async def mark_done(
+        db: AsyncSession,
+        clinic_id: UUID,
+        recall_id: UUID,
+        by_user: UUID | None,
+        commit: bool = True,
+    ) -> Recall | None:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None
+        recall.status = "done"
+        recall.completed_at = datetime.now(UTC)
+        await db.flush()
+        event_bus.publish(EventType.RECALL_COMPLETED, _build_event_payload(recall))
+        return recall
+
+    @staticmethod
+    async def log_attempt(
+        db: AsyncSession,
+        clinic_id: UUID,
+        recall_id: UUID,
+        attempt_data: dict[str, Any],
+        by_user: UUID,
+    ) -> tuple[Recall, RecallContactAttempt] | None:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None
+        attempt = RecallContactAttempt(
+            recall_id=recall.id,
+            clinic_id=clinic_id,
+            attempted_by=by_user,
+            channel=attempt_data["channel"],
+            outcome=attempt_data["outcome"],
+            note=attempt_data.get("note"),
+        )
+        db.add(attempt)
+        recall.contact_attempt_count = (recall.contact_attempt_count or 0) + 1
+        recall.last_contact_attempt_at = datetime.now(UTC)
+
+        outcome = attempt_data["outcome"]
+        linked = attempt_data.get("linked_appointment_id")
+        if outcome == "scheduled":
+            recall.status = "contacted_scheduled"
+            if linked:
+                recall.linked_appointment_id = linked
+        elif outcome == "declined":
+            recall.status = "contacted_declined"
+        elif outcome in ("no_answer", "voicemail", "wrong_number"):
+            if recall.status == "pending":
+                recall.status = "contacted_no_answer"
+
+        await db.flush()
+        return recall, attempt
+
+    @staticmethod
+    async def link_appointment(
+        db: AsyncSession,
+        clinic_id: UUID,
+        recall_id: UUID,
+        appointment_id: UUID,
+    ) -> Recall | None:
+        recall = await RecallService.get(db, clinic_id, recall_id)
+        if not recall:
+            return None
+        recall.linked_appointment_id = appointment_id
+        if recall.status in ("pending", "contacted_no_answer"):
+            recall.status = "contacted_scheduled"
+        await db.flush()
+        return recall
+
+    @staticmethod
+    async def auto_link_for_appointment(
+        db: AsyncSession,
+        clinic_id: UUID,
+        patient_id: UUID,
+        appointment_id: UUID,
+        appointment_date: date,
+    ) -> Recall | None:
+        """Called from ``on_appointment_scheduled``.
+
+        Picks the most due *active* recall for the patient whose
+        ``due_month`` is at or before the appointment month, links it
+        and transitions to ``contacted_scheduled``. Returns the linked
+        recall or None when no candidate exists.
+        """
+        appointment_month = _normalize_due_month(appointment_date)
+        result = await db.execute(
+            select(Recall)
+            .where(
+                Recall.clinic_id == clinic_id,
+                Recall.patient_id == patient_id,
+                Recall.status.in_(("pending", "contacted_no_answer")),
+                Recall.due_month <= appointment_month,
+                Recall.linked_appointment_id.is_(None),
+            )
+            .order_by(Recall.due_month.asc(), Recall.created_at.asc())
+            .limit(1)
+        )
+        recall = result.scalar_one_or_none()
+        if not recall:
+            return None
+        recall.linked_appointment_id = appointment_id
+        recall.status = "contacted_scheduled"
+        await db.flush()
+        return recall
+
+    # --- Suggestion ----------------------------------------------------------
+
+    @staticmethod
+    async def suggest_next_for_treatment(
+        db: AsyncSession,
+        clinic_id: UUID,
+        patient_id: UUID,
+        treatment_category_key: str | None,
+        treatment_id: UUID | None = None,
+    ) -> dict[str, Any] | None:
+        """Compute a non-binding next-recall suggestion.
+
+        Returns ``None`` when the patient is excluded
+        (archived / do_not_contact) or no mapping exists for the
+        given category. Caller decides whether to materialise the
+        suggestion as a recall (via POST /recalls).
+        """
+        patient = (
+            await db.execute(select(Patient).where(Patient.id == patient_id))
+        ).scalar_one_or_none()
+        if not patient or patient.clinic_id != clinic_id:
+            return None
+        if patient.status == "archived" or patient.do_not_contact:
+            return None
+
+        settings = await RecallSettingsService.get_or_create(db, clinic_id)
+        reason = (
+            settings.category_to_reason.get(treatment_category_key)
+            if treatment_category_key
+            else None
+        )
+        if not reason:
+            return None
+        interval = settings.reason_intervals.get(reason)
+        if not interval:
+            return None
+        due_month = _add_months(date.today(), int(interval))
+        return {
+            "patient_id": patient_id,
+            "reason": reason,
+            "due_month": due_month,
+            "interval_months": int(interval),
+            "treatment_category_key": treatment_category_key,
+            "treatment_id": treatment_id,
+            "matched_setting": True,
+        }
+
+    # --- Stats / export ------------------------------------------------------
+
+    @staticmethod
+    async def dashboard_stats(
+        db: AsyncSession, clinic_id: UUID, today: date | None = None
+    ) -> dict[str, int | float]:
+        today = today or date.today()
+        month_start = _normalize_due_month(today)
+        month_end = _add_months(month_start, 1)
+        week_end = today + timedelta(days=7)
+
+        async def count_where(*conditions: Any) -> int:
+            stmt = (
+                select(func.count())
+                .select_from(Recall)
+                .join(Patient, Patient.id == Recall.patient_id)
+                .where(
+                    Recall.clinic_id == clinic_id,
+                    Patient.status != "archived",
+                    Patient.do_not_contact.is_(False),
+                    *conditions,
+                )
+            )
+            return int((await db.execute(stmt)).scalar_one() or 0)
+
+        due_this_week = await count_where(
+            Recall.status.in_(ACTIVE_STATUSES),
+            Recall.due_month <= week_end,
+            Recall.due_month >= month_start,
+        )
+        due_this_month = await count_where(
+            Recall.status.in_(ACTIVE_STATUSES),
+            Recall.due_month == month_start,
+        )
+        overdue = await count_where(
+            Recall.status.in_(ACTIVE_STATUSES),
+            Recall.due_month < month_start,
+        )
+        scheduled_this_month = await count_where(
+            Recall.status == "contacted_scheduled",
+            Recall.due_month >= month_start,
+            Recall.due_month < month_end,
+        )
+        completed_this_month_count = await count_where(
+            Recall.status == "done",
+            Recall.completed_at >= datetime.combine(month_start, datetime.min.time()),
+            Recall.completed_at < datetime.combine(month_end, datetime.min.time()),
+        )
+        # Conversion = completed this month / (completed + cancelled this month)
+        cancelled_this_month_count = await count_where(
+            Recall.status == "cancelled",
+            Recall.updated_at >= datetime.combine(month_start, datetime.min.time()),
+            Recall.updated_at < datetime.combine(month_end, datetime.min.time()),
+        )
+        denominator = completed_this_month_count + cancelled_this_month_count
+        conversion_rate = float(completed_this_month_count) / denominator if denominator else 0.0
+        return {
+            "due_this_week": due_this_week,
+            "due_this_month": due_this_month,
+            "overdue": overdue,
+            "scheduled_this_month": scheduled_this_month,
+            "completed_this_month": completed_this_month_count,
+            "conversion_rate": round(conversion_rate, 4),
+        }
+
+    @staticmethod
+    async def export_rows(
+        db: AsyncSession,
+        clinic_id: UUID,
+        filters: RecallFilters,
+    ) -> Sequence[tuple[Recall, Patient]]:
+        """Stream rows for CSV export. Same filter rules as ``list``."""
+        items, _ = await RecallService.list(db, clinic_id, filters, page=1, page_size=10_000)
+        # Patient was attached as ``recall.patient`` in ``list``.
+        return [(r, r.patient) for r in items]  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# RecallSettingsService
+# ---------------------------------------------------------------------------
+
+
+class RecallSettingsService:
+    @staticmethod
+    async def get_or_create(db: AsyncSession, clinic_id: UUID) -> RecallSettings:
+        result = await db.execute(
+            select(RecallSettings).where(RecallSettings.clinic_id == clinic_id)
+        )
+        settings = result.scalar_one_or_none()
+        if settings:
+            return settings
+        settings = RecallSettings(
+            clinic_id=clinic_id,
+            reason_intervals=dict(DEFAULT_REASON_INTERVALS),
+            category_to_reason=dict(DEFAULT_CATEGORY_TO_REASON),
+            auto_suggest_on_treatment_completed=True,
+            auto_link_on_appointment_scheduled=True,
+        )
+        db.add(settings)
+        await db.flush()
+        return settings
+
+    @staticmethod
+    async def update(
+        db: AsyncSession,
+        clinic_id: UUID,
+        data: dict[str, Any],
+    ) -> RecallSettings:
+        settings = await RecallSettingsService.get_or_create(db, clinic_id)
+        if "reason_intervals" in data and data["reason_intervals"] is not None:
+            settings.reason_intervals = data["reason_intervals"]
+        if "category_to_reason" in data and data["category_to_reason"] is not None:
+            settings.category_to_reason = data["category_to_reason"]
+        if (
+            "auto_suggest_on_treatment_completed" in data
+            and data["auto_suggest_on_treatment_completed"] is not None
+        ):
+            settings.auto_suggest_on_treatment_completed = data[
+                "auto_suggest_on_treatment_completed"
+            ]
+        if (
+            "auto_link_on_appointment_scheduled" in data
+            and data["auto_link_on_appointment_scheduled"] is not None
+        ):
+            settings.auto_link_on_appointment_scheduled = data["auto_link_on_appointment_scheduled"]
+        settings.updated_at = datetime.now(UTC)
+        await db.flush()
+        return settings
+
+
+# ---------------------------------------------------------------------------
+# Re-export for convenience.
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "ACTIVE_STATUSES",
+    "OPEN_STATUSES",
+    "TERMINAL_STATUSES",
+    "RecallFilters",
+    "RecallService",
+    "RecallSettingsService",
+    "_add_months",
+    "_normalize_due_month",
+]

--- a/backend/app/modules/recalls/service.py
+++ b/backend/app/modules/recalls/service.py
@@ -430,10 +430,13 @@ class RecallService:
     ) -> Recall | None:
         """Called from ``on_appointment_scheduled``.
 
-        Picks the most due *active* recall for the patient whose
-        ``due_month`` is at or before the appointment month, links it
-        and transitions to ``contacted_scheduled``. Returns the linked
-        recall or None when no candidate exists.
+        Conservative auto-link policy: link the appointment only when
+        the patient has *exactly one* active recall whose ``due_month``
+        is at or before the appointment month. Bails out when there are
+        zero or two-plus candidates so the system never silently
+        attaches the appointment to the wrong recall — reception keeps
+        the explicit "Agendar cita" path from a recall row when the
+        patient has more than one active recall.
         """
         appointment_month = _normalize_due_month(appointment_date)
         result = await db.execute(
@@ -445,12 +448,15 @@ class RecallService:
                 Recall.due_month <= appointment_month,
                 Recall.linked_appointment_id.is_(None),
             )
-            .order_by(Recall.due_month.asc(), Recall.created_at.asc())
-            .limit(1)
+            # Two is enough to know we have to bail; no need to fetch more.
+            .limit(2)
         )
-        recall = result.scalar_one_or_none()
-        if not recall:
+        candidates = list(result.scalars().all())
+        if len(candidates) != 1:
+            # Zero candidates: nothing to do.
+            # Two-plus: ambiguous — let reception link manually.
             return None
+        recall = candidates[0]
         recall.linked_appointment_id = appointment_id
         recall.status = "contacted_scheduled"
         await db.flush()

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Enrich `treatment_plan.treatment_completed` event payload with a
+  `treatment_category_key` snapshot (issue #62, recalls). Allows
+  sibling modules to map completed treatments to follow-up policies
+  without importing catalog or treatment_plan models. Loaded via
+  the existing `_treatment_loader` selectinload chain (now also
+  pulls `catalog_item.category`); event-handler paths use a small
+  helper query when the relationships aren't already loaded.
+
 - Patient detail → Clínica → Planes: `PlansMode` paginates plans at
   page_size=20. `PlansListView` now exposes `page` / `total-pages`
   props and renders the shared `PaginationBar` below the grouped lists.

--- a/backend/app/modules/treatment_plan/CLAUDE.md
+++ b/backend/app/modules/treatment_plan/CLAUDE.md
@@ -65,7 +65,7 @@ the `clinical_notes` module since issue #60.
 | `treatment_plan.reactivated` | closed → draft | Subscriber: `patient_timeline`. |
 | `treatment_plan.treatment_added` | item added | snapshot payload (catalog_item_id, tooth, surfaces, unit_price, budget_id). Subscriber: `budget`. |
 | `treatment_plan.treatment_removed` | item removed | payload includes `budget_id`. Subscriber: `budget`. |
-| `treatment_plan.treatment_completed` | item marked done | consumed by `patient_timeline` |
+| `treatment_plan.treatment_completed` | item marked done | consumed by `patient_timeline`, `recalls`. Payload includes `treatment_category_key` (snapshot, may be null) so subscribers can map a completed treatment to a follow-up policy without importing catalog or treatment_plan models (issue #62). |
 | `treatment_plan.budget_sync_requested` | manual resync | snapshot payload includes full `items[]`. Subscriber: `budget`. |
 | `treatment_plan.item_completed_without_note` | completion check | consumed by `patient_timeline` |
 

--- a/backend/app/modules/treatment_plan/events.py
+++ b/backend/app/modules/treatment_plan/events.py
@@ -18,9 +18,7 @@ from .models import PlannedTreatmentItem
 logger = logging.getLogger(__name__)
 
 
-async def _resolve_treatment_category_key(
-    db: AsyncSession, treatment_id: UUID
-) -> str | None:
+async def _resolve_treatment_category_key(db: AsyncSession, treatment_id: UUID) -> str | None:
     """Look up the catalog category key for a Treatment.
 
     Used to enrich ``treatment_plan.treatment_completed`` payloads so
@@ -85,9 +83,7 @@ async def on_appointment_completed(data: dict[str, Any]) -> None:
                         item.status = "completed"
                         item.completed_without_appointment = False
 
-                        category_key = await _resolve_treatment_category_key(
-                            db, item.treatment_id
-                        )
+                        category_key = await _resolve_treatment_category_key(db, item.treatment_id)
                         event_bus.publish(
                             "treatment_plan.treatment_completed",
                             {
@@ -227,9 +223,7 @@ async def on_treatment_performed(data: dict[str, Any]) -> None:
                 item.status = "completed"
                 item.completed_without_appointment = True
 
-                category_key = await _resolve_treatment_category_key(
-                    db, item.treatment_id
-                )
+                category_key = await _resolve_treatment_category_key(db, item.treatment_id)
                 event_bus.publish(
                     "treatment_plan.treatment_completed",
                     {

--- a/backend/app/modules/treatment_plan/events.py
+++ b/backend/app/modules/treatment_plan/events.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import event_bus
 from app.database import async_session_maker
@@ -15,6 +16,32 @@ from app.database import async_session_maker
 from .models import PlannedTreatmentItem
 
 logger = logging.getLogger(__name__)
+
+
+async def _resolve_treatment_category_key(
+    db: AsyncSession, treatment_id: UUID
+) -> str | None:
+    """Look up the catalog category key for a Treatment.
+
+    Used to enrich ``treatment_plan.treatment_completed`` payloads so
+    sibling modules (e.g. ``recalls``) can map the completed treatment
+    to a recall reason without importing catalog or treatment_plan
+    models. ``odontogram`` and ``catalog`` are in this module's
+    ``depends``, so the read is permitted.
+    """
+    from app.modules.catalog.models import TreatmentCatalogItem, TreatmentCategory
+    from app.modules.odontogram.models import Treatment
+
+    result = await db.execute(
+        select(TreatmentCategory.key)
+        .join(
+            TreatmentCatalogItem,
+            TreatmentCatalogItem.category_id == TreatmentCategory.id,
+        )
+        .join(Treatment, Treatment.catalog_item_id == TreatmentCatalogItem.id)
+        .where(Treatment.id == treatment_id)
+    )
+    return result.scalar_one_or_none()
 
 
 async def on_appointment_completed(data: dict[str, Any]) -> None:
@@ -58,6 +85,9 @@ async def on_appointment_completed(data: dict[str, Any]) -> None:
                         item.status = "completed"
                         item.completed_without_appointment = False
 
+                        category_key = await _resolve_treatment_category_key(
+                            db, item.treatment_id
+                        )
                         event_bus.publish(
                             "treatment_plan.treatment_completed",
                             {
@@ -67,6 +97,7 @@ async def on_appointment_completed(data: dict[str, Any]) -> None:
                                 "clinic_id": clinic_id,
                                 "patient_id": data.get("patient_id"),
                                 "triggered_by": "appointment_completed",
+                                "treatment_category_key": category_key,
                             },
                         )
 
@@ -196,6 +227,9 @@ async def on_treatment_performed(data: dict[str, Any]) -> None:
                 item.status = "completed"
                 item.completed_without_appointment = True
 
+                category_key = await _resolve_treatment_category_key(
+                    db, item.treatment_id
+                )
                 event_bus.publish(
                     "treatment_plan.treatment_completed",
                     {
@@ -205,6 +239,7 @@ async def on_treatment_performed(data: dict[str, Any]) -> None:
                         "clinic_id": clinic_id,
                         "patient_id": data.get("patient_id"),
                         "triggered_by": "odontogram_performed",
+                        "treatment_category_key": category_key,
                     },
                 )
 

--- a/backend/app/modules/treatment_plan/service.py
+++ b/backend/app/modules/treatment_plan/service.py
@@ -32,9 +32,7 @@ def _treatment_loader() -> selectinload:
 
     return selectinload(PlannedTreatmentItem.treatment).options(
         selectinload(Treatment.teeth),
-        selectinload(Treatment.catalog_item).selectinload(
-            TreatmentCatalogItem.category
-        ),
+        selectinload(Treatment.catalog_item).selectinload(TreatmentCatalogItem.category),
     )
 
 

--- a/backend/app/modules/treatment_plan/service.py
+++ b/backend/app/modules/treatment_plan/service.py
@@ -21,10 +21,20 @@ logger = logging.getLogger(__name__)
 
 
 def _treatment_loader() -> selectinload:
-    """Eager-load the Treatment (with teeth + catalog_item)."""
+    """Eager-load the Treatment (with teeth + catalog_item + its category).
+
+    The ``category`` chain is loaded so consumers of the
+    ``treatment_plan.treatment_completed`` event get the
+    ``treatment_category_key`` snapshot without a follow-up query
+    (issue #62, recalls).
+    """
+    from app.modules.catalog.models import TreatmentCatalogItem
+
     return selectinload(PlannedTreatmentItem.treatment).options(
         selectinload(Treatment.teeth),
-        selectinload(Treatment.catalog_item),
+        selectinload(Treatment.catalog_item).selectinload(
+            TreatmentCatalogItem.category
+        ),
     )
 
 
@@ -684,11 +694,14 @@ class TreatmentPlanService:
 
         item_name: str | None = None
         patient_id_str: str | None = None
+        treatment_category_key: str | None = None
         if item.treatment:
             patient_id_str = str(item.treatment.patient_id)
             if item.treatment.catalog_item:
                 names = item.treatment.catalog_item.names or {}
                 item_name = names.get("es") or names.get("en")
+                if item.treatment.catalog_item.category:
+                    treatment_category_key = item.treatment.catalog_item.category.key
 
         event_bus.publish(
             "treatment_plan.treatment_completed",
@@ -701,6 +714,7 @@ class TreatmentPlanService:
                 "completed_by": str(user_id),
                 "item_name": item_name,
                 "occurred_at": item.completed_at.isoformat() if item.completed_at else None,
+                "treatment_category_key": treatment_category_key,
             },
         )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -61,6 +61,7 @@ media = "app.modules.media:MediaModule"
 notifications = "app.modules.notifications:NotificationsModule"
 reports = "app.modules.reports:ReportsModule"
 schedules = "app.modules.schedules:SchedulesModule"
+recalls = "app.modules.recalls:RecallsModule"
 verifactu = "app.modules.verifactu:VerifactuModule"
 
 [tool.setuptools.packages.find]

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -58,6 +58,7 @@ from app.seeds.demo_data import (
     CLINIC_ID,
     USER_DENTIST_ID,
     USER_HYGIENIST_ID,
+    USER_RECEPTIONIST_ID,
     generate_appointments_data,
     generate_budgets_data,
     generate_invoice_series_data,
@@ -664,6 +665,27 @@ async def main(lang: str = "en") -> None:
                     f"  Visits: {stats['visit']} | "
                     f"Treatments: {stats['treatment']} | "
                     f"Financial: {stats['financial']}"
+                )
+
+            if await _module_is_installed(db, "recalls"):
+                print("\n[opt] Creating recalls demo (module installed)...")
+                from app.modules.recalls.seed import seed_recalls_demo
+
+                stats = await seed_recalls_demo(
+                    db,
+                    clinic_id=CLINIC_ID,
+                    dentist_id=USER_DENTIST_ID,
+                    hygienist_id=USER_HYGIENIST_ID,
+                    receptionist_id=USER_RECEPTIONIST_ID,
+                )
+                print(
+                    f"  Total: {stats['total']} | "
+                    f"Pending: {stats['pending']} | "
+                    f"No answer: {stats['contacted_no_answer']} | "
+                    f"Scheduled: {stats['contacted_scheduled']} | "
+                    f"Done: {stats['done']} | "
+                    f"Needs review: {stats['needs_review']} | "
+                    f"Attempts logged: {stats['attempts']}"
                 )
 
             await db.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -55,6 +55,11 @@ from app.modules.odontogram.models import (  # noqa: F401
     TreatmentTooth,
 )
 from app.modules.patients.models import Patient  # noqa: F401
+from app.modules.recalls.models import (  # noqa: F401
+    Recall,
+    RecallContactAttempt,
+    RecallSettings,
+)
 from app.modules.schedules.models import (  # noqa: F401
     ClinicOverride,
     ClinicWeeklySchedule,

--- a/backend/tests/modules/recalls/test_router.py
+++ b/backend/tests/modules/recalls/test_router.py
@@ -1,0 +1,220 @@
+"""Recalls router smoke tests.
+
+Cover the API surface a receptionist hits while working a call list:
+create + duplicate guard, list, log attempt with auto-transition,
+snooze, settings GET/PUT, dashboard stats, do_not_contact filter.
+
+Issue #62.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic
+from app.modules.patients.models import Patient
+
+
+@pytest.mark.asyncio
+async def test_create_then_duplicate_guard_updates_existing(
+    client: AsyncClient, auth_headers: dict, test_patient: Patient
+):
+    payload = {
+        "patient_id": str(test_patient.id),
+        "due_month": "2026-08-01",
+        "reason": "hygiene",
+        "priority": "normal",
+        "reason_note": "first",
+    }
+    res = await client.post("/api/v1/recalls/", json=payload, headers=auth_headers)
+    assert res.status_code == 201, res.text
+    first = res.json()["data"]
+    assert first["status"] == "pending"
+    assert first["due_month"] == "2026-08-01"
+
+    # Same patient + reason + active status → guard updates instead of insert.
+    payload2 = {
+        **payload,
+        "due_month": "2026-09-01",
+        "priority": "high",
+        "reason_note": "second",
+    }
+    res2 = await client.post("/api/v1/recalls/", json=payload2, headers=auth_headers)
+    assert res2.status_code == 201, res2.text
+    second = res2.json()["data"]
+    assert second["id"] == first["id"]  # same row
+    assert second["due_month"] == "2026-09-01"
+    assert second["priority"] == "high"
+
+    # List shows exactly one row.
+    list_res = await client.get(
+        f"/api/v1/recalls/?patient_id={test_patient.id}&page_size=10",
+        headers=auth_headers,
+    )
+    assert list_res.status_code == 200
+    body = list_res.json()
+    assert body["total"] == 1
+    assert body["data"][0]["patient"]["first_name"] == "Test"
+
+
+@pytest.mark.asyncio
+async def test_log_attempt_auto_transitions_status(
+    client: AsyncClient, auth_headers: dict, test_patient: Patient
+):
+    # Seed a recall.
+    create = await client.post(
+        "/api/v1/recalls/",
+        json={
+            "patient_id": str(test_patient.id),
+            "due_month": "2026-07-01",
+            "reason": "checkup",
+        },
+        headers=auth_headers,
+    )
+    rid = create.json()["data"]["id"]
+
+    res = await client.post(
+        f"/api/v1/recalls/{rid}/attempts",
+        json={"channel": "phone", "outcome": "no_answer"},
+        headers=auth_headers,
+    )
+    assert res.status_code == 201, res.text
+
+    detail = (await client.get(f"/api/v1/recalls/{rid}", headers=auth_headers)).json()["data"]
+    assert detail["status"] == "contacted_no_answer"
+    assert detail["contact_attempt_count"] == 1
+    assert len(detail["attempts"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_snooze_bumps_due_month_forward(
+    client: AsyncClient, auth_headers: dict, test_patient: Patient
+):
+    create = await client.post(
+        "/api/v1/recalls/",
+        json={
+            "patient_id": str(test_patient.id),
+            "due_month": "2026-06-01",
+            "reason": "hygiene",
+        },
+        headers=auth_headers,
+    )
+    rid = create.json()["data"]["id"]
+
+    res = await client.post(
+        f"/api/v1/recalls/{rid}/snooze",
+        json={"months": 4},
+        headers=auth_headers,
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["data"]["due_month"] == "2026-10-01"
+
+
+@pytest.mark.asyncio
+async def test_settings_lazy_create_and_update(
+    client: AsyncClient, auth_headers: dict, test_clinic: Clinic
+):
+    res = await client.get("/api/v1/recalls/settings", headers=auth_headers)
+    assert res.status_code == 200
+    settings = res.json()["data"]
+    assert settings["clinic_id"] == str(test_clinic.id)
+    assert settings["reason_intervals"]["hygiene"] == 6
+    assert settings["category_to_reason"]["preventivo"] == "hygiene"
+    assert settings["auto_suggest_on_treatment_completed"] is True
+
+    update = await client.put(
+        "/api/v1/recalls/settings",
+        json={
+            "reason_intervals": {**settings["reason_intervals"], "hygiene": 4},
+            "auto_suggest_on_treatment_completed": False,
+        },
+        headers=auth_headers,
+    )
+    assert update.status_code == 200, update.text
+    updated = update.json()["data"]
+    assert updated["reason_intervals"]["hygiene"] == 4
+    assert updated["auto_suggest_on_treatment_completed"] is False
+
+
+@pytest.mark.asyncio
+async def test_dashboard_stats_endpoint(
+    client: AsyncClient, auth_headers: dict, test_patient: Patient
+):
+    # Seed a recall so the counters are non-zero where relevant.
+    await client.post(
+        "/api/v1/recalls/",
+        json={
+            "patient_id": str(test_patient.id),
+            "due_month": "1900-01-01",
+            "reason": "checkup",
+        },
+        headers=auth_headers,
+    )
+    res = await client.get("/api/v1/recalls/stats/dashboard", headers=auth_headers)
+    assert res.status_code == 200
+    stats = res.json()["data"]
+    assert stats["overdue"] >= 1
+    assert isinstance(stats["conversion_rate"], float)
+
+
+@pytest.mark.asyncio
+async def test_do_not_contact_excluded_from_active_list(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    test_patient: Patient,
+):
+    await client.post(
+        "/api/v1/recalls/",
+        json={
+            "patient_id": str(test_patient.id),
+            "due_month": "2026-08-01",
+            "reason": "hygiene",
+        },
+        headers=auth_headers,
+    )
+    test_patient.do_not_contact = True
+    await db_session.commit()
+
+    res = await client.get("/api/v1/recalls/?page_size=10", headers=auth_headers)
+    assert res.status_code == 200
+    assert res.json()["total"] == 0
+
+    # Opting in surfaces the row again.
+    res2 = await client.get(
+        "/api/v1/recalls/?include_do_not_contact=true&page_size=10",
+        headers=auth_headers,
+    )
+    assert res2.status_code == 200
+    assert res2.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_suggestion_returns_null_when_no_mapping(
+    client: AsyncClient, auth_headers: dict, test_patient: Patient
+):
+    res = await client.get(
+        f"/api/v1/recalls/suggestions/next?patient_id={test_patient.id}",
+        headers=auth_headers,
+    )
+    assert res.status_code == 200
+    assert res.json()["data"] is None
+
+
+@pytest.mark.asyncio
+async def test_suggestion_uses_category_map(
+    client: AsyncClient, auth_headers: dict, test_patient: Patient
+):
+    res = await client.get(
+        f"/api/v1/recalls/suggestions/next?patient_id={test_patient.id}"
+        f"&treatment_category_key=preventivo",
+        headers=auth_headers,
+    )
+    assert res.status_code == 200
+    suggestion = res.json()["data"]
+    assert suggestion is not None
+    assert suggestion["reason"] == "hygiene"
+    assert suggestion["interval_months"] == 6
+    assert suggestion["matched_setting"] is True

--- a/backend/tests/modules/recalls/test_uninstall_roundtrip.py
+++ b/backend/tests/modules/recalls/test_uninstall_roundtrip.py
@@ -1,0 +1,86 @@
+"""Recalls round-trip uninstall test (issue #62).
+
+Mirrors ``backend/tests/test_uninstall_roundtrip.py``'s schedules
+scenario: install → uninstall → reinstall must drop only the recalls
+tables and leave every other module untouched.
+
+Marked ``alembic_roundtrip`` and excluded from the default pytest run
+(same policy as the other migration round-trip suites).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.config import settings
+
+pytestmark = pytest.mark.alembic_roundtrip
+
+BACKEND_ROOT = Path(__file__).resolve().parents[3]
+ALEMBIC_INI = BACKEND_ROOT / "alembic.ini"
+
+RECALLS_TABLES = {
+    "recalls",
+    "recall_contact_attempts",
+    "recall_settings",
+}
+
+
+def _alembic(*args: str) -> None:
+    subprocess.run(
+        ["alembic", "-c", str(ALEMBIC_INI), *args],
+        cwd=BACKEND_ROOT,
+        check=True,
+    )
+
+
+def _dsn() -> str:
+    return settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _list_tables_async() -> set[str]:
+    conn = await asyncpg.connect(_dsn())
+    try:
+        rows = await conn.fetch(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name != 'alembic_version'"
+        )
+        return {row["table_name"] for row in rows}
+    finally:
+        await conn.close()
+
+
+def _list_tables() -> set[str]:
+    return asyncio.run(_list_tables_async())
+
+
+def test_recalls_uninstall_roundtrip_is_branch_scoped() -> None:
+    """install → uninstall → reinstall drops only recalls tables."""
+    _alembic("upgrade", "heads")
+    before = _list_tables()
+    assert RECALLS_TABLES.issubset(before), (
+        f"expected recalls tables at heads; missing: {RECALLS_TABLES - before}"
+    )
+    baseline_other = before - RECALLS_TABLES
+
+    _alembic("downgrade", "recalls@-1")
+
+    after_down = _list_tables()
+    assert RECALLS_TABLES.isdisjoint(after_down), (
+        f"recalls tables survived downgrade: {RECALLS_TABLES & after_down}"
+    )
+    assert baseline_other <= after_down, (
+        "downgrade leaked into other modules; missing: "
+        f"{baseline_other - after_down}"
+    )
+
+    _alembic("upgrade", "recalls@head")
+    after_up = _list_tables()
+    assert before <= after_up, (
+        f"reinstall did not restore every table; missing: {before - after_up}"
+    )

--- a/backend/tests/modules/recalls/test_uninstall_roundtrip.py
+++ b/backend/tests/modules/recalls/test_uninstall_roundtrip.py
@@ -75,8 +75,7 @@ def test_recalls_uninstall_roundtrip_is_branch_scoped() -> None:
         f"recalls tables survived downgrade: {RECALLS_TABLES & after_down}"
     )
     assert baseline_other <= after_down, (
-        "downgrade leaked into other modules; missing: "
-        f"{baseline_other - after_down}"
+        f"downgrade leaked into other modules; missing: {baseline_other - after_down}"
     )
 
     _alembic("upgrade", "recalls@head")

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -12,13 +12,13 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 |-------|----------|------------|-------------|
 | `agenda.visit_note_updated` | `EventType.AGENDA_VISIT_NOTE_UPDATED` | — | `patient_timeline` |
 | `appointment.cabinet_changed` | `EventType.APPOINTMENT_CABINET_CHANGED` | — | — |
-| `appointment.cancelled` | `EventType.APPOINTMENT_CANCELLED` | — | `notifications`, `patient_timeline`, `schedules` |
+| `appointment.cancelled` | `EventType.APPOINTMENT_CANCELLED` | — | `notifications`, `patient_timeline`, `recalls`, `schedules` |
 | `appointment.checked_in` | `EventType.APPOINTMENT_CHECKED_IN` | — | `patient_timeline` |
-| `appointment.completed` | `EventType.APPOINTMENT_COMPLETED` | — | `patient_timeline`, `treatment_plan` |
+| `appointment.completed` | `EventType.APPOINTMENT_COMPLETED` | — | `patient_timeline`, `recalls`, `treatment_plan` |
 | `appointment.confirmed` | `EventType.APPOINTMENT_CONFIRMED` | — | `patient_timeline` |
 | `appointment.in_treatment` | `EventType.APPOINTMENT_IN_TREATMENT` | — | `patient_timeline` |
 | `appointment.no_show` | `EventType.APPOINTMENT_NO_SHOW` | — | `patient_timeline` |
-| `appointment.scheduled` | `EventType.APPOINTMENT_SCHEDULED` | — | `notifications`, `patient_timeline`, `schedules` |
+| `appointment.scheduled` | `EventType.APPOINTMENT_SCHEDULED` | — | `notifications`, `patient_timeline`, `recalls`, `schedules` |
 | `appointment.status_changed` | `EventType.APPOINTMENT_STATUS_CHANGED` | — | — |
 | `appointment.updated` | `EventType.APPOINTMENT_UPDATED` | — | `schedules` |
 | `budget.accepted` | `EventType.BUDGET_ACCEPTED` | — | `notifications`, `patient_timeline`, `treatment_plan` |
@@ -53,12 +53,17 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `odontogram.treatment.deleted` | `EventType.ODONTOGRAM_TREATMENT_DELETED` | — | — |
 | `odontogram.treatment.performed` | `EventType.ODONTOGRAM_TREATMENT_PERFORMED` | — | `budget`, `patient_timeline`, `treatment_plan` |
 | `odontogram.treatment.status_changed` | `EventType.ODONTOGRAM_TREATMENT_STATUS_CHANGED` | — | — |
-| `patient.archived` | `EventType.PATIENT_ARCHIVED` | — | `media` |
+| `patient.archived` | `EventType.PATIENT_ARCHIVED` | — | `media`, `recalls` |
 | `patient.created` | `EventType.PATIENT_CREATED` | — | `notifications` |
 | `patient.medical_updated` | `EventType.PATIENT_MEDICAL_UPDATED` | — | `patient_timeline` |
 | `patient.updated` | `EventType.PATIENT_UPDATED` | — | — |
 | `payment.recorded` | `EventType.PAYMENT_RECORDED` | — | — |
 | `payment.voided` | `EventType.PAYMENT_VOIDED` | — | — |
+| `recall.cancelled` | `EventType.RECALL_CANCELLED` | — | — |
+| `recall.completed` | `EventType.RECALL_COMPLETED` | — | — |
+| `recall.created` | `EventType.RECALL_CREATED` | — | — |
+| `recall.due` | `EventType.RECALL_DUE` | — | — |
+| `recall.snoozed` | `EventType.RECALL_SNOOZED` | — | — |
 | `treatment.completed` | `EventType.TREATMENT_COMPLETED` | — | — |
 | `treatment_plan.budget_sync_requested` | `EventType.TREATMENT_PLAN_BUDGET_SYNC_REQUESTED` | — | `budget` |
 | `treatment_plan.closed` | `EventType.TREATMENT_PLAN_CLOSED` | — | `patient_timeline` |
@@ -69,7 +74,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `treatment_plan.reactivated` | `EventType.TREATMENT_PLAN_REACTIVATED` | — | `patient_timeline` |
 | `treatment_plan.status_changed` | `EventType.TREATMENT_PLAN_STATUS_CHANGED` | — | — |
 | `treatment_plan.treatment_added` | `EventType.TREATMENT_PLAN_TREATMENT_ADDED` | — | `budget` |
-| `treatment_plan.treatment_completed` | `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED` | — | `patient_timeline` |
+| `treatment_plan.treatment_completed` | `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED` | — | `patient_timeline`, `recalls` |
 | `treatment_plan.treatment_removed` | `EventType.TREATMENT_PLAN_TREATMENT_REMOVED` | — | `budget` |
 | `verifactu.record.rejected` | `EventType.VERIFACTU_RECORD_REJECTED` | — | — |
 
@@ -95,6 +100,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
+  - `recalls`
   - `schedules`
 
 ### `appointment.checked_in`
@@ -110,6 +116,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Publishers:** _none in tree — declared but unused_
 - **Subscribers:**
   - `patient_timeline`
+  - `recalls`
   - `treatment_plan`
 
 ### `appointment.confirmed`
@@ -140,6 +147,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
+  - `recalls`
   - `schedules`
 
 ### `appointment.status_changed`
@@ -379,6 +387,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Publishers:** _none in tree — declared but unused_
 - **Subscribers:**
   - `media`
+  - `recalls`
 
 ### `patient.created`
 
@@ -409,6 +418,36 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `payment.voided`
 
 - **Constant:** `EventType.PAYMENT_VOIDED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `recall.cancelled`
+
+- **Constant:** `EventType.RECALL_CANCELLED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `recall.completed`
+
+- **Constant:** `EventType.RECALL_COMPLETED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `recall.created`
+
+- **Constant:** `EventType.RECALL_CREATED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `recall.due`
+
+- **Constant:** `EventType.RECALL_DUE`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `recall.snoozed`
+
+- **Constant:** `EventType.RECALL_SNOOZED`
 - **Publishers:** _none in tree — declared but unused_
 - **Subscribers:** —
 
@@ -485,6 +524,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Publishers:** _none in tree — declared but unused_
 - **Subscribers:**
   - `patient_timeline`
+  - `recalls`
 
 ### `treatment_plan.treatment_removed`
 

--- a/docs/features/recalls.md
+++ b/docs/features/recalls.md
@@ -1,0 +1,225 @@
+# Recalls — patient call-back workflow
+
+> Status: planned (issue #62). Module: `recalls`. Spec last updated:
+> 2026-05-01.
+
+## Why
+
+When a patient leaves the clinic without booking the next visit
+(hygiene, check-up, ortho review, implant follow-up, post-op control),
+there is no structured way to bring them back. Receptionists rely on
+memory, sticky notes, or ad-hoc spreadsheets. Patients fall through
+the cracks → lost revenue and worse continuity of care.
+
+The clinic needs a first-class **recalls** workflow:
+
+- Mark a patient to be called in month *X* with a reason and an
+  assigned professional.
+- Work a reliable monthly **call list** with filters and inline
+  actions.
+- Track every contact attempt so a patient is not called five times
+  in two days — or forgotten for a year.
+- Auto-link the booked appointment back to the recall so reception
+  can see the loop closed at a glance.
+- Reduce manual entry: many recalls should be auto-suggested from
+  completed treatments (hygiene → +6 months, post-op → +1 week).
+
+The feature is operational, not marketing — it does not run
+campaigns, it gives front desk a list to work.
+
+## Module placement
+
+A new optional module `recalls` lives at `backend/app/modules/recalls/`
+with a matching Nuxt layer. Placement decisions:
+
+| Manifest field   | Value                  |
+|------------------|------------------------|
+| `depends`        | `["patients", "agenda"]` |
+| `installable`    | `True`                 |
+| `auto_install`   | `True`                 |
+| `removable`      | `True`                 |
+| `category`       | `"official"`           |
+
+Sibling to agenda + patients, *not* embedded inside agenda. The recall
+state machine, monthly list workflow, and `recall.*` events are
+independent of the appointment lifecycle and deserve their own module.
+The future outreach module will subscribe to `recall.*` events without
+touching agenda.
+
+## What we build (in V1)
+
+### Data
+
+- `recalls` table (per-clinic, per-patient): `due_month` (day-1 of
+  target month, indexed), optional `due_date`, `reason` enum,
+  `reason_note`, `priority`, `status`, `recommended_by`,
+  `assigned_professional_id`, `last_contact_attempt_at`,
+  `contact_attempt_count`, `linked_appointment_id`,
+  `linked_treatment_id` (no FK — snapshot only),
+  `linked_treatment_category_key` (snapshot string), timestamps.
+- `recall_contact_attempts` table: per-attempt log
+  (`channel`, `outcome`, `note`, `attempted_at`, `attempted_by`).
+- `recall_settings` table (per-clinic, JSONB): `reason_intervals`,
+  `category_to_reason`, two automation toggles.
+
+### Lifecycle (status transitions)
+
+```
+pending ───log_attempt(no_answer/voicemail/wrong_number)──► contacted_no_answer
+       │                                                           │
+       ├──link_appointment / log_attempt(scheduled)────► contacted_scheduled
+       │                                                           │
+       │                                          appointment.completed
+       │                                                           │
+       ├──log_attempt(declined)────► contacted_declined            ▼
+       │                                                          done
+       ├──cancel ───► cancelled
+       │
+       ▼
+   needs_review  (set by patient.archived or do_not_contact rules)
+```
+
+Snooze bumps `due_month` forward N months, keeps status `pending`.
+
+### Entry points
+
+- **Patient record** — "Set recall" action in summary hero (slot
+  `patient.summary.actions`).
+- **Appointment close-out** — when transitioning an appointment to
+  `completed`, AppointmentModal renders any components in the
+  `appointment.completed.followup` slot. Recalls registers a
+  "Schedule a recall?" prompt.
+- **Treatment plan / odontogram per item** — slot
+  `odontogram.condition.actions` (existing). Pre-fills reason from
+  the treatment's category.
+- **Auto-suggest** — recalls listens to
+  `treatment_plan.treatment_completed`. If the clinic's mapping has
+  the treatment's category → a reason, surfaces a non-blocking
+  suggestion in `patient.summary.feed`. Never auto-creates without
+  user confirmation.
+
+### Monthly call list (`/recalls`)
+
+- Default: current month, status `pending`, sorted by priority + due
+  date.
+- Filters: month, reason, professional, status, priority, overdue
+  toggle, patient.
+- Counters strip: due this week, overdue, scheduled this month,
+  conversion rate.
+- Per-row inline actions: click-to-call (`tel:` on mobile), log
+  attempt (one tap for "no answer"), book appointment (opens agenda
+  composer pre-filled, links recall on save), snooze, cancel.
+- Bulk actions: export CSV, bulk snooze, bulk reassign professional.
+- Mobile-first: collapses to single column, touch targets ≥44px.
+
+### Patient-side surfaces
+
+- Recall pill in summary hero (next due month + reason).
+- History card in summary feed (last 5 recalls, link to filtered
+  `/recalls`).
+- No new patient-detail tab — keeps the existing 5-tab layout.
+
+### Settings (per clinic)
+
+A settings section `Recordatorios` registered into the existing
+`settings.sections` slot:
+
+- Default intervals per reason (hygiene 6mo, checkup 12mo,
+  ortho_review 1mo, implant_review 6mo, post_op 1wk,
+  treatment_followup 3mo, other 3mo).
+- Treatment-category → recall-reason map (preventivo→hygiene,
+  ortodoncia→ortho_review, cirugia→post_op, …).
+- Toggle: auto-suggest on treatment completion (default on).
+- Toggle: auto-link on appointment scheduled (default on).
+
+### Permissions
+
+| Permission        | Default roles                                                    |
+|-------------------|------------------------------------------------------------------|
+| `recalls.read`    | admin, dentist, hygienist, assistant, receptionist               |
+| `recalls.write`   | admin, dentist, hygienist, assistant, receptionist               |
+| `recalls.delete`  | admin                                                            |
+
+### Events published
+
+| Event              | When                                                |
+|--------------------|-----------------------------------------------------|
+| `recall.created`   | new recall row inserted (duplicate-guard fired = no event) |
+| `recall.due`       | reserved for future cron; not published in V1       |
+| `recall.completed` | recall transitions to `done`                        |
+| `recall.snoozed`   | recall snoozed N months                             |
+| `recall.cancelled` | recall cancelled (manual or by `patient.archived`)  |
+
+These are the foundation for the future outreach module
+(WhatsApp/SMS/email automation) — that work is a separate issue.
+
+### Events consumed
+
+| Event                              | Effect                                                                 |
+|------------------------------------|------------------------------------------------------------------------|
+| `appointment.scheduled`            | Auto-link a pending recall if (patient, due_month) overlaps. Best-effort: agenda's `treatment_type` is free-text so reason match isn't reliable. |
+| `appointment.completed`            | If linked to a recall in `contacted_scheduled`, transition to `done`.  |
+| `appointment.cancelled`            | Unlink recall, revert to `pending`, log synthetic attempt note.        |
+| `treatment_plan.treatment_completed` | Look up reason mapping, surface non-blocking suggestion in patient feed. |
+| `patient.archived`                 | Active recalls for the patient → `needs_review` (not deleted).         |
+
+### Module isolation contract
+
+- Cross-module FKs only to `patients.id` and `appointments.id`.
+- `linked_treatment_id` stored without FK; treatment_plan is *not* in
+  `depends`. The treatment category arrives via
+  `treatment_plan.treatment_completed` payload (enriched at
+  publish-time in treatment_plan).
+- New slots added by this PR:
+  - `patient.summary.actions` (host: patients module)
+  - `appointment.completed.followup` (host: agenda module)
+- Slots reused from existing modules:
+  `patient.summary.feed`, `odontogram.condition.actions`,
+  `dashboard.attention`, `settings.sections`.
+- Agenda gains a small `initialRecallId` prop on `AppointmentModal`
+  so booking from a recall row links the resulting appointment back
+  on save.
+
+## What we don't build (out of scope)
+
+- Outbound automation (WhatsApp / SMS / email). A future module will
+  subscribe to `recall.*` events.
+- Online self-booking from a recall link.
+- Marketing-style mass recalls.
+- Patient `deceased` status + GDPR erasure markers — separate issue.
+  In V1 we filter `Patient.status = "archived"` and the new
+  `Patient.do_not_contact = true` flag.
+- Cron-driven `recall.due` event. The enum value is reserved.
+- Backup-on-uninstall data dump. Uninstall drops the three tables.
+
+## Acceptance criteria (mirrors issue #62)
+
+- [ ] Recall created from patient record, appointment close-out, and
+  treatment plan / odontogram, with reason + month + optional note.
+- [ ] `/recalls` lists current month's pending recalls with filters
+  and inline actions.
+- [ ] Click-to-call works on mobile; logging "no answer" is one tap.
+- [ ] Booking an appointment from a recall row pre-fills agenda
+  composer and links the appointment back on save.
+- [ ] Completing the linked appointment auto-closes the recall and
+  surfaces the next-recall suggestion when settings map to one.
+- [ ] Duplicate-recall guard updates the existing pending recall
+  instead of creating a new row for the same `(patient, reason)`.
+- [ ] Patients with `status = archived` or `do_not_contact = true`
+  are excluded from the active call list and surface in
+  `needs_review`.
+- [ ] Permissions enforced on every endpoint.
+- [ ] Module is installable and removable cleanly (round-trip
+  uninstall test passes).
+- [ ] Events `recall.{created,completed,snoozed,cancelled}` published.
+- [ ] Dashboard widget shows due / overdue / conversion counters.
+- [ ] Mobile-first responsive on the call list.
+
+## Related
+
+- Issue: <https://github.com/martinezsalmeron/dentalpin/issues/62>
+- ADRs: `docs/adr/0001-modular-plugin-architecture.md`,
+  `docs/adr/0003-event-bus-over-direct-imports.md`,
+  `docs/adr/0005-relative-permissions.md`.
+- Glossary: `docs/glossary.md` — recall ↔ recordatorio, call list ↔
+  lista de llamadas, snooze ↔ posponer, recall reason ↔ motivo.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -39,6 +39,17 @@ ADRs) for the full story.
 | Clinic hours | Horario de clínica | Open/closed slots defined in the schedules module. |
 | Professional hours | Horario del profesional | Optional per-professional availability override. |
 
+## Recalls
+
+| EN (code) | ES (UI) | Definition |
+|---|---|---|
+| Recall | Recordatorio | A scheduled call-back for a patient who left without booking the next visit. Owned by the `recalls` module. |
+| Call list | Lista de llamadas | The monthly worked list at `/recalls`. Front desk works it row by row. |
+| Recall reason | Motivo de recordatorio | Why the patient is being recalled (`hygiene`, `checkup`, `ortho_review`, `implant_review`, `post_op`, `treatment_followup`, `other`). |
+| Snooze | Posponer | Bump a recall's `due_month` forward N months without losing its history. |
+| Contact attempt | Intento de contacto | One row in `recall_contact_attempts`: channel + outcome + note. Logged every time the front desk reaches out. |
+| Needs review | Revisar | Bucket for recalls whose patient was archived or marked `do_not_contact` after the recall existed — surfaced in a separate filter, not deleted. |
+
 ## Billing
 
 | EN (code) | ES (UI) | Definition |

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -21,6 +21,7 @@ Maintained by `backend/scripts/generate_catalogs.py`. CI fails if a manifest cha
 | `patient_timeline` | 0.1.0 | official | patients | auto | no | 1 | 0 | 32 | yes |
 | `patients` | 0.1.0 | official | — | auto | no | 2 | 0 | 0 | yes |
 | `patients_clinical` | 0.1.0 | official | patients | auto | no | 4 | 0 | 0 | yes |
+| `recalls` | 0.1.0 | official | patients, agenda | auto | yes | 3 | 0 | 5 | yes |
 | `reports` | 0.1.0 | official | patients, agenda, catalog, budget, billing | auto | no | 3 | 0 | 0 | yes |
 | `schedules` | 0.1.0 | official | agenda | auto | yes | 8 | 0 | 3 | yes |
 | `treatment_plan` | 0.1.0 | official | patients, agenda, odontogram, catalog, budget, media | auto | no | 5 | 0 | 5 | yes |
@@ -262,6 +263,28 @@ Normalized medical history, allergies, medications, emergency contacts.
   - `patients_clinical.medical.write`
 - **Events emitted:** —
 - **Events consumed:** —
+
+### `recalls` — v0.1.0
+
+Patient recalls: schedule call-backs, work the monthly call list, log attempts, auto-link booked appointments.
+
+- **Author:** DentalPin Core Team
+- **License:** BSL-1.1
+- **Category:** official
+- **Install policy:** installable=True · auto_install=True · removable=True
+- **Depends:** `patients`, `agenda`
+- **Frontend layer:** `frontend`
+- **Permissions:**
+  - `recalls.recalls.delete`
+  - `recalls.recalls.read`
+  - `recalls.recalls.write`
+- **Events emitted:** —
+- **Events consumed:**
+  - `appointment.cancelled`
+  - `appointment.completed`
+  - `appointment.scheduled`
+  - `patient.archived`
+  - `treatment_plan.treatment_completed`
 
 ### `reports` — v0.1.0
 

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -146,6 +146,7 @@ export interface Patient {
   date_of_birth?: string
   notes?: string
   status: 'active' | 'archived'
+  do_not_contact: boolean
   // Billing fields
   billing_name?: string
   billing_tax_id?: string
@@ -163,6 +164,7 @@ export interface PatientCreate {
   email?: string
   date_of_birth?: string
   notes?: string
+  do_not_contact?: boolean
   // Billing fields
   billing_name?: string
   billing_tax_id?: string
@@ -172,6 +174,7 @@ export interface PatientCreate {
 
 export interface PatientUpdate extends Partial<PatientCreate> {
   status?: 'active' | 'archived'
+  do_not_contact?: boolean
 }
 
 // Appointment treatment brief (from planned treatment item)

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -16,6 +16,7 @@
     "dashboard": "Home",
     "patients": "Patients",
     "appointments": "Schedule",
+    "recalls": "Recalls",
     "treatmentPlans": "Treatment Plans",
     "budgets": "Quotes",
     "invoices": "Invoices",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -102,6 +102,11 @@
       "active": "Active",
       "archived": "Archived"
     },
+    "doNotContact": {
+      "label": "Do not contact",
+      "hint": "Patient will be excluded from the call list and automated outreach",
+      "badge": "Do not contact"
+    },
     "gender": {
       "label": "Gender",
       "select": "Select gender",
@@ -693,6 +698,9 @@
     "confirmNoShowMessage": "Mark this patient as no show? The change will be logged.",
     "noteLabel": "Note (optional)",
     "transitionFailed": "Could not change appointment status",
+    "followup": {
+      "title": "Post-appointment actions"
+    },
     "created": "Appointment created",
     "saved": "Appointment saved",
     "updated": "Appointment updated",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -699,6 +699,9 @@
     "confirmNoShowMessage": "Mark this patient as no show? The change will be logged.",
     "noteLabel": "Note (optional)",
     "transitionFailed": "Could not change appointment status",
+    "when": "When",
+    "whereWho": "Cabinet and professional",
+    "notesPlaceholder": "Internal details for the team",
     "followup": {
       "title": "Post-appointment actions"
     },

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -720,6 +720,9 @@
     "confirmNoShowMessage": "¿Marcar al paciente como no asistido? Se registrará en el historial.",
     "noteLabel": "Nota (opcional)",
     "transitionFailed": "No se pudo cambiar el estado de la cita",
+    "when": "Cuándo",
+    "whereWho": "Gabinete y profesional",
+    "notesPlaceholder": "Detalles internos para el equipo",
     "followup": {
       "title": "Acciones tras finalizar la cita"
     },

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -16,6 +16,7 @@
     "dashboard": "Inicio",
     "patients": "Pacientes",
     "appointments": "Agenda",
+    "recalls": "Recordatorios",
     "treatmentPlans": "Planes de tratamiento",
     "budgets": "Presupuestos",
     "invoices": "Facturas",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -102,6 +102,11 @@
       "active": "Activo",
       "archived": "Archivado"
     },
+    "doNotContact": {
+      "label": "No contactar",
+      "hint": "El paciente no aparecerá en la lista de llamadas ni en envíos automatizados",
+      "badge": "No contactar"
+    },
     "gender": {
       "label": "Género",
       "select": "Seleccionar género",
@@ -714,6 +719,9 @@
     "confirmNoShowMessage": "¿Marcar al paciente como no asistido? Se registrará en el historial.",
     "noteLabel": "Nota (opcional)",
     "transitionFailed": "No se pudo cambiar el estado de la cita",
+    "followup": {
+      "title": "Acciones tras finalizar la cita"
+    },
     "created": "Cita creada",
     "saved": "Cita guardada",
     "updated": "Cita actualizada",

--- a/frontend/modules.json
+++ b/frontend/modules.json
@@ -13,7 +13,8 @@
     "/module_layers/reports/frontend",
     "/module_layers/schedules/frontend",
     "/module_layers/treatment_plan/frontend",
-    "/module_layers/clinical_notes/frontend"
+    "/module_layers/clinical_notes/frontend",
+    "/module_layers/recalls/frontend"
   ],
   "modules": [
     {
@@ -71,6 +72,10 @@
     {
       "name": "clinical_notes",
       "path": "/module_layers/clinical_notes/frontend"
+    },
+    {
+      "name": "recalls",
+      "path": "/module_layers/recalls/frontend"
     }
   ],
   "version": 1

--- a/frontend/modules.json
+++ b/frontend/modules.json
@@ -10,11 +10,11 @@
     "/module_layers/notifications/frontend",
     "/module_layers/patient_timeline/frontend",
     "/module_layers/patients_clinical/frontend",
+    "/module_layers/recalls/frontend",
     "/module_layers/reports/frontend",
     "/module_layers/schedules/frontend",
     "/module_layers/treatment_plan/frontend",
-    "/module_layers/clinical_notes/frontend",
-    "/module_layers/recalls/frontend"
+    "/module_layers/clinical_notes/frontend"
   ],
   "modules": [
     {
@@ -58,6 +58,10 @@
       "path": "/module_layers/patients_clinical/frontend"
     },
     {
+      "name": "recalls",
+      "path": "/module_layers/recalls/frontend"
+    },
+    {
       "name": "reports",
       "path": "/module_layers/reports/frontend"
     },
@@ -72,10 +76,6 @@
     {
       "name": "clinical_notes",
       "path": "/module_layers/clinical_notes/frontend"
-    },
-    {
-      "name": "recalls",
-      "path": "/module_layers/recalls/frontend"
     }
   ],
   "version": 1


### PR DESCRIPTION
## Summary
- New optional module `recalls` (`depends: ["patients", "agenda"]`, `auto_install=True`, `removable=True`) — call-back workflow + monthly call list at `/recalls`. Issue #62.
- Backend: 3 tables (`recalls`, `recall_contact_attempts`, `recall_settings`), service + router (~17 endpoints), 5 event subscribers, conservative auto-link (only fires when exactly 1 active recall matches), auto-close on `appointment.completed`, settings registry page at `/settings/clinical/recalls`.
- Frontend: full Nuxt layer — `/recalls` page with month picker, filters, counters, CSV export, plus slot contributions on patient hero (CTA + inline next-active card with `do_not_contact` opt-out banner), patient summary feed, dashboard, settings.
- Cross-cutting: `patients` gains `do_not_contact: bool` (migration `pat_0002`), `treatment_plan` enriches `treatment_plan.treatment_completed` payload with `treatment_category_key`, agenda gains `appointment.completed.followup` slot + `CompletionFollowupHost` consumed by both QuickActions and Kanban drag-drop.
- Agenda fix: migration `ag_0004` relaxes `idx_appointment_slot` to exclude `cancelled`/`completed`/`no_show` so terminal statuses don't block cabinet reassignment.
- Demo seed: `seed_recalls_demo` produces 15 recalls across all statuses + 10 attempts.
- Spec doc: `docs/features/recalls.md`. Glossary updated (recall ↔ recordatorio, etc.). Catalogs regenerated (16 modules, 67 events).
- Tests: 8 router tests + alembic round-trip uninstall (CI-only mark). Full backend suite 527 passed; frontend ESLint clean.

## Test plan
- [ ] `./scripts/reset-db.sh && ./scripts/seed-demo.sh` — recalls demo seeds 15 across all statuses
- [ ] Login `admin@demo.clinic / demo1234`, sidebar shows "Recordatorios" entry
- [ ] `/recalls` — counters strip, filter month/reason/status/priority/overdue, row actions (call / log attempt / book / snooze / cancel / mark done), CSV export
- [ ] Patient hero shows "Programar recordatorio" CTA + inline active-recall card; `do_not_contact` patients see opt-out banner instead
- [ ] Set Recall modal: reason tiles, month picker + shortcuts, priority segmented, optional date + note
- [ ] Auto-link: create new appointment for patient with exactly 1 active recall → `pending → contacted_scheduled`; with ≥2 active → no-op
- [ ] Auto-close: transition appointment to `completed` (via QuickActions or Kanban drag-drop) → `RecallCloseoutPrompt` modal opens; linked recall → `done`
- [ ] `/settings/clinical/recalls` settings page (intervals + category map + auto-suggest + auto-link toggles)
- [ ] Round-trip uninstall: `alembic downgrade recalls@-1` drops 3 tables, `alembic upgrade recalls@head` restores
- [ ] Agenda: drag appointment to "Finalizadas" column on cabinets previously occupied by `completed` rows — no longer 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)