### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,84 +1,104 @@
+version: "3.9"
+
 services:
+
   db:
     image: postgres:15-alpine
+    container_name: dentalpin-db
+
+    restart: unless-stopped
+
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-dental_clinic}
-      POSTGRES_USER: ${POSTGRES_USER:-dental}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: dental_clinic
+      POSTGRES_USER: dental
+      POSTGRES_PASSWORD: Bokloz55
+
     ports:
       - "5432:5432"
+
     volumes:
       - pgdata:/var/lib/postgresql/data
+
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dental} -d ${POSTGRES_DB:-dental_clinic}"]
+      test: ["CMD-SHELL", "pg_isready -U dental -d dental_clinic"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
-    restart: unless-stopped
+
+    networks:
+      - yahia-net
+
+
 
   backend:
-    build: ./backend
-    environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-dental}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-dental_clinic}
-      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env}
-      ENVIRONMENT: ${ENVIRONMENT:-development}
-      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-}
-      STORAGE_BACKEND: ${STORAGE_BACKEND:-local}
-      STORAGE_LOCAL_PATH: ${STORAGE_LOCAL_PATH:-/app/storage}
-    ports:
-      - "8000:8000"
+    build:
+      context: ./backend
+
+    container_name: dentalpin-backend
+
+    restart: unless-stopped
+
     depends_on:
       db:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=2).status == 200 else 1)"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 60s
-    restart: unless-stopped
+
+    environment:
+      DATABASE_URL: postgresql+asyncpg://dental:Bokloz55@db:5432/dental_clinic
+      SECRET_KEY: Bokloz55
+      ENVIRONMENT: development
+      ALLOWED_ORIGINS: "*"
+      STORAGE_BACKEND: local
+      STORAGE_LOCAL_PATH: /app/storage
+
+    ports:
+      - "8040:8000"
+
     volumes:
-      - ./backend:/app
       - storage_data:/app/storage
-      # Mount the frontend root read-write so the backend can regenerate
-      # modules.json when a module with a Nuxt layer is installed.
-      - ./frontend:/host_frontend
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --proxy-headers --forwarded-allow-ips=*
+
+    command: >
+      uvicorn app.main:app
+      --host 0.0.0.0
+      --port 8000
+      --reload
+
+    networks:
+      - yahia-net
+
+
 
   frontend:
     build:
       context: ./frontend
-      target: builder
-      args:
-        API_BASE_URL: http://localhost:8000
+
+    container_name: dentalpin-frontend
+
+    restart: unless-stopped
+
+    depends_on:
+      - backend
+
     environment:
       NITRO_HOST: 0.0.0.0
       NITRO_PORT: 3000
-      NUXT_PUBLIC_API_BASE_URL: http://localhost:8000
-      NODE_OPTIONS: --max-old-space-size=4096
+      NUXT_PUBLIC_API_BASE_URL: http://localhost:8040
+
     ports:
       - "3000:3000"
-    depends_on:
-      backend:
-        condition: service_started
-    volumes:
-      - ./frontend:/app
-      # Mount backend module packages read-only so Nuxt can `extends`
-      # each module's layer (declared via `manifest.frontend.layer_path`).
-      # The backend writes absolute paths under this mount into
-      # `frontend/modules.json`.
-      - ./backend/app/modules:/module_layers:ro
-      - /app/node_modules
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 60s
-    restart: unless-stopped
+
     command: npm run dev
+
+    networks:
+      - yahia-net
+
+
 
 volumes:
   pgdata:
   storage_data:
+
+
+
+networks:
+  yahia-net:
+    external: true


### PR DESCRIPTION
<!--
PR template for DentalPin. The checklist enforces conventions documented
in CLAUDE.md and docs/checklists/. Tick boxes that apply; strike through
the rest. Reviewers: don't approve while a relevant box is unchecked.
-->

## Summary

<!-- 1–3 bullets. What and why, not how. -->

-

## Modules touched

<!-- e.g. patients, billing/, frontend layer for schedules, none -->

-

## Checklist

### Always

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
- [ ] `cd backend && ruff check . && ruff format --check .` passes
- [ ] `cd frontend && npm run lint` passes
- [ ] Tests added or updated when behaviour changed
- [ ] No cross-module imports outside `manifest.depends`

### If a new module was added

- [ ] Entry point registered in `backend/pyproject.toml` (`[project.entry-points."dentalpin.modules"]`)
- [ ] `backend/app/modules/<name>/CLAUDE.md` written (purpose, public API, events, permissions, gotchas)
- [ ] `backend/app/modules/<name>/CHANGELOG.md` started
- [ ] Alembic migrations live on the module's own branch (`branch_labels=("<name>",)`)
- [ ] `python backend/scripts/generate_catalogs.py` re-run, `docs/modules-catalog.md` and `docs/events-catalog.md` updated
- [ ] If `removable=True`: uninstall round-trip test added (see `backend/tests/test_uninstall_roundtrip.py`)

### If events were added or changed

- [ ] New event added to `backend/app/core/events/types.py` `EventType`
- [ ] `python backend/scripts/generate_catalogs.py` re-run
- [ ] Payload shape documented in module CLAUDE.md (publishers + consumers)

### If permissions were added or changed

- [ ] Returned by module `get_permissions()` (no module prefix; registry adds it)
- [ ] Listed in `manifest.role_permissions`
- [ ] If user-facing: added to `frontend/app/config/permissions.ts`
- [ ] Endpoint protected with `require_permission("module.resource.action")`

### If a cross-module FK was introduced

- [ ] Target module is in `manifest.depends`
- [ ] CI `manifest-consistency` is green

### If an architectural decision was made

- [ ] ADR added under `docs/adr/NNNN-title.md` (copy `docs/adr/TEMPLATE.md`)

### If a new domain term was introduced

- [ ] Appended to `docs/glossary.md` (ES ↔ EN)

### If a touched module already exists

- [ ] Its `backend/app/modules/<name>/CHANGELOG.md` updated under `## Unreleased`

## Test plan

<!-- How a reviewer would verify this end-to-end. -->

- [ ]
