### PR TITLE
feat(notifications): multi-channel gateway + outbox (Phase 1, #63)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -67,11 +67,12 @@ from app.modules.catalog.models import (  # noqa: F401
 )
 from app.modules.media.models import Document, MediaAttachment  # noqa: F401
 from app.modules.notifications.models import (  # noqa: F401
+    ClinicChannelSettings,
     ClinicNotificationSettings,
     ClinicSmtpSettings,
-    EmailLog,
-    EmailTemplate,
+    CommunicationMessage,
     NotificationPreference,
+    NotificationTemplate,
 )
 from app.modules.odontogram.models import (  # noqa: F401
     OdontogramHistory,

--- a/backend/app/core/events/types.py
+++ b/backend/app/core/events/types.py
@@ -64,9 +64,19 @@ class EventType:
     # sent_at). Only fired when ``budget_reminders_enabled`` for the clinic.
     BUDGET_REMINDER_SENT = "budget.reminder_sent"
 
-    # Email events
+    # Email events (legacy — kept for one release; see NOTIFICATION_* below).
+    # The notifications gateway dual-publishes these for channel=="email" so
+    # patient_timeline keeps working until it migrates to the generic events.
     EMAIL_SENT = "email.sent"
     EMAIL_FAILED = "email.failed"
+
+    # Notification (multi-channel) lifecycle events — published by the
+    # notifications gateway across every channel (email, whatsapp, …).
+    NOTIFICATION_QUEUED = "notification.queued"
+    NOTIFICATION_SENT = "notification.sent"
+    NOTIFICATION_FAILED = "notification.failed"
+    NOTIFICATION_DELIVERED = "notification.delivered"
+    NOTIFICATION_REPLY_RECEIVED = "notification.reply_received"
 
     # Invoice events
     INVOICE_CREATED = "invoice.created"

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+- feat(multichannel): turn the email-only module into a channel-agnostic
+  gateway. New ``channels/`` package (``ChannelAdapter`` protocol,
+  ``OutboundMessage``/``AdapterResult``, idempotent ``channel_registry``,
+  built-in ``EmailAdapter``). Vendor modules register adapters at import
+  time. See ADR 0016.
+- feat(outbox): ``gateway.NotificationGateway.enqueue`` persists a ``queued``
+  row (no network in-request) and a ``dispatch_outbox`` scheduled job
+  (every 45s) sends with ``FOR UPDATE SKIP LOCKED`` + exponential backoff.
+  ``do_not_contact`` is now a hard block on every channel.
+- refactor(models): ``email_logs`` → ``communication_messages`` (outbox +
+  audit in one table, ``channel``/``attempts``/``next_attempt_at``/
+  ``dedup_key``/delivery timestamps); ``email_templates`` →
+  ``notification_templates`` (``channel`` + ``provider_template_name`` for
+  WhatsApp HSM); per-channel WhatsApp opt-in on ``notification_preferences``;
+  new generic ``clinic_channel_settings``. Alembic ``notif_0002`` (data
+  preserved, ``channel`` backfilled to ``email``).
+- refactor(send-path): handlers, the reminder cron, and the manual-send
+  route now ``enqueue`` instead of sending synchronously; the reminder
+  dedup moved from a ``context_data["appointment_id"]`` scan to a
+  ``dedup_key`` unique index. Removed the dead ``send_notification``/
+  ``create_log`` service methods.
+- feat(events): ``notification.queued/sent/failed/delivered/reply_received``.
+  ``EMAIL_SENT/FAILED`` are dual-published for ``channel=email`` for one
+  release so ``patient_timeline`` keeps working unchanged.
+- feat(agents): ``tools.py`` exposes ``send_notification`` (WRITE) wrapping
+  the gateway; respects consent, never bypasses ``do_not_contact``.
 - refactor(scheduler): declare the ``appointment_reminders`` interval job
   via ``get_scheduled_jobs()`` instead of being imported by name in
   ``app/core/scheduler.py``.

--- a/backend/app/modules/notifications/CLAUDE.md
+++ b/backend/app/modules/notifications/CLAUDE.md
@@ -1,7 +1,26 @@
 # Notifications module
 
-Email templates, preferences, SMTP, event-driven sending. Heavy
-subscriber.
+Multi-channel notification **gateway**: our own communications logic
+(channel resolution, consent, templates, outbox, logging) with pluggable
+adapters that put a rendered message on the wire. Email ships built-in;
+WhatsApp arrives via the `whatsapp_kapso` community module (Phase 2).
+Heavy subscriber + now a publisher. See ADR 0016.
+
+## Architecture
+
+- `channels/` — the **public contract** vendor modules import:
+  `ChannelAdapter` protocol, `OutboundMessage`/`AdapterResult`, `Channel`
+  enum, and the idempotent `channel_registry` (pre-loads `EmailAdapter`).
+  A vendor module `depends=["notifications"]` and calls
+  `channel_registry.register(...)` at import time.
+- `gateway.py` — `NotificationGateway.enqueue` (consent gate → channel
+  resolution → persist `queued` row → publish) and `dispatch_outbox`
+  (the scheduled sender, retry + backoff). **No network in a request.**
+- `service.py` — CRUD for templates/preferences/settings/SMTP + the
+  `should_send_notification` consent check. No send path here anymore.
+- Tables: `communication_messages` (outbox + audit), `notification_templates`,
+  `notification_preferences`, `clinic_notification_settings`,
+  `clinic_channel_settings`, `clinic_smtp_settings`.
 
 ## Public API
 
@@ -20,9 +39,24 @@ settings, logs).
 `notifications.settings.{read,write}`,
 `notifications.logs.read`.
 
+## Tools exposed
+
+Agent tool in `tools.py` (wraps `NotificationGateway`, no logic duplicated).
+
+| Tool | Category | Wraps | Permission |
+|---|---|---|---|
+| `send_notification` | WRITE | `NotificationGateway.enqueue` | `notifications.send` |
+
+Structured params only (cloud-eligible under redaction). Enqueues through
+the full consent path — never bypasses `do_not_contact`.
+
 ## Events emitted
 
-None.
+- `notification.queued` / `notification.sent` / `notification.failed` /
+  `notification.delivered` / `notification.reply_received`.
+- `email.sent` / `email.failed` — **legacy, dual-published** for
+  `channel=email` only, for one release, so `patient_timeline` keeps
+  recording email comms until it migrates to the generic events.
 
 ## Events consumed
 

--- a/backend/app/modules/notifications/__init__.py
+++ b/backend/app/modules/notifications/__init__.py
@@ -6,12 +6,14 @@ from app.core.events.types import EventType
 from app.core.plugins import BaseModule
 from app.core.scheduling import ScheduledJob
 
+from . import channels  # noqa: F401 — registers the built-in EmailAdapter at import
 from .models import (
+    ClinicChannelSettings,
     ClinicNotificationSettings,
     ClinicSmtpSettings,
-    EmailLog,
-    EmailTemplate,
+    CommunicationMessage,
     NotificationPreference,
+    NotificationTemplate,
 )
 from .router import router
 
@@ -52,18 +54,24 @@ class NotificationsModule(BaseModule):
 
     def get_models(self) -> list:
         return [
-            EmailTemplate,
+            NotificationTemplate,
             NotificationPreference,
             ClinicNotificationSettings,
+            ClinicChannelSettings,
             ClinicSmtpSettings,
-            EmailLog,
+            CommunicationMessage,
         ]
 
     def get_router(self) -> APIRouter:
         return router
 
+    def get_tools(self) -> list:
+        from . import tools
+
+        return tools.get_tools()
+
     def get_scheduled_jobs(self) -> list[ScheduledJob]:
-        from .tasks import process_appointment_reminders
+        from .tasks import dispatch_outbox, process_appointment_reminders
 
         return [
             ScheduledJob(
@@ -72,6 +80,13 @@ class NotificationsModule(BaseModule):
                 trigger="interval",
                 trigger_args={"minutes": 5},
                 name="Process appointment reminders (every 5 minutes)",
+            ),
+            ScheduledJob(
+                id="notifications_dispatch_outbox",
+                func=dispatch_outbox,
+                trigger="interval",
+                trigger_args={"seconds": 45},
+                name="Dispatch the notifications outbox (every 45s)",
             ),
         ]
 

--- a/backend/app/modules/notifications/channels/__init__.py
+++ b/backend/app/modules/notifications/channels/__init__.py
@@ -1,0 +1,29 @@
+"""Channel adapter contract + registry (public surface for vendor modules).
+
+Vendors import from here only:
+
+    from app.modules.notifications.channels import (
+        channel_registry, ChannelAdapter, Channel, OutboundMessage, AdapterResult, SendStatus,
+    )
+"""
+
+from .base import (
+    AdapterResult,
+    Channel,
+    ChannelAdapter,
+    OutboundMessage,
+    SendStatus,
+)
+from .email_adapter import EmailAdapter
+from .registry import ChannelRegistry, channel_registry
+
+__all__ = [
+    "AdapterResult",
+    "Channel",
+    "ChannelAdapter",
+    "ChannelRegistry",
+    "EmailAdapter",
+    "OutboundMessage",
+    "SendStatus",
+    "channel_registry",
+]

--- a/backend/app/modules/notifications/channels/base.py
+++ b/backend/app/modules/notifications/channels/base.py
@@ -1,0 +1,109 @@
+"""Channel adapter contract — the public surface vendor modules import.
+
+A *channel* is a way of reaching a patient (email, WhatsApp, …). The
+``notifications`` gateway owns the routing, consent and outbox logic; an
+*adapter* only knows how to put one rendered message on the wire for one
+channel. Vendor modules (e.g. ``whatsapp_kapso``) depend on
+``notifications`` and register their adapter into :mod:`.registry`.
+
+This module is the stable contract: vendors import ``Channel``,
+``OutboundMessage``, ``AdapterResult`` and ``ChannelAdapter`` from here and
+nothing else from the notifications internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class Channel(StrEnum):
+    """Delivery channels the gateway can route to."""
+
+    EMAIL = "email"
+    WHATSAPP = "whatsapp"
+    # SMS and others land here as adapters appear.
+
+
+class SendStatus(StrEnum):
+    """Terminal-ish outcome of a single adapter ``send`` attempt.
+
+    Mirrors ``app.core.email.providers.base.EmailStatus`` so the email
+    path maps 1:1, but uses ``sent`` (the value persisted on
+    ``communication_messages``) rather than ``success``.
+    """
+
+    SENT = "sent"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class OutboundMessage:
+    """A rendered message handed to an adapter for delivery.
+
+    Superset of ``app.core.email.providers.base.EmailMessage``: it carries
+    both the email-shaped fields (``subject``/``body_html``/``body_text``)
+    and the WhatsApp-shaped fields (``provider_template_name`` + ordered
+    ``context``). An adapter uses whichever its channel needs.
+    """
+
+    channel: Channel
+    to_address: str  # email address or E.164 phone number
+    clinic_id: UUID
+    template_key: str
+    locale: str = "es"
+    context: dict = field(default_factory=dict)
+    to_name: str | None = None
+    patient_id: UUID | None = None
+    # "template" = pre-approved template (the only kind allowed for proactive
+    # WhatsApp, outside the 24h session window); "session" = free-form.
+    message_kind: str = "template"
+    provider_template_name: str | None = None
+    subject: str | None = None
+    body_html: str | None = None
+    body_text: str | None = None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class AdapterResult:
+    """Outcome of an adapter ``send``. Mirrors ``EmailResult``."""
+
+    status: SendStatus
+    provider: str
+    provider_message_id: str | None = None
+    error_message: str | None = None
+    sent_at: datetime | None = None
+
+    @property
+    def is_sent(self) -> bool:
+        return self.status == SendStatus.SENT
+
+
+@runtime_checkable
+class ChannelAdapter(Protocol):
+    """What a module must implement to deliver one channel.
+
+    Adapters are stateless and registered process-wide; per-clinic
+    activation is decided by :meth:`supports` (reads the clinic's config),
+    never by the adapter's mere presence.
+    """
+
+    channel: Channel
+    adapter_name: str  # unique, e.g. "email", "whatsapp_kapso"
+
+    async def supports(self, db: AsyncSession, clinic_id: UUID) -> bool:
+        """Is this channel configured and active for the clinic?"""
+        ...
+
+    async def send(self, db: AsyncSession, msg: OutboundMessage) -> AdapterResult:
+        """Deliver one message. Must not raise for delivery failures —
+        return ``AdapterResult(status=FAILED, ...)`` instead."""
+        ...

--- a/backend/app/modules/notifications/channels/email_adapter.py
+++ b/backend/app/modules/notifications/channels/email_adapter.py
@@ -1,0 +1,60 @@
+"""Built-in email adapter.
+
+Thin wrapper over the existing ``app.core.email.email_service`` — no SMTP
+logic moves here; per-clinic provider resolution stays in
+``email_service.create_provider_for_clinic``. This makes email "just
+another channel" behind :class:`ChannelAdapter` with no behavioural change.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from app.core.email.providers.base import EmailStatus
+from app.core.email.service import email_service
+
+from .base import AdapterResult, Channel, OutboundMessage, SendStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_STATUS_MAP = {
+    EmailStatus.SUCCESS: SendStatus.SENT,
+    EmailStatus.FAILED: SendStatus.FAILED,
+    EmailStatus.SKIPPED: SendStatus.SKIPPED,
+}
+
+
+class EmailAdapter:
+    """Delivers the ``email`` channel via the core email service."""
+
+    channel = Channel.EMAIL
+    adapter_name = "email"
+
+    async def supports(self, db: AsyncSession, clinic_id: UUID) -> bool:
+        # ponytail: email is always a viable fallback — a global provider
+        # exists even without per-clinic SMTP. Clinic enable/disable is
+        # governed by clinic_notification_settings + email_enabled, not here.
+        return True
+
+    async def send(self, db: AsyncSession, msg: OutboundMessage) -> AdapterResult:
+        result = await email_service.send_templated(
+            to_email=msg.to_address,
+            template_key=msg.template_key,
+            context=msg.context,
+            subject=msg.subject or f"Notificación: {msg.template_key}",
+            locale=msg.locale,
+            to_name=msg.to_name,
+            template_html=msg.body_html,
+            template_text=msg.body_text,
+            db=db,
+            clinic_id=msg.clinic_id,
+        )
+        return AdapterResult(
+            status=_STATUS_MAP.get(result.status, SendStatus.FAILED),
+            provider=result.provider,
+            provider_message_id=result.message_id,
+            error_message=result.error_message,
+            sent_at=result.sent_at,
+        )

--- a/backend/app/modules/notifications/channels/registry.py
+++ b/backend/app/modules/notifications/channels/registry.py
@@ -1,0 +1,63 @@
+"""Process-wide registry of channel adapters.
+
+Vendor modules register their adapter here at import time (see the module's
+``__init__.py``). The loader imports module packages in dependency order
+(``topological_sort``), so ``notifications`` — and therefore the built-in
+:class:`EmailAdapter` — is always registered before any vendor that depends
+on it.
+
+Registration is idempotent (unlike ``ModuleRegistry.register``): re-import
+during the dev filesystem re-scan is a no-op, not an error.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .base import Channel, ChannelAdapter
+from .email_adapter import EmailAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelRegistry:
+    """Maps a channel to its active adapter (last-writer-wins per channel)."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, ChannelAdapter] = {}  # adapter_name -> adapter
+
+    def register(self, adapter: ChannelAdapter) -> None:
+        name = adapter.adapter_name
+        existing = self._adapters.get(name)
+        if existing is not None and type(existing) is type(adapter):
+            return  # idempotent: same adapter re-registered on re-import
+        if name in self._adapters:
+            logger.info("Channel adapter %r re-registered (override)", name)
+        self._adapters[name] = adapter
+
+    def unregister(self, adapter_name: str) -> None:
+        """Drop an adapter (called on vendor-module uninstall)."""
+        self._adapters.pop(adapter_name, None)
+
+    def get_for_channel(self, channel: Channel | str) -> ChannelAdapter | None:
+        """Return the adapter handling ``channel``, or None.
+
+        With multiple adapters for one channel the last registered wins —
+        fine for v1 (one vendor per channel per deployment).
+        """
+        channel = Channel(channel)
+        for adapter in reversed(list(self._adapters.values())):
+            if adapter.channel == channel:
+                return adapter
+        return None
+
+    def get_by_name(self, adapter_name: str) -> ChannelAdapter | None:
+        return self._adapters.get(adapter_name)
+
+    def available_channels(self) -> list[Channel]:
+        return sorted({a.channel for a in self._adapters.values()})
+
+
+# Global singleton. Email is always present.
+channel_registry = ChannelRegistry()
+channel_registry.register(EmailAdapter())

--- a/backend/app/modules/notifications/gateway.py
+++ b/backend/app/modules/notifications/gateway.py
@@ -1,0 +1,413 @@
+"""Multi-channel notification gateway: consent gate, channel resolution,
+outbox enqueue, and the dispatch loop.
+
+Our communications logic lives here; adapters (email, whatsapp_kapso, …) only
+put a rendered message on the wire. ``enqueue`` never touches the network — it
+persists a ``queued`` row and returns; the scheduled ``dispatch_outbox`` job
+sends with retry/backoff.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.events import EventType, event_bus
+
+from .channels import Channel, OutboundMessage, SendStatus, channel_registry
+from .models import CommunicationMessage
+from .service import NotificationService, resolve_clinic_communication_locale
+
+logger = logging.getLogger(__name__)
+
+_BACKOFF_CAP_SECONDS = 3600
+_DISPATCH_BATCH = 50
+
+
+def _backoff_seconds(attempts: int) -> int:
+    """Exponential backoff with cap: 1m, 2m, 4m, … ≤ 1h."""
+    return min(60 * (2 ** max(0, attempts - 1)), _BACKOFF_CAP_SECONDS)
+
+
+def _sanitize(context: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in context.items() if k not in ("password", "token")}
+
+
+class NotificationGateway:
+    """Owns enqueue + dispatch for every channel."""
+
+    # ------------------------------------------------------------------ enqueue
+    @staticmethod
+    async def enqueue(
+        db: AsyncSession,
+        clinic_id: UUID,
+        notification_type: str,
+        *,
+        context: dict[str, Any],
+        patient_id: UUID | None = None,
+        to_address: str | None = None,
+        channels: list[str] | None = None,
+        force_send: bool = False,
+        triggered_by_event: str | None = None,
+        triggered_by_user_id: UUID | None = None,
+        dedup_key: str | None = None,
+    ) -> CommunicationMessage | None:
+        """Queue a notification for delivery.
+
+        Returns the queued ``CommunicationMessage`` (status ``queued`` or
+        ``skipped``), or ``None`` when a row with the same ``dedup_key``
+        already exists (idempotent no-op).
+        """
+        # Idempotency: never double-enqueue the same logical message.
+        if dedup_key:
+            existing = await db.execute(
+                select(CommunicationMessage.id).where(
+                    CommunicationMessage.clinic_id == clinic_id,
+                    CommunicationMessage.dedup_key == dedup_key,
+                )
+            )
+            if existing.first():
+                return None
+
+        patient = await NotificationGateway._load_patient(db, clinic_id, patient_id)
+
+        # Consent: do_not_contact is a hard block on every channel, even when
+        # force_send is set (manual sends / agent tool never override it).
+        if patient is not None and patient.do_not_contact:
+            return await NotificationGateway._skip(
+                db,
+                clinic_id,
+                notification_type,
+                patient_id,
+                to_address or (patient.email or ""),
+                "do_not_contact",
+                triggered_by_event,
+                triggered_by_user_id,
+            )
+
+        # Clinic-level enable / auto_send + per-patient per-type opt-in.
+        if not force_send:
+            should, reason = await NotificationService.should_send_notification(
+                db, clinic_id, notification_type, patient_id
+            )
+            if not should:
+                return await NotificationGateway._skip(
+                    db,
+                    clinic_id,
+                    notification_type,
+                    patient_id,
+                    to_address or (patient.email if patient else "") or "",
+                    reason,
+                    triggered_by_event,
+                    triggered_by_user_id,
+                )
+
+        # Locale: clinic default → patient preference override.
+        locale = await resolve_clinic_communication_locale(db, clinic_id)
+        prefs = (
+            await NotificationService.get_patient_preferences(db, clinic_id, patient_id)
+            if patient_id
+            else None
+        )
+        if prefs and prefs.preferred_locale:
+            locale = prefs.preferred_locale
+
+        # Channel resolution: first viable channel from the ordered list.
+        requested = channels or await NotificationGateway._clinic_channels(
+            db, clinic_id, notification_type
+        )
+        resolved = await NotificationGateway._resolve_channel(
+            db, clinic_id, notification_type, patient, prefs, locale, requested, to_address
+        )
+        if resolved is None:
+            return await NotificationGateway._skip(
+                db,
+                clinic_id,
+                notification_type,
+                patient_id,
+                to_address or (patient.email if patient else "") or "",
+                "no_viable_channel",
+                triggered_by_event,
+                triggered_by_user_id,
+            )
+        channel, addr, message_kind, _provider_template = resolved
+
+        # Subject is resolved now (email) for the logs view; the body is
+        # (re)rendered at dispatch time.
+        template = await NotificationService.get_template(
+            db, clinic_id, notification_type, locale, channel=channel.value
+        )
+        subject = template.subject if template else None
+
+        msg = CommunicationMessage(
+            clinic_id=clinic_id,
+            channel=channel.value,
+            to_address=addr,
+            patient_id=patient_id,
+            template_key=notification_type,
+            message_kind=message_kind,
+            subject=subject,
+            status="queued",
+            # stash the resolved locale so dispatch renders in the right language
+            context_data=_sanitize({**context, "locale": locale}),
+            triggered_by_event=triggered_by_event,
+            triggered_by_user_id=triggered_by_user_id,
+            dedup_key=dedup_key,
+            next_attempt_at=datetime.now(UTC),
+        )
+        db.add(msg)
+        await db.commit()
+        await db.refresh(msg)
+        await NotificationGateway._publish(msg, EventType.NOTIFICATION_QUEUED)
+        return msg
+
+    # ------------------------------------------------------------------ dispatch
+    @staticmethod
+    async def dispatch_outbox(db: AsyncSession, limit: int = _DISPATCH_BATCH) -> int:
+        """Send a batch of due queued/failed messages. Returns count attempted.
+
+        Each row is locked ``FOR UPDATE SKIP LOCKED`` so concurrent dispatch
+        ticks never grab the same message. Per-row exceptions are isolated.
+        """
+        now = datetime.now(UTC)
+        rows = (
+            (
+                await db.execute(
+                    select(CommunicationMessage)
+                    .where(
+                        CommunicationMessage.status.in_(("queued", "failed")),
+                        CommunicationMessage.attempts < CommunicationMessage.max_attempts,
+                        (CommunicationMessage.next_attempt_at.is_(None))
+                        | (CommunicationMessage.next_attempt_at <= now),
+                    )
+                    .order_by(CommunicationMessage.created_at)
+                    .limit(limit)
+                    .with_for_update(skip_locked=True)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        attempted = 0
+        for msg in rows:
+            attempted += 1
+            try:
+                await NotificationGateway._dispatch_one(db, msg)
+            except Exception as exc:  # noqa: BLE001 — isolate one poisoned row
+                logger.error("dispatch failed for message %s: %s", msg.id, exc, exc_info=True)
+                await db.rollback()
+                await NotificationGateway._mark_failed(db, msg, str(exc))
+        return attempted
+
+    @staticmethod
+    async def _dispatch_one(db: AsyncSession, msg: CommunicationMessage) -> None:
+        adapter = channel_registry.get_for_channel(msg.channel)
+        if adapter is None:
+            await NotificationGateway._mark_failed(db, msg, f"no adapter for channel {msg.channel}")
+            return
+
+        msg.status = "sending"
+        msg.attempts += 1
+        # ponytail: commit before the network call so we don't hold a row lock
+        # across I/O. Ceiling: a crash mid-send leaves the row in 'sending'
+        # (visible in the logs view). Upgrade path: sweep 'sending' rows whose
+        # updated_at is older than N minutes back to 'failed'.
+        await db.commit()
+
+        # (Re)render the template for this channel at send time.
+        template = await NotificationService.get_template(
+            db, msg.clinic_id, msg.template_key, _locale_of(msg), channel=msg.channel
+        )
+        outbound = OutboundMessage(
+            channel=Channel(msg.channel),
+            to_address=msg.to_address,
+            clinic_id=msg.clinic_id,
+            template_key=msg.template_key,
+            locale=_locale_of(msg),
+            context=msg.context_data or {},
+            to_name=(msg.context_data or {}).get("patient_name"),
+            patient_id=msg.patient_id,
+            message_kind=msg.message_kind,
+            provider_template_name=template.provider_template_name if template else None,
+            subject=template.subject if template else msg.subject,
+            body_html=template.body_html if template else None,
+            body_text=template.body_text if template else None,
+        )
+
+        result = await adapter.send(db, outbound)
+        if result.status == SendStatus.SENT:
+            msg.status = "sent"
+            msg.sent_at = result.sent_at or datetime.now(UTC)
+            msg.provider = result.provider
+            msg.provider_message_id = result.provider_message_id
+            msg.error_message = None
+            await db.commit()
+            await NotificationGateway._publish(msg, EventType.NOTIFICATION_SENT)
+        else:
+            await NotificationGateway._mark_failed(db, msg, result.error_message or "send failed")
+
+    @staticmethod
+    async def _mark_failed(db: AsyncSession, msg: CommunicationMessage, error: str) -> None:
+        msg.status = "failed"
+        msg.error_message = error[:2000]
+        if msg.attempts < msg.max_attempts:
+            msg.next_attempt_at = datetime.now(UTC) + timedelta(
+                seconds=_backoff_seconds(msg.attempts)
+            )
+        await db.commit()
+        await NotificationGateway._publish(msg, EventType.NOTIFICATION_FAILED)
+
+    # ------------------------------------------------------------------ delivery
+    @staticmethod
+    async def record_delivery_status(
+        db: AsyncSession, clinic_id: UUID, provider_message_id: str, status: str
+    ) -> CommunicationMessage | None:
+        """Apply a vendor webhook delivery/read receipt. Clinic-scoped."""
+        msg = (
+            await db.execute(
+                select(CommunicationMessage).where(
+                    CommunicationMessage.clinic_id == clinic_id,
+                    CommunicationMessage.provider_message_id == provider_message_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if msg is None:
+            return None
+        now = datetime.now(UTC)
+        if status == "delivered" and msg.status not in ("read",):
+            msg.status = "delivered"
+            msg.delivered_at = now
+        elif status == "read":
+            msg.status = "read"
+            msg.read_at = now
+            msg.delivered_at = msg.delivered_at or now
+        elif status == "failed":
+            msg.status = "failed"
+        await db.commit()
+        if msg.status in ("delivered", "read"):
+            await NotificationGateway._publish(msg, EventType.NOTIFICATION_DELIVERED)
+        return msg
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    async def _load_patient(db: AsyncSession, clinic_id: UUID, patient_id: UUID | None):
+        if not patient_id:
+            return None
+        from app.modules.patients.models import Patient
+
+        return (
+            await db.execute(
+                select(Patient).where(Patient.clinic_id == clinic_id, Patient.id == patient_id)
+            )
+        ).scalar_one_or_none()
+
+    @staticmethod
+    async def _clinic_channels(
+        db: AsyncSession, clinic_id: UUID, notification_type: str
+    ) -> list[str]:
+        settings = await NotificationService.get_clinic_settings(db, clinic_id)
+        if settings:
+            type_settings = settings.settings.get(notification_type, {})
+            channels = type_settings.get("channels")
+            if channels:
+                return list(channels)
+        return ["email"]  # ponytail: missing config ⇒ email-only, no migration
+
+    @staticmethod
+    async def _resolve_channel(
+        db, clinic_id, notification_type, patient, prefs, locale, requested, to_address
+    ):
+        for name in requested:
+            try:
+                channel = Channel(name)
+            except ValueError:
+                continue
+            adapter = channel_registry.get_for_channel(channel)
+            if adapter is None or not await adapter.supports(db, clinic_id):
+                continue
+
+            if channel == Channel.EMAIL:
+                addr = (patient.email if patient else None) or to_address
+                if not addr:
+                    continue
+                if prefs is not None and not prefs.email_enabled:
+                    continue
+                return channel, addr, "template", None
+
+            if channel == Channel.WHATSAPP:
+                addr = patient.phone if patient else None
+                if not addr or not (prefs and prefs.whatsapp_enabled):
+                    continue
+                tmpl = await NotificationService.get_template(
+                    db, clinic_id, notification_type, locale, channel="whatsapp"
+                )
+                if (
+                    not tmpl
+                    or tmpl.provider_template_status != "approved"
+                    or not tmpl.provider_template_name
+                ):
+                    continue
+                return channel, addr, "template", tmpl.provider_template_name
+        return None
+
+    @staticmethod
+    async def _skip(
+        db,
+        clinic_id,
+        notification_type,
+        patient_id,
+        to_address,
+        reason,
+        triggered_by_event,
+        triggered_by_user_id,
+    ) -> CommunicationMessage:
+        logger.info("skip notification %s: %s", notification_type, reason)
+        msg = CommunicationMessage(
+            clinic_id=clinic_id,
+            channel="email",
+            to_address=to_address or "",
+            patient_id=patient_id,
+            template_key=notification_type,
+            status="skipped",
+            error_message=reason,
+            triggered_by_event=triggered_by_event,
+            triggered_by_user_id=triggered_by_user_id,
+        )
+        db.add(msg)
+        await db.commit()
+        await db.refresh(msg)
+        return msg
+
+    @staticmethod
+    async def _publish(msg: CommunicationMessage, event_type: str) -> None:
+        occurred = msg.sent_at or msg.delivered_at or msg.created_at
+        payload = {
+            "clinic_id": str(msg.clinic_id),
+            "patient_id": str(msg.patient_id) if msg.patient_id else None,
+            "message_id": str(msg.id),
+            "channel": msg.channel,
+            "template_key": msg.template_key,
+            "subject": msg.subject,
+            "status": msg.status,
+            "error_message": msg.error_message,
+            "occurred_at": occurred.isoformat() if occurred else None,
+        }
+        await event_bus.publish(event_type, payload)
+
+        # Dual-publish the legacy EMAIL_* events for one release so
+        # patient_timeline keeps recording email comms unchanged.
+        if msg.channel == Channel.EMAIL:
+            legacy = {**payload, "email_log_id": str(msg.id), "recipient_email": msg.to_address}
+            if event_type == EventType.NOTIFICATION_SENT:
+                await event_bus.publish(EventType.EMAIL_SENT, legacy)
+            elif event_type == EventType.NOTIFICATION_FAILED:
+                await event_bus.publish(EventType.EMAIL_FAILED, legacy)
+
+
+def _locale_of(msg: CommunicationMessage) -> str:
+    ctx = msg.context_data or {}
+    return ctx.get("locale") or "es"

--- a/backend/app/modules/notifications/handlers.py
+++ b/backend/app/modules/notifications/handlers.py
@@ -31,7 +31,7 @@ class NotificationHandlers:
     async def _handle_appointment_scheduled(data: dict[str, Any]) -> None:
         """Async handler for appointment scheduled."""
         from app.modules.agenda.models import Appointment
-        from app.modules.notifications.service import NotificationService
+        from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
         try:
@@ -89,11 +89,11 @@ class NotificationHandlers:
                 }
 
                 # Send notification
-                await NotificationService.send_notification(
+                await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
                     notification_type="appointment_confirmation",
-                    to_email=patient.email,
+                    to_address=patient.email,
                     context=context,
                     patient_id=patient.id,
                     triggered_by_event="appointment.scheduled",
@@ -114,7 +114,7 @@ class NotificationHandlers:
     async def _handle_appointment_cancelled(data: dict[str, Any]) -> None:
         """Async handler for appointment cancelled."""
         from app.modules.agenda.models import Appointment
-        from app.modules.notifications.service import NotificationService
+        from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
         try:
@@ -168,11 +168,11 @@ class NotificationHandlers:
                     "clinic_phone": clinic.phone if clinic else None,
                 }
 
-                await NotificationService.send_notification(
+                await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
                     notification_type="appointment_cancelled",
-                    to_email=patient.email,
+                    to_address=patient.email,
                     context=context,
                     patient_id=patient.id,
                     triggered_by_event="appointment.cancelled",
@@ -192,7 +192,7 @@ class NotificationHandlers:
     @staticmethod
     async def _handle_patient_created(data: dict[str, Any]) -> None:
         """Async handler for patient created."""
-        from app.modules.notifications.service import NotificationService
+        from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
         try:
@@ -220,11 +220,11 @@ class NotificationHandlers:
                     "clinic_address": clinic.address if clinic else None,
                 }
 
-                await NotificationService.send_notification(
+                await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
                     notification_type="welcome",
-                    to_email=patient.email,
+                    to_address=patient.email,
                     context=context,
                     patient_id=patient.id,
                     triggered_by_event="patient.created",
@@ -249,7 +249,7 @@ class NotificationHandlers:
         Manual sends (printed/handed) don't trigger email.
         """
         from app.modules.budget.models import Budget, BudgetItem
-        from app.modules.notifications.service import NotificationService
+        from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
         # Only send email if explicitly requested
@@ -329,11 +329,11 @@ class NotificationHandlers:
                     "clinic_phone": clinic.phone if clinic else None,
                 }
 
-                await NotificationService.send_notification(
+                await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
                     notification_type="budget_sent",
-                    to_email=patient.email,
+                    to_address=patient.email,
                     context=context,
                     patient_id=patient.id,
                     triggered_by_event="budget.sent",
@@ -358,7 +358,7 @@ class NotificationHandlers:
         Manual sends don't trigger email.
         """
         from app.modules.billing.models import Invoice, InvoiceItem
-        from app.modules.notifications.service import NotificationService
+        from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
         # Only send email if explicitly requested
@@ -433,11 +433,11 @@ class NotificationHandlers:
                     "clinic_address": clinic.address if clinic else None,
                 }
 
-                await NotificationService.send_notification(
+                await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
                     notification_type="invoice_sent",
-                    to_email=patient.email,
+                    to_address=patient.email,
                     context=context,
                     patient_id=patient.id,
                     triggered_by_event="invoice.sent",
@@ -458,7 +458,7 @@ class NotificationHandlers:
     async def _handle_budget_accepted(data: dict[str, Any]) -> None:
         """Async handler for budget accepted."""
         from app.modules.budget.models import Budget
-        from app.modules.notifications.service import NotificationService
+        from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
         try:
@@ -495,11 +495,11 @@ class NotificationHandlers:
                     "clinic_phone": clinic.phone if clinic else None,
                 }
 
-                await NotificationService.send_notification(
+                await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
                     notification_type="budget_accepted",
-                    to_email=patient.email,
+                    to_address=patient.email,
                     context=context,
                     patient_id=patient.id,
                     triggered_by_event="budget.accepted",

--- a/backend/app/modules/notifications/migrations/versions/notif_0002_multichannel.py
+++ b/backend/app/modules/notifications/migrations/versions/notif_0002_multichannel.py
@@ -1,0 +1,270 @@
+"""notifications: generalize email-only → multi-channel gateway.
+
+Renames ``email_templates`` → ``notification_templates`` and ``email_logs``
+→ ``communication_messages`` (data preserved, ``channel`` backfilled to
+``'email'``), adds the outbox/retry lifecycle, per-channel WhatsApp opt-in on
+preferences, and the generic ``clinic_channel_settings`` table.
+
+Revision ID: notif_0002
+Revises: notif_0001
+Create Date: 2026-06-26
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "notif_0002"
+down_revision: str | None = "notif_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ---- email_templates -> notification_templates -------------------------
+    op.rename_table("email_templates", "notification_templates")
+    op.add_column(
+        "notification_templates",
+        sa.Column("channel", sa.String(length=20), nullable=False, server_default="email"),
+    )
+    op.add_column(
+        "notification_templates",
+        sa.Column("provider_template_name", sa.String(length=200), nullable=True),
+    )
+    op.add_column(
+        "notification_templates",
+        sa.Column("provider_template_status", sa.String(length=20), nullable=True),
+    )
+    # WhatsApp rows have no subject/body — relax the email NOT NULLs.
+    op.alter_column("notification_templates", "subject", nullable=True)
+    op.alter_column("notification_templates", "body_html", nullable=True)
+    op.alter_column("notification_templates", "channel", server_default=None)
+
+    op.drop_constraint(
+        "uq_email_template_clinic_key_locale", "notification_templates", type_="unique"
+    )
+    op.create_unique_constraint(
+        "uq_notification_template_clinic_key_locale_channel",
+        "notification_templates",
+        ["clinic_id", "template_key", "locale", "channel"],
+    )
+    op.execute("ALTER INDEX idx_email_templates_clinic RENAME TO idx_notification_templates_clinic")
+    op.execute("ALTER INDEX idx_email_templates_key RENAME TO idx_notification_templates_key")
+    op.execute(
+        "ALTER INDEX ix_email_templates_clinic_id RENAME TO ix_notification_templates_clinic_id"
+    )
+    op.execute(
+        "ALTER INDEX ix_email_templates_template_key "
+        "RENAME TO ix_notification_templates_template_key"
+    )
+    op.create_index(
+        op.f("ix_notification_templates_channel"),
+        "notification_templates",
+        ["channel"],
+        unique=False,
+    )
+
+    # ---- email_logs -> communication_messages (outbox + audit) -------------
+    op.rename_table("email_logs", "communication_messages")
+    op.alter_column("communication_messages", "recipient_email", new_column_name="to_address")
+    op.add_column(
+        "communication_messages",
+        sa.Column("channel", sa.String(length=20), nullable=False, server_default="email"),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("message_kind", sa.String(length=20), nullable=False, server_default="template"),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("max_attempts", sa.Integer(), nullable=False, server_default="5"),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("dedup_key", sa.String(length=200), nullable=True),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "communication_messages",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    # provider/subject are unknown while a row is still queued.
+    op.alter_column("communication_messages", "provider", nullable=True)
+    op.alter_column("communication_messages", "subject", nullable=True)
+    # drop the temporary server defaults — the model fills these in Python.
+    for col in ("channel", "message_kind", "attempts", "max_attempts", "updated_at"):
+        op.alter_column("communication_messages", col, server_default=None)
+
+    op.execute("ALTER INDEX idx_email_logs_clinic RENAME TO idx_communication_messages_clinic")
+    op.execute(
+        "ALTER INDEX idx_email_logs_created_at RENAME TO idx_communication_messages_created_at"
+    )
+    op.execute("ALTER INDEX idx_email_logs_patient RENAME TO idx_communication_messages_patient")
+    op.execute("ALTER INDEX idx_email_logs_status RENAME TO idx_communication_messages_status")
+    op.execute("ALTER INDEX idx_email_logs_template RENAME TO idx_communication_messages_template")
+    op.execute("ALTER INDEX ix_email_logs_clinic_id RENAME TO ix_communication_messages_clinic_id")
+    op.execute(
+        "ALTER INDEX ix_email_logs_patient_id RENAME TO ix_communication_messages_patient_id"
+    )
+    op.execute("ALTER INDEX ix_email_logs_status RENAME TO ix_communication_messages_status")
+    op.execute(
+        "ALTER INDEX ix_email_logs_triggered_by_user_id "
+        "RENAME TO ix_communication_messages_triggered_by_user_id"
+    )
+    op.create_index(
+        "idx_communication_messages_dispatch",
+        "communication_messages",
+        ["status", "next_attempt_at"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_communication_messages_dedup",
+        "communication_messages",
+        ["clinic_id", "dedup_key"],
+        unique=True,
+        postgresql_where=sa.text("dedup_key IS NOT NULL"),
+    )
+
+    # ---- notification_preferences: per-channel WhatsApp opt-in -------------
+    op.add_column(
+        "notification_preferences",
+        sa.Column("whatsapp_enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "notification_preferences",
+        sa.Column("whatsapp_opt_in_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "notification_preferences",
+        sa.Column("last_inbound_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.alter_column("notification_preferences", "whatsapp_enabled", server_default=None)
+
+    # ---- clinic_channel_settings (new, generic, no secrets) ----------------
+    op.create_table(
+        "clinic_channel_settings",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("clinic_id", sa.UUID(), nullable=False),
+        sa.Column("channel", sa.String(length=20), nullable=False),
+        sa.Column("adapter_name", sa.String(length=50), nullable=False),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False),
+        sa.Column("is_verified", sa.Boolean(), nullable=False),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["clinic_id"], ["clinics.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "clinic_id", "channel", name="uq_clinic_channel_settings_clinic_channel"
+        ),
+    )
+    op.create_index(
+        "idx_clinic_channel_settings_clinic", "clinic_channel_settings", ["clinic_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_clinic_channel_settings_clinic_id"),
+        "clinic_channel_settings",
+        ["clinic_id"],
+        unique=False,
+    )
+
+    # clinic_notification_settings: no backfill — the gateway treats a missing
+    # per-type "channels" key as ["email"] at read time (no brittle JSONB migration).
+
+
+def downgrade() -> None:
+    op.drop_index("ix_clinic_channel_settings_clinic_id", table_name="clinic_channel_settings")
+    op.drop_index("idx_clinic_channel_settings_clinic", table_name="clinic_channel_settings")
+    op.drop_table("clinic_channel_settings")
+
+    op.drop_column("notification_preferences", "last_inbound_at")
+    op.drop_column("notification_preferences", "whatsapp_opt_in_at")
+    op.drop_column("notification_preferences", "whatsapp_enabled")
+
+    # communication_messages -> email_logs
+    op.drop_index("uq_communication_messages_dedup", table_name="communication_messages")
+    op.drop_index("idx_communication_messages_dispatch", table_name="communication_messages")
+    op.execute(
+        "ALTER INDEX ix_communication_messages_triggered_by_user_id "
+        "RENAME TO ix_email_logs_triggered_by_user_id"
+    )
+    op.execute("ALTER INDEX ix_communication_messages_status RENAME TO ix_email_logs_status")
+    op.execute(
+        "ALTER INDEX ix_communication_messages_patient_id RENAME TO ix_email_logs_patient_id"
+    )
+    op.execute("ALTER INDEX ix_communication_messages_clinic_id RENAME TO ix_email_logs_clinic_id")
+    op.execute("ALTER INDEX idx_communication_messages_template RENAME TO idx_email_logs_template")
+    op.execute("ALTER INDEX idx_communication_messages_status RENAME TO idx_email_logs_status")
+    op.execute("ALTER INDEX idx_communication_messages_patient RENAME TO idx_email_logs_patient")
+    op.execute(
+        "ALTER INDEX idx_communication_messages_created_at RENAME TO idx_email_logs_created_at"
+    )
+    op.execute("ALTER INDEX idx_communication_messages_clinic RENAME TO idx_email_logs_clinic")
+    op.alter_column("communication_messages", "subject", nullable=False)
+    op.alter_column("communication_messages", "provider", nullable=False)
+    for col in (
+        "updated_at",
+        "read_at",
+        "delivered_at",
+        "dedup_key",
+        "next_attempt_at",
+        "max_attempts",
+        "attempts",
+        "message_kind",
+        "channel",
+    ):
+        op.drop_column("communication_messages", col)
+    op.alter_column("communication_messages", "to_address", new_column_name="recipient_email")
+    op.rename_table("communication_messages", "email_logs")
+
+    # notification_templates -> email_templates
+    op.drop_index("ix_notification_templates_channel", table_name="notification_templates")
+    op.drop_constraint(
+        "uq_notification_template_clinic_key_locale_channel",
+        "notification_templates",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_email_template_clinic_key_locale",
+        "notification_templates",
+        ["clinic_id", "template_key", "locale"],
+    )
+    op.execute(
+        "ALTER INDEX ix_notification_templates_template_key "
+        "RENAME TO ix_email_templates_template_key"
+    )
+    op.execute(
+        "ALTER INDEX ix_notification_templates_clinic_id RENAME TO ix_email_templates_clinic_id"
+    )
+    op.execute("ALTER INDEX idx_notification_templates_key RENAME TO idx_email_templates_key")
+    op.execute("ALTER INDEX idx_notification_templates_clinic RENAME TO idx_email_templates_clinic")
+    op.alter_column("notification_templates", "body_html", nullable=False)
+    op.alter_column("notification_templates", "subject", nullable=False)
+    op.drop_column("notification_templates", "provider_template_status")
+    op.drop_column("notification_templates", "provider_template_name")
+    op.drop_column("notification_templates", "channel")
+    op.rename_table("notification_templates", "email_templates")

--- a/backend/app/modules/notifications/models.py
+++ b/backend/app/modules/notifications/models.py
@@ -1,4 +1,15 @@
-"""Notifications module database models."""
+"""Notifications module database models (multi-channel).
+
+Generalized from email-only to a channel-agnostic gateway:
+- ``NotificationTemplate`` (was ``EmailTemplate``) carries a ``channel`` and,
+  for WhatsApp, a Meta/Kapso approved-template name.
+- ``CommunicationMessage`` (was ``EmailLog``) is BOTH the outbox queue row
+  and the immutable-ish audit record, across every channel.
+- ``NotificationPreference`` gains per-channel WhatsApp opt-in + the 24h
+  session-window marker.
+- ``ClinicChannelSettings`` (new) records which adapter handles which
+  channel per clinic (no secrets — those live in the vendor module).
+"""
 
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -13,6 +24,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -24,42 +36,44 @@ if TYPE_CHECKING:
     from app.modules.patients.models import Patient
 
 
-class EmailTemplate(Base, TimestampMixin):
-    """Customizable email template.
+class NotificationTemplate(Base, TimestampMixin):
+    """Customizable notification template, per channel.
 
-    Templates can be defined at system level (clinic_id=None) or
-    customized per clinic. When sending, clinic-specific templates
-    take precedence over system templates.
+    Templates can be system-level (clinic_id=None) or per-clinic. For
+    ``channel='email'`` the ``subject``/``body_html`` are used; for
+    ``channel='whatsapp'`` the ``provider_template_name`` (a Meta-approved
+    HSM) is used and ``variables`` holds the ordered substitution list.
     """
 
-    __tablename__ = "email_templates"
+    __tablename__ = "notification_templates"
 
     id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     clinic_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("clinics.id"), index=True, default=None
     )  # NULL = system template
 
-    # Template identification
-    template_key: Mapped[str] = mapped_column(
-        String(100), index=True
-    )  # e.g., "appointment_confirmation"
+    # Identification
+    channel: Mapped[str] = mapped_column(String(20), default="email", index=True)
+    template_key: Mapped[str] = mapped_column(String(100), index=True)
     locale: Mapped[str] = mapped_column(String(5), default="es")  # es, en
 
-    # Content
-    subject: Mapped[str] = mapped_column(String(255))
-    body_html: Mapped[str] = mapped_column(Text)
+    # Email content (ignored for non-email channels)
+    subject: Mapped[str | None] = mapped_column(String(255), default=None)
+    body_html: Mapped[str | None] = mapped_column(Text, default=None)
     body_text: Mapped[str | None] = mapped_column(Text, default=None)
 
+    # WhatsApp / provider-template content (ignored for email)
+    provider_template_name: Mapped[str | None] = mapped_column(String(200), default=None)
+    provider_template_status: Mapped[str | None] = mapped_column(
+        String(20), default=None
+    )  # approved, pending, rejected
+
     # Metadata
-    variables: Mapped[dict | None] = mapped_column(
-        JSONB, default=None
-    )  # Available template variables
-    description: Mapped[str | None] = mapped_column(
-        String(500), default=None
-    )  # Template description
+    variables: Mapped[dict | None] = mapped_column(JSONB, default=None)
+    description: Mapped[str | None] = mapped_column(String(500), default=None)
 
     # Flags
-    is_system: Mapped[bool] = mapped_column(Boolean, default=False)  # System = not editable
+    is_system: Mapped[bool] = mapped_column(Boolean, default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
 
     # Relationships
@@ -67,18 +81,21 @@ class EmailTemplate(Base, TimestampMixin):
 
     __table_args__ = (
         UniqueConstraint(
-            "clinic_id", "template_key", "locale", name="uq_email_template_clinic_key_locale"
+            "clinic_id",
+            "template_key",
+            "locale",
+            "channel",
+            name="uq_notification_template_clinic_key_locale_channel",
         ),
-        Index("idx_email_templates_clinic", "clinic_id"),
-        Index("idx_email_templates_key", "template_key"),
+        Index("idx_notification_templates_clinic", "clinic_id"),
+        Index("idx_notification_templates_key", "template_key"),
     )
 
 
 class NotificationPreference(Base, TimestampMixin):
     """Notification preferences for patients or users.
 
-    Stores opt-in/opt-out settings for different notification types.
-    Either patient_id or user_id should be set, not both.
+    Stores opt-in/opt-out settings. Either patient_id or user_id is set.
     """
 
     __tablename__ = "notification_preferences"
@@ -92,10 +109,17 @@ class NotificationPreference(Base, TimestampMixin):
     )
     user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id"), index=True, default=None)
 
-    # Global email toggle
+    # Channel master toggles
     email_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    # WhatsApp uses patients.phone as the number; this flag is the opt-in.
+    whatsapp_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    whatsapp_opt_in_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    # Last inbound message timestamp — opens the 24h free-form session window.
+    last_inbound_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
-    # Per-type preferences
+    # Per-type preferences (channel-agnostic opt-in)
     preferences: Mapped[dict] = mapped_column(
         JSONB,
         default=lambda: {
@@ -116,9 +140,7 @@ class NotificationPreference(Base, TimestampMixin):
     patient: Mapped["Patient | None"] = relationship(foreign_keys=[patient_id])
 
     __table_args__ = (
-        # A patient can only have one preference record per clinic
         UniqueConstraint("clinic_id", "patient_id", name="uq_notification_pref_clinic_patient"),
-        # A user can only have one preference record per clinic
         UniqueConstraint("clinic_id", "user_id", name="uq_notification_pref_clinic_user"),
         Index("idx_notification_preferences_clinic", "clinic_id"),
         Index("idx_notification_preferences_patient", "patient_id"),
@@ -129,8 +151,9 @@ class NotificationPreference(Base, TimestampMixin):
 class ClinicNotificationSettings(Base, TimestampMixin):
     """Clinic-level notification settings.
 
-    Configures which notifications are auto-sent vs manual,
-    and general notification behavior for the clinic.
+    Each notification type carries ``enabled``/``auto_send`` and an ordered
+    ``channels`` fallback list. Defaults stay email-only so existing clinics
+    are unchanged until they enable WhatsApp.
     """
 
     __tablename__ = "clinic_notification_settings"
@@ -138,41 +161,68 @@ class ClinicNotificationSettings(Base, TimestampMixin):
     id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     clinic_id: Mapped[UUID] = mapped_column(ForeignKey("clinics.id"), unique=True, index=True)
 
-    # Per-notification-type settings
     settings: Mapped[dict] = mapped_column(
         JSONB,
         default=lambda: {
-            "appointment_confirmation": {"auto_send": True, "enabled": True},
-            "appointment_cancelled": {"auto_send": True, "enabled": True},
-            "appointment_reminder": {"auto_send": True, "enabled": True, "hours_before": 24},
-            "budget_sent": {"auto_send": False, "enabled": True},  # Manual
-            "budget_accepted": {"auto_send": True, "enabled": True},
-            "welcome": {"auto_send": False, "enabled": True},  # Manual
+            "appointment_confirmation": {
+                "auto_send": True,
+                "enabled": True,
+                "channels": ["email"],
+            },
+            "appointment_cancelled": {"auto_send": True, "enabled": True, "channels": ["email"]},
+            "appointment_reminder": {
+                "auto_send": True,
+                "enabled": True,
+                "hours_before": 24,
+                "channels": ["email"],
+            },
+            "budget_sent": {"auto_send": False, "enabled": True, "channels": ["email"]},
+            "budget_accepted": {"auto_send": True, "enabled": True, "channels": ["email"]},
+            "welcome": {"auto_send": False, "enabled": True, "channels": ["email"]},
         },
     )
 
-    # Relationships
     clinic: Mapped["Clinic"] = relationship(foreign_keys=[clinic_id])
 
     __table_args__ = (Index("idx_clinic_notification_settings_clinic", "clinic_id"),)
 
 
-class ClinicSmtpSettings(Base, TimestampMixin):
-    """SMTP configuration per clinic.
+class ClinicChannelSettings(Base, TimestampMixin):
+    """Which adapter handles which channel for a clinic. NO secrets here.
 
-    Stores SMTP server settings for sending emails from a specific clinic.
-    Passwords are encrypted using Fernet symmetric encryption.
+    Generic and reusable by any future vendor (Twilio, telephony). Vendor
+    credentials live in the vendor module's own table.
     """
+
+    __tablename__ = "clinic_channel_settings"
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    clinic_id: Mapped[UUID] = mapped_column(ForeignKey("clinics.id"), index=True)
+
+    channel: Mapped[str] = mapped_column(String(20))  # email, whatsapp, ...
+    adapter_name: Mapped[str] = mapped_column(String(50))  # e.g. "whatsapp_kapso"
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
+    config: Mapped[dict | None] = mapped_column(JSONB, default=None)  # non-secret display config
+
+    clinic: Mapped["Clinic"] = relationship(foreign_keys=[clinic_id])
+
+    __table_args__ = (
+        UniqueConstraint("clinic_id", "channel", name="uq_clinic_channel_settings_clinic_channel"),
+        Index("idx_clinic_channel_settings_clinic", "clinic_id"),
+    )
+
+
+class ClinicSmtpSettings(Base, TimestampMixin):
+    """SMTP configuration per clinic (Fernet-encrypted password)."""
 
     __tablename__ = "clinic_smtp_settings"
 
     id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     clinic_id: Mapped[UUID] = mapped_column(ForeignKey("clinics.id"), unique=True, index=True)
 
-    # Provider selection: smtp, console, disabled
-    provider: Mapped[str] = mapped_column(String(20), default="smtp")
+    provider: Mapped[str] = mapped_column(String(20), default="smtp")  # smtp, console, disabled
 
-    # SMTP Configuration
     host: Mapped[str | None] = mapped_column(String(255), default=None)
     port: Mapped[int] = mapped_column(Integer, default=587)
     username: Mapped[str | None] = mapped_column(String(255), default=None)
@@ -180,79 +230,90 @@ class ClinicSmtpSettings(Base, TimestampMixin):
     use_tls: Mapped[bool] = mapped_column(Boolean, default=True)
     use_ssl: Mapped[bool] = mapped_column(Boolean, default=False)
 
-    # Sender defaults
     from_email: Mapped[str | None] = mapped_column(String(255), default=None)
     from_name: Mapped[str | None] = mapped_column(String(255), default=None)
 
-    # Status
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     last_verified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
-    # Relationships
     clinic: Mapped["Clinic"] = relationship(foreign_keys=[clinic_id])
 
     __table_args__ = (Index("idx_clinic_smtp_settings_clinic", "clinic_id"),)
 
 
-class EmailLog(Base):
-    """Audit log for sent emails.
+class CommunicationMessage(Base, TimestampMixin):
+    """Outbox queue row AND audit record for one outbound message.
 
-    Records all email send attempts for auditing and troubleshooting.
+    Lifecycle: ``queued`` → ``sending`` → ``sent`` → (``delivered``/``read``)
+    or ``failed`` (retried up to ``max_attempts``) or ``skipped`` (consent /
+    no viable channel). One source of truth across all channels.
     """
 
-    __tablename__ = "email_logs"
+    __tablename__ = "communication_messages"
 
     id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     clinic_id: Mapped[UUID] = mapped_column(ForeignKey("clinics.id"), index=True)
 
-    # Recipient info
-    recipient_email: Mapped[str] = mapped_column(String(255))
+    # Routing
+    channel: Mapped[str] = mapped_column(String(20), default="email")
+    to_address: Mapped[str] = mapped_column(String(255))  # email or E.164 phone
     patient_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("patients.id"), index=True, default=None
     )
 
-    # Template info
+    # Content reference
     template_key: Mapped[str] = mapped_column(String(100))
-    subject: Mapped[str] = mapped_column(String(255))
+    message_kind: Mapped[str] = mapped_column(String(20), default="template")  # template | session
+    subject: Mapped[str | None] = mapped_column(String(255), default=None)
 
-    # Status
-    status: Mapped[str] = mapped_column(String(20), index=True)  # pending, sent, failed, skipped
+    # Lifecycle
+    status: Mapped[str] = mapped_column(
+        String(20), default="queued", index=True
+    )  # queued, sending, sent, failed, skipped, delivered, read
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+    max_attempts: Mapped[int] = mapped_column(Integer, default=5)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     # Provider info
-    provider: Mapped[str] = mapped_column(String(50))  # smtp, sendgrid, console
+    provider: Mapped[str | None] = mapped_column(String(50), default=None)
     provider_message_id: Mapped[str | None] = mapped_column(String(255), default=None)
-
-    # Error tracking
     error_message: Mapped[str | None] = mapped_column(Text, default=None)
 
-    # Timestamps
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now()
-    )
+    # Idempotency
+    dedup_key: Mapped[str | None] = mapped_column(String(200), default=None)
+
+    # Timestamps (created_at/updated_at via TimestampMixin)
     sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     # Event tracking
-    triggered_by_event: Mapped[str | None] = mapped_column(
-        String(100), default=None
-    )  # Event that triggered this email
+    triggered_by_event: Mapped[str | None] = mapped_column(String(100), default=None)
     triggered_by_user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("users.id"), index=True, default=None
-    )  # User who triggered manual send
+    )
 
-    # Context data for debugging
-    context_data: Mapped[dict | None] = mapped_column(
-        JSONB, default=None
-    )  # Template context (sanitized)
+    # Sanitized template context for debugging
+    context_data: Mapped[dict | None] = mapped_column(JSONB, default=None)
 
-    # Relationships
     clinic: Mapped["Clinic"] = relationship(foreign_keys=[clinic_id])
     patient: Mapped["Patient | None"] = relationship(foreign_keys=[patient_id])
 
     __table_args__ = (
-        Index("idx_email_logs_clinic", "clinic_id"),
-        Index("idx_email_logs_status", "status"),
-        Index("idx_email_logs_created_at", "created_at"),
-        Index("idx_email_logs_patient", "patient_id"),
-        Index("idx_email_logs_template", "template_key"),
+        Index("idx_communication_messages_clinic", "clinic_id"),
+        Index("idx_communication_messages_status", "status"),
+        Index("idx_communication_messages_created_at", "created_at"),
+        Index("idx_communication_messages_patient", "patient_id"),
+        Index("idx_communication_messages_template", "template_key"),
+        # Drives the dispatch poll.
+        Index("idx_communication_messages_dispatch", "status", "next_attempt_at"),
+        # Idempotency: at most one row per (clinic, dedup_key) when set.
+        Index(
+            "uq_communication_messages_dedup",
+            "clinic_id",
+            "dedup_key",
+            unique=True,
+            postgresql_where=text("dedup_key IS NOT NULL"),
+        ),
     )

--- a/backend/app/modules/notifications/router.py
+++ b/backend/app/modules/notifications/router.py
@@ -10,6 +10,7 @@ from app.core.auth.dependencies import ClinicContext, get_clinic_context, requir
 from app.core.schemas import ApiResponse, PaginatedApiResponse
 from app.database import get_db
 
+from .gateway import NotificationGateway
 from .schemas import (
     ClinicNotificationSettingsResponse,
     ClinicNotificationSettingsUpdate,
@@ -465,34 +466,36 @@ async def send_notification(
             detail="Could not determine recipient email address",
         )
 
-    # Send the notification (force_send=True to bypass auto_send check)
-    result = await NotificationService.send_notification(
+    # Enqueue the notification (force_send=True to bypass auto_send check).
+    # Delivery happens asynchronously via the outbox dispatch job.
+    msg = await NotificationGateway.enqueue(
         db=db,
         clinic_id=ctx.clinic_id,
         notification_type=data.notification_type,
-        to_email=patient_email,
         context=context,
         patient_id=patient.id if patient else None,
+        to_address=patient_email,
         triggered_by_user_id=ctx.user.id,
         force_send=True,
     )
 
-    if result.is_success:
+    if msg is not None and msg.status == "queued":
         return ApiResponse(
             data=ManualSendResponse(
                 success=True,
-                message="Email enviado correctamente",
-                log_id=None,  # Could return the log ID if needed
+                message="Notificación encolada para envío",
+                log_id=msg.id,
             )
         )
-    else:
-        return ApiResponse(
-            data=ManualSendResponse(
-                success=False,
-                message=f"Error al enviar email: {result.error_message}",
-                log_id=None,
-            )
+
+    reason = msg.error_message if msg else "no se pudo encolar"
+    return ApiResponse(
+        data=ManualSendResponse(
+            success=False,
+            message=f"No se pudo enviar: {reason}",
+            log_id=msg.id if msg else None,
         )
+    )
 
 
 # ============================================================================

--- a/backend/app/modules/notifications/schemas.py
+++ b/backend/app/modules/notifications/schemas.py
@@ -14,10 +14,12 @@ class EmailTemplateBase(BaseModel):
     """Base schema for email templates."""
 
     template_key: str = Field(..., max_length=100)
+    channel: str = Field(default="email", max_length=20)
     locale: str = Field(default="es", max_length=5)
-    subject: str = Field(..., max_length=255)
-    body_html: str
+    subject: str | None = Field(default=None, max_length=255)
+    body_html: str | None = None
     body_text: str | None = None
+    provider_template_name: str | None = Field(default=None, max_length=200)
     variables: dict | None = None
     description: str | None = Field(default=None, max_length=500)
     is_active: bool = True
@@ -61,6 +63,7 @@ class NotificationPreferenceBase(BaseModel):
     """Base schema for notification preferences."""
 
     email_enabled: bool = True
+    whatsapp_enabled: bool = False
     preferences: dict = Field(
         default_factory=lambda: {
             "appointment_confirmation": True,
@@ -85,6 +88,7 @@ class NotificationPreferenceUpdate(BaseModel):
     """Schema for updating notification preferences."""
 
     email_enabled: bool | None = None
+    whatsapp_enabled: bool | None = None
     preferences: dict | None = None
     preferred_locale: str | None = Field(default=None, max_length=5)
 
@@ -113,6 +117,7 @@ class NotificationTypeSettings(BaseModel):
     auto_send: bool = True
     enabled: bool = True
     hours_before: int | None = None  # For reminders
+    channels: list[str] | None = None  # Ordered fallback, e.g. ["whatsapp", "email"]
 
 
 class ClinicNotificationSettingsBase(BaseModel):
@@ -153,20 +158,23 @@ class ClinicNotificationSettingsResponse(ClinicNotificationSettingsBase):
 
 
 class EmailLogResponse(BaseModel):
-    """Schema for email log response."""
+    """Schema for a communication-message (outbox + audit) response."""
 
     id: UUID
     clinic_id: UUID
-    recipient_email: str
+    channel: str
+    to_address: str
     patient_id: UUID | None
     template_key: str
-    subject: str
+    subject: str | None
     status: str
-    provider: str
+    attempts: int
+    provider: str | None
     provider_message_id: str | None
     error_message: str | None
     created_at: datetime
     sent_at: datetime | None
+    delivered_at: datetime | None
     triggered_by_event: str | None
 
     model_config = {"from_attributes": True}

--- a/backend/app/modules/notifications/service.py
+++ b/backend/app/modules/notifications/service.py
@@ -2,22 +2,19 @@
 
 import logging
 from datetime import UTC, datetime
-from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.email import EmailResult, email_service
-from app.core.email.providers.base import EmailStatus
-from app.core.events import EventType, event_bus
 
 from .models import (
     ClinicNotificationSettings,
     ClinicSmtpSettings,
-    EmailLog,
-    EmailTemplate,
+    CommunicationMessage,
     NotificationPreference,
+    NotificationTemplate,
 )
 
 # Default locale used for patient-facing communications when neither a
@@ -69,7 +66,7 @@ class NotificationService:
         page_size: int = 20,
         locale: str | None = None,
         include_system: bool = True,
-    ) -> tuple[list[EmailTemplate], int]:
+    ) -> tuple[list[NotificationTemplate], int]:
         """List email templates for a clinic.
 
         Returns clinic-specific templates and optionally system templates.
@@ -80,23 +77,26 @@ class NotificationService:
         if include_system:
             # Include system templates and clinic templates
             conditions.append(
-                (EmailTemplate.clinic_id == clinic_id) | (EmailTemplate.clinic_id.is_(None))
+                (NotificationTemplate.clinic_id == clinic_id)
+                | (NotificationTemplate.clinic_id.is_(None))
             )
         else:
-            conditions.append(EmailTemplate.clinic_id == clinic_id)
+            conditions.append(NotificationTemplate.clinic_id == clinic_id)
 
         if locale:
-            conditions.append(EmailTemplate.locale == locale)
+            conditions.append(NotificationTemplate.locale == locale)
 
         # Count total
-        count_query = select(func.count()).select_from(EmailTemplate)
+        count_query = select(func.count()).select_from(NotificationTemplate)
         for condition in conditions:
             count_query = count_query.where(condition)
         total_result = await db.execute(count_query)
         total = total_result.scalar() or 0
 
         # Get items
-        query = select(EmailTemplate).order_by(EmailTemplate.template_key, EmailTemplate.locale)
+        query = select(NotificationTemplate).order_by(
+            NotificationTemplate.template_key, NotificationTemplate.locale
+        )
         for condition in conditions:
             query = query.where(condition)
 
@@ -112,18 +112,20 @@ class NotificationService:
         clinic_id: UUID,
         template_key: str,
         locale: str = "es",
-    ) -> EmailTemplate | None:
-        """Get a template by key and locale.
+        channel: str = "email",
+    ) -> NotificationTemplate | None:
+        """Get a template by key, locale and channel.
 
         Priority: clinic-specific > system template.
         """
         # First try clinic-specific
         result = await db.execute(
-            select(EmailTemplate).where(
-                EmailTemplate.clinic_id == clinic_id,
-                EmailTemplate.template_key == template_key,
-                EmailTemplate.locale == locale,
-                EmailTemplate.is_active == True,  # noqa: E712
+            select(NotificationTemplate).where(
+                NotificationTemplate.clinic_id == clinic_id,
+                NotificationTemplate.template_key == template_key,
+                NotificationTemplate.locale == locale,
+                NotificationTemplate.channel == channel,
+                NotificationTemplate.is_active == True,  # noqa: E712
             )
         )
         template = result.scalar_one_or_none()
@@ -132,11 +134,12 @@ class NotificationService:
 
         # Fallback to system template
         result = await db.execute(
-            select(EmailTemplate).where(
-                EmailTemplate.clinic_id.is_(None),
-                EmailTemplate.template_key == template_key,
-                EmailTemplate.locale == locale,
-                EmailTemplate.is_active == True,  # noqa: E712
+            select(NotificationTemplate).where(
+                NotificationTemplate.clinic_id.is_(None),
+                NotificationTemplate.template_key == template_key,
+                NotificationTemplate.locale == locale,
+                NotificationTemplate.channel == channel,
+                NotificationTemplate.is_active == True,  # noqa: E712
             )
         )
         return result.scalar_one_or_none()
@@ -146,12 +149,13 @@ class NotificationService:
         db: AsyncSession,
         clinic_id: UUID,
         template_id: UUID,
-    ) -> EmailTemplate | None:
+    ) -> NotificationTemplate | None:
         """Get a template by ID."""
         result = await db.execute(
-            select(EmailTemplate).where(
-                EmailTemplate.id == template_id,
-                (EmailTemplate.clinic_id == clinic_id) | (EmailTemplate.clinic_id.is_(None)),
+            select(NotificationTemplate).where(
+                NotificationTemplate.id == template_id,
+                (NotificationTemplate.clinic_id == clinic_id)
+                | (NotificationTemplate.clinic_id.is_(None)),
             )
         )
         return result.scalar_one_or_none()
@@ -161,9 +165,9 @@ class NotificationService:
         db: AsyncSession,
         clinic_id: UUID,
         data: dict,
-    ) -> EmailTemplate:
+    ) -> NotificationTemplate:
         """Create a new email template for a clinic."""
-        template = EmailTemplate(
+        template = NotificationTemplate(
             clinic_id=clinic_id,
             is_system=False,
             **data,
@@ -176,9 +180,9 @@ class NotificationService:
     @staticmethod
     async def update_template(
         db: AsyncSession,
-        template: EmailTemplate,
+        template: NotificationTemplate,
         data: dict,
-    ) -> EmailTemplate:
+    ) -> NotificationTemplate:
         """Update an email template."""
         if template.is_system:
             raise ValueError("Cannot modify system templates")
@@ -194,7 +198,7 @@ class NotificationService:
     @staticmethod
     async def delete_template(
         db: AsyncSession,
-        template: EmailTemplate,
+        template: NotificationTemplate,
     ) -> None:
         """Delete an email template."""
         if template.is_system:
@@ -479,26 +483,26 @@ class NotificationService:
         patient_id: UUID | None = None,
         status: str | None = None,
         template_key: str | None = None,
-    ) -> tuple[list[EmailLog], int]:
+    ) -> tuple[list[CommunicationMessage], int]:
         """List email logs with optional filters."""
-        conditions = [EmailLog.clinic_id == clinic_id]
+        conditions = [CommunicationMessage.clinic_id == clinic_id]
 
         if patient_id:
-            conditions.append(EmailLog.patient_id == patient_id)
+            conditions.append(CommunicationMessage.patient_id == patient_id)
         if status:
-            conditions.append(EmailLog.status == status)
+            conditions.append(CommunicationMessage.status == status)
         if template_key:
-            conditions.append(EmailLog.template_key == template_key)
+            conditions.append(CommunicationMessage.template_key == template_key)
 
         # Count total
-        count_query = select(func.count()).select_from(EmailLog)
+        count_query = select(func.count()).select_from(CommunicationMessage)
         for condition in conditions:
             count_query = count_query.where(condition)
         total_result = await db.execute(count_query)
         total = total_result.scalar() or 0
 
         # Get items
-        query = select(EmailLog).order_by(EmailLog.created_at.desc())
+        query = select(CommunicationMessage).order_by(CommunicationMessage.created_at.desc())
         for condition in conditions:
             query = query.where(condition)
 
@@ -508,65 +512,8 @@ class NotificationService:
 
         return items, total
 
-    @staticmethod
-    async def create_log(
-        db: AsyncSession,
-        clinic_id: UUID,
-        recipient_email: str,
-        template_key: str,
-        subject: str,
-        status: str,
-        provider: str,
-        patient_id: UUID | None = None,
-        provider_message_id: str | None = None,
-        error_message: str | None = None,
-        triggered_by_event: str | None = None,
-        triggered_by_user_id: UUID | None = None,
-        context_data: dict | None = None,
-    ) -> EmailLog:
-        """Create an email log entry."""
-        log = EmailLog(
-            clinic_id=clinic_id,
-            recipient_email=recipient_email,
-            patient_id=patient_id,
-            template_key=template_key,
-            subject=subject,
-            status=status,
-            provider=provider,
-            provider_message_id=provider_message_id,
-            error_message=error_message,
-            triggered_by_event=triggered_by_event,
-            triggered_by_user_id=triggered_by_user_id,
-            context_data=context_data,
-            sent_at=datetime.now(UTC) if status == "sent" else None,
-        )
-        db.add(log)
-        await db.commit()
-        await db.refresh(log)
-
-        # Broadcast to the event bus so the patient_timeline (and any other
-        # listener) can record the communication without querying email_logs.
-        bus_event = EventType.EMAIL_SENT if log.status == "sent" else EventType.EMAIL_FAILED
-        await event_bus.publish(
-            bus_event,
-            {
-                "clinic_id": str(log.clinic_id),
-                "patient_id": str(log.patient_id) if log.patient_id else None,
-                "email_log_id": str(log.id),
-                "template_key": log.template_key,
-                "subject": log.subject,
-                "recipient_email": log.recipient_email,
-                "status": log.status,
-                "error_message": log.error_message,
-                "occurred_at": (log.sent_at or log.created_at).isoformat()
-                if (log.sent_at or log.created_at)
-                else None,
-            },
-        )
-        return log
-
     # ========================================================================
-    # Send Email
+    # Consent gate (used by the gateway)
     # ========================================================================
 
     @staticmethod
@@ -607,118 +554,6 @@ class NotificationService:
                     return False, f"patient_opted_out_of_{notification_type}"
 
         return True, "ok"
-
-    @staticmethod
-    async def send_notification(
-        db: AsyncSession,
-        clinic_id: UUID,
-        notification_type: str,
-        to_email: str,
-        context: dict[str, Any],
-        patient_id: UUID | None = None,
-        triggered_by_event: str | None = None,
-        triggered_by_user_id: UUID | None = None,
-        force_send: bool = False,
-    ) -> EmailResult:
-        """Send a notification email.
-
-        Args:
-            db: Database session.
-            clinic_id: Clinic ID.
-            notification_type: Type of notification (e.g., 'appointment_confirmation').
-            to_email: Recipient email address.
-            context: Template context variables.
-            patient_id: Patient ID (optional).
-            triggered_by_event: Event that triggered this email (optional).
-            triggered_by_user_id: User who triggered manual send (optional).
-            force_send: Skip preference checks (for manual send).
-
-        Returns:
-            EmailResult with status.
-        """
-        # Check if should send (unless forced)
-        if not force_send:
-            should_send, reason = await NotificationService.should_send_notification(
-                db, clinic_id, notification_type, patient_id
-            )
-            if not should_send:
-                logger.info(
-                    f"Skipping notification {notification_type}: {reason}",
-                    extra={"clinic_id": str(clinic_id), "patient_id": str(patient_id)},
-                )
-                # Log the skipped email
-                await NotificationService.create_log(
-                    db=db,
-                    clinic_id=clinic_id,
-                    recipient_email=to_email,
-                    template_key=notification_type,
-                    subject=f"[SKIPPED] {notification_type}",
-                    status="skipped",
-                    provider=email_service.get_provider_name(),
-                    patient_id=patient_id,
-                    error_message=reason,
-                    triggered_by_event=triggered_by_event,
-                    triggered_by_user_id=triggered_by_user_id,
-                )
-                return EmailResult(
-                    status=EmailStatus.SKIPPED,
-                    provider=email_service.get_provider_name(),
-                    error_message=reason,
-                )
-
-        # Resolve locale: clinic-wide default (settings.communication_language)
-        # → patient preference override when present.
-        locale = await resolve_clinic_communication_locale(db, clinic_id)
-        if patient_id:
-            prefs = await NotificationService.get_patient_preferences(db, clinic_id, patient_id)
-            if prefs and prefs.preferred_locale:
-                locale = prefs.preferred_locale
-
-        # Get template
-        template = await NotificationService.get_template(db, clinic_id, notification_type, locale)
-
-        # Build subject from template or use default
-        subject = template.subject if template else f"Notificación: {notification_type}"
-
-        # Get custom template content if available
-        template_html = template.body_html if template else None
-        template_text = template.body_text if template else None
-
-        # Send email (use clinic-specific SMTP if configured)
-        result = await email_service.send_templated(
-            to_email=to_email,
-            to_name=context.get("patient_name"),
-            template_key=notification_type,
-            locale=locale,
-            context=context,
-            subject=subject,
-            template_html=template_html,
-            template_text=template_text,
-            db=db,
-            clinic_id=clinic_id,
-        )
-
-        # Sanitize context for logging (remove sensitive data)
-        safe_context = {k: v for k, v in context.items() if k not in ["password", "token"]}
-
-        # Log the email
-        await NotificationService.create_log(
-            db=db,
-            clinic_id=clinic_id,
-            recipient_email=to_email,
-            template_key=notification_type,
-            subject=subject,
-            status="sent" if result.is_success else "failed",
-            provider=result.provider,
-            patient_id=patient_id,
-            provider_message_id=result.message_id,
-            error_message=result.error_message,
-            triggered_by_event=triggered_by_event,
-            triggered_by_user_id=triggered_by_user_id,
-            context_data=safe_context,
-        )
-
-        return result
 
     @staticmethod
     async def test_email_connection(to_email: str) -> EmailResult:

--- a/backend/app/modules/notifications/tasks.py
+++ b/backend/app/modules/notifications/tasks.py
@@ -15,6 +15,23 @@ from app.database import async_session_maker
 logger = logging.getLogger(__name__)
 
 
+async def dispatch_outbox() -> None:
+    """Scheduled tick: send a batch of due queued/failed messages.
+
+    Thin wrapper around ``NotificationGateway.dispatch_outbox`` that owns the
+    DB session. Network I/O happens here (in the scheduler), never in a request.
+    """
+    from app.modules.notifications.gateway import NotificationGateway
+
+    try:
+        async with async_session_maker() as db:
+            sent = await NotificationGateway.dispatch_outbox(db)
+            if sent:
+                logger.debug("Outbox dispatch tick processed %d message(s)", sent)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Outbox dispatch tick failed: %s", exc, exc_info=True)
+
+
 async def process_appointment_reminders() -> None:
     """Process and send appointment reminders.
 
@@ -28,8 +45,8 @@ async def process_appointment_reminders() -> None:
     """
     from app.core.auth.models import Clinic, User
     from app.modules.agenda.models import Appointment
-    from app.modules.notifications.models import ClinicNotificationSettings, EmailLog
-    from app.modules.notifications.service import NotificationService
+    from app.modules.notifications.gateway import NotificationGateway
+    from app.modules.notifications.models import ClinicNotificationSettings
     from app.modules.patients.models import Patient
 
     logger.debug("Processing appointment reminders...")
@@ -82,24 +99,6 @@ async def process_appointment_reminders() -> None:
                 clinic = result.scalar_one_or_none()
 
                 for appointment in appointments:
-                    # Check if reminder was already sent for this appointment
-                    result = await db.execute(
-                        select(EmailLog.id).where(
-                            and_(
-                                EmailLog.clinic_id == clinic_id,
-                                EmailLog.template_key == "appointment_reminder",
-                                EmailLog.status == "sent",
-                                # Check context_data for appointment_id
-                                EmailLog.context_data["appointment_id"].astext
-                                == str(appointment.id),
-                            )
-                        )
-                    )
-                    already_sent = result.scalar_one_or_none()
-                    if already_sent:
-                        reminders_skipped += 1
-                        continue
-
                     # Get patient
                     result = await db.execute(
                         select(Patient).where(Patient.id == appointment.patient_id)
@@ -133,27 +132,26 @@ async def process_appointment_reminders() -> None:
                         "appointment_id": str(appointment.id),  # For duplicate check
                     }
 
-                    # Send reminder
-                    result = await NotificationService.send_notification(
+                    # Enqueue reminder — dedup_key keeps the 5-min re-runs idempotent
+                    # (replaces the old context_data["appointment_id"] log scan).
+                    msg = await NotificationGateway.enqueue(
                         db=db,
                         clinic_id=clinic_id,
                         notification_type="appointment_reminder",
-                        to_email=patient.email,
                         context=context,
                         patient_id=patient.id,
+                        to_address=patient.email,
                         triggered_by_event="scheduler.appointment_reminder",
                         force_send=True,  # Skip preference check (already checked auto_send)
+                        dedup_key=f"appointment_reminder:{appointment.id}",
                     )
 
-                    if result.is_success:
+                    if msg is None or msg.status == "skipped":
+                        reminders_skipped += 1
+                    else:
                         reminders_sent += 1
                         logger.info(
-                            f"Sent reminder for appointment {appointment.id} to {patient.email}"
-                        )
-                    else:
-                        logger.warning(
-                            f"Failed to send reminder for appointment {appointment.id}: "
-                            f"{result.error_message}"
+                            f"Queued reminder for appointment {appointment.id} to {patient.email}"
                         )
 
         if reminders_sent > 0 or reminders_skipped > 0:
@@ -179,7 +177,7 @@ async def send_single_reminder(appointment_id: UUID, clinic_id: UUID) -> bool:
     """
     from app.core.auth.models import Clinic, User
     from app.modules.agenda.models import Appointment
-    from app.modules.notifications.service import NotificationService
+    from app.modules.notifications.gateway import NotificationGateway
     from app.modules.patients.models import Patient
 
     try:
@@ -231,19 +229,20 @@ async def send_single_reminder(appointment_id: UUID, clinic_id: UUID) -> bool:
                 "appointment_id": str(appointment.id),
             }
 
-            # Send reminder (force_send to bypass auto_send check)
-            send_result = await NotificationService.send_notification(
+            # Enqueue reminder (force_send to bypass auto_send check)
+            msg = await NotificationGateway.enqueue(
                 db=db,
                 clinic_id=clinic_id,
                 notification_type="appointment_reminder",
-                to_email=patient.email,
                 context=context,
                 patient_id=patient.id,
+                to_address=patient.email,
                 triggered_by_event="manual.appointment_reminder",
                 force_send=True,
+                dedup_key=f"appointment_reminder:{appointment.id}",
             )
 
-            return send_result.is_success
+            return msg is not None and msg.status != "skipped"
 
     except Exception as e:
         logger.error(f"Error sending single reminder: {e}", exc_info=True)

--- a/backend/app/modules/notifications/tools.py
+++ b/backend/app/modules/notifications/tools.py
@@ -1,0 +1,91 @@
+"""Agent tools for the notifications module.
+
+Thin wrapper over :class:`NotificationGateway` — no business logic here.
+``send_notification`` enqueues through the same consent + channel-resolution
+path as every other producer (it never bypasses ``do_not_contact`` or clinic
+settings). Structured params only, so it stays cloud-eligible under redaction.
+See ``docs/technical/copilot-agentic-architecture.md`` §3.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.core.agents import AgentContext, Tool, ToolCategory
+
+from .channels import Channel
+from .gateway import NotificationGateway
+
+
+class SendNotificationArgs(BaseModel):
+    patient_id: UUID
+    notification_type: str = Field(
+        description=(
+            "Tipo de notificación: 'appointment_reminder', 'welcome', "
+            "'budget_sent', 'appointment_confirmation', etc."
+        )
+    )
+    channel: Channel | None = Field(
+        default=None,
+        description="Canal forzado (email / whatsapp). None = automático con fallback.",
+    )
+    context: dict[str, str] = Field(
+        default_factory=dict,
+        description="Variables adicionales de plantilla (p. ej. fecha de la cita).",
+    )
+
+
+async def _send_notification(ctx: AgentContext, params: SendNotificationArgs) -> dict:
+    from app.modules.patients.models import Patient
+
+    patient = (
+        await ctx.db.execute(
+            select(Patient).where(
+                Patient.clinic_id == ctx.clinic_id, Patient.id == params.patient_id
+            )
+        )
+    ).scalar_one_or_none()
+    if patient is None:
+        return {"error": "patient_not_found"}
+
+    context = dict(params.context)
+    context.setdefault("patient_name", f"{patient.first_name} {patient.last_name}")
+
+    msg = await NotificationGateway.enqueue(
+        ctx.db,
+        ctx.clinic_id,
+        params.notification_type,
+        context=context,
+        patient_id=params.patient_id,
+        channels=[params.channel.value] if params.channel else None,
+        triggered_by_user_id=ctx.supervisor_id,
+    )
+    if msg is None:
+        return {"status": "duplicate_skipped"}
+    return {
+        "message_id": msg.id,
+        "channel": msg.channel,
+        "status": msg.status,
+        "error_message": msg.error_message,
+    }
+
+
+def get_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="send_notification",
+            description=(
+                "Encolar una notificación a un paciente por su canal preferido "
+                "(email / WhatsApp), con fallback a email. Respeta el "
+                "consentimiento del paciente (do_not_contact) y la configuración "
+                "de la clínica. La entrega es asíncrona (cola de salida)."
+            ),
+            parameters=SendNotificationArgs,
+            handler=_send_notification,
+            permissions=["send"],
+            category=ToolCategory.WRITE,
+        ),
+    ]

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.notifications.models import (
-    EmailTemplate,
+    NotificationTemplate,
 )
 from app.modules.notifications.service import NotificationService
 
@@ -207,7 +207,7 @@ async def test_cannot_delete_system_template(
     # First create a system template in DB
     from uuid import uuid4
 
-    system_template = EmailTemplate(
+    system_template = NotificationTemplate(
         id=uuid4(),
         clinic_id=None,
         template_key="system_test",

--- a/backend/tests/test_notifications_gateway.py
+++ b/backend/tests/test_notifications_gateway.py
@@ -1,0 +1,248 @@
+"""Tests for the multi-channel notification gateway + channel adapters."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.notifications.channels import (
+    AdapterResult,
+    Channel,
+    ChannelAdapter,
+    SendStatus,
+    channel_registry,
+)
+from app.modules.notifications.channels.email_adapter import EmailAdapter
+from app.modules.notifications.gateway import NotificationGateway, _backoff_seconds
+from app.modules.notifications.models import CommunicationMessage, NotificationTemplate
+
+
+async def _email_template(db: AsyncSession, clinic_id, key: str = "appointment_confirmation"):
+    tmpl = NotificationTemplate(
+        clinic_id=clinic_id,
+        channel="email",
+        template_key=key,
+        locale="es",
+        subject="Hola",
+        body_html="<p>{{patient_name}}</p>",
+        is_system=False,
+    )
+    db.add(tmpl)
+    await db.commit()
+    return tmpl
+
+
+# --------------------------------------------------------------------------- #
+# Adapter contract + registry
+# --------------------------------------------------------------------------- #
+def test_email_adapter_satisfies_protocol():
+    adapter = EmailAdapter()
+    assert isinstance(adapter, ChannelAdapter)
+    assert adapter.channel == Channel.EMAIL
+    assert channel_registry.get_for_channel(Channel.EMAIL) is not None
+
+
+def test_registry_register_is_idempotent_and_unregisterable():
+    class FakeAdapter:
+        channel = Channel.WHATSAPP
+        adapter_name = "fake_test_adapter"
+
+        async def supports(self, db, clinic_id):  # noqa: ARG002
+            return True
+
+        async def send(self, db, msg):  # noqa: ARG002
+            return AdapterResult(status=SendStatus.SENT, provider="fake")
+
+    a = FakeAdapter()
+    channel_registry.register(a)
+    channel_registry.register(a)  # idempotent — no duplicate, no raise
+    assert channel_registry.get_for_channel(Channel.WHATSAPP) is a
+    channel_registry.unregister("fake_test_adapter")
+    assert channel_registry.get_for_channel(Channel.WHATSAPP) is None
+
+
+def test_backoff_is_exponential_and_capped():
+    assert _backoff_seconds(1) == 60
+    assert _backoff_seconds(2) == 120
+    assert _backoff_seconds(3) == 240
+    assert _backoff_seconds(99) == 3600  # capped at 1h
+
+
+# --------------------------------------------------------------------------- #
+# Enqueue + dispatch (email round-trip through the console provider)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_enqueue_then_dispatch_sends_email(db_session, test_patient):
+    await _email_template(db_session, test_patient.clinic_id)
+
+    msg = await NotificationGateway.enqueue(
+        db_session,
+        test_patient.clinic_id,
+        "appointment_confirmation",
+        context={},
+        patient_id=test_patient.id,
+        to_address=test_patient.email,
+    )
+    assert msg is not None
+    assert msg.status == "queued"
+    assert msg.channel == "email"
+    assert msg.to_address == test_patient.email
+
+    attempted = await NotificationGateway.dispatch_outbox(db_session)
+    assert attempted == 1
+    await db_session.refresh(msg)
+    assert msg.status == "sent"
+    assert msg.sent_at is not None
+    assert msg.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_key_is_idempotent(db_session, test_patient):
+    await _email_template(db_session, test_patient.clinic_id)
+    key = f"appointment_reminder:{uuid4()}"
+    first = await NotificationGateway.enqueue(
+        db_session,
+        test_patient.clinic_id,
+        "appointment_confirmation",
+        context={},
+        patient_id=test_patient.id,
+        to_address=test_patient.email,
+        dedup_key=key,
+    )
+    second = await NotificationGateway.enqueue(
+        db_session,
+        test_patient.clinic_id,
+        "appointment_confirmation",
+        context={},
+        patient_id=test_patient.id,
+        to_address=test_patient.email,
+        dedup_key=key,
+    )
+    assert first is not None
+    assert second is None  # idempotent no-op
+
+
+# --------------------------------------------------------------------------- #
+# Consent
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_do_not_contact_hard_blocks_even_force(db_session, test_patient):
+    test_patient.do_not_contact = True
+    await db_session.commit()
+
+    msg = await NotificationGateway.enqueue(
+        db_session,
+        test_patient.clinic_id,
+        "appointment_confirmation",
+        context={},
+        patient_id=test_patient.id,
+        to_address=test_patient.email,
+        force_send=True,
+    )
+    assert msg is not None
+    assert msg.status == "skipped"
+    assert msg.error_message == "do_not_contact"
+
+
+@pytest.mark.asyncio
+async def test_email_opt_out_skips(db_session, test_patient):
+    from app.modules.notifications.models import NotificationPreference
+
+    db_session.add(
+        NotificationPreference(
+            clinic_id=test_patient.clinic_id,
+            patient_id=test_patient.id,
+            email_enabled=False,
+        )
+    )
+    await db_session.commit()
+
+    msg = await NotificationGateway.enqueue(
+        db_session,
+        test_patient.clinic_id,
+        "appointment_confirmation",
+        context={},
+        patient_id=test_patient.id,
+        to_address=test_patient.email,
+    )
+    assert msg.status == "skipped"
+    assert msg.error_message == "patient_opted_out"
+
+
+# --------------------------------------------------------------------------- #
+# Retry / backoff with a failing adapter
+# --------------------------------------------------------------------------- #
+@pytest_asyncio.fixture
+async def failing_email_adapter():
+    """Override the email channel with an adapter that always fails."""
+
+    class FailingEmail:
+        channel = Channel.EMAIL
+        adapter_name = "failing_email_test"
+
+        async def supports(self, db, clinic_id):  # noqa: ARG002
+            return True
+
+        async def send(self, db, msg):  # noqa: ARG002
+            return AdapterResult(status=SendStatus.FAILED, provider="failing", error_message="boom")
+
+    adapter = FailingEmail()
+    channel_registry.register(adapter)
+    yield adapter
+    channel_registry.unregister("failing_email_test")
+
+
+@pytest.mark.asyncio
+async def test_failed_send_schedules_backoff(db_session, test_patient, failing_email_adapter):
+    await _email_template(db_session, test_patient.clinic_id)
+    msg = await NotificationGateway.enqueue(
+        db_session,
+        test_patient.clinic_id,
+        "appointment_confirmation",
+        context={},
+        patient_id=test_patient.id,
+        to_address=test_patient.email,
+    )
+
+    await NotificationGateway.dispatch_outbox(db_session)
+    await db_session.refresh(msg)
+    assert msg.status == "failed"
+    assert msg.attempts == 1
+    assert msg.error_message == "boom"
+    assert msg.next_attempt_at is not None and msg.next_attempt_at > datetime.now(UTC)
+
+    # A second tick before next_attempt_at must not re-pick the row.
+    attempted = await NotificationGateway.dispatch_outbox(db_session)
+    assert attempted == 0
+
+
+# --------------------------------------------------------------------------- #
+# Agent tool wrapper
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_send_notification_tool_enqueues(db_session, test_patient):
+    from types import SimpleNamespace
+
+    from app.modules.notifications.tools import SendNotificationArgs, _send_notification
+
+    await _email_template(db_session, test_patient.clinic_id)
+    ctx = SimpleNamespace(db=db_session, clinic_id=test_patient.clinic_id, supervisor_id=None)
+    result = await _send_notification(
+        ctx,
+        SendNotificationArgs(
+            patient_id=test_patient.id, notification_type="appointment_confirmation"
+        ),
+    )
+    assert result["status"] == "queued"
+    assert result["channel"] == "email"
+
+    row = (
+        await db_session.execute(
+            select(CommunicationMessage).where(CommunicationMessage.id == result["message_id"])
+        )
+    ).scalar_one()
+    # tool auto-injected patient_name into context
+    assert row.context_data.get("patient_name") == "Test Patient"

--- a/docs/adr/0016-channel-adapter-architecture.md
+++ b/docs/adr/0016-channel-adapter-architecture.md
@@ -1,0 +1,79 @@
+# 0016 — Channel-adapter architecture for the notifications gateway
+
+- **Status:** accepted
+- **Date:** 2026-06-26
+- **Deciders:** Backend team
+- **Tags:** modules, notifications, events, integrations
+
+## Context
+
+The `notifications` module was email-only and sent synchronously inside the
+request (`service.send_notification`), which its own `CLAUDE.md` flagged as a
+gotcha ("no outbound network calls during a request"). The clinic market
+(ES/LATAM) needs WhatsApp, delivered through a third-party vendor (Kapso, with
+Twilio as an alternative) — issue #63. We want our own communications logic in
+core and a thin, swappable adapter for the wire, without coupling the core
+module to any vendor and without breaking module isolation.
+
+## Decision
+
+The **channel-adapter contract and registry live inside `notifications`**
+(`backend/app/modules/notifications/channels/`), not in core. A vendor module
+declares `depends=["notifications"]`, imports the public contract, and
+**registers its adapter at import time** via `channel_registry.register(...)`.
+Delivery goes through a **durable outbox**: `enqueue` persists a `queued`
+`communication_messages` row (committing with the request) and a scheduled
+`dispatch_outbox` job sends it with `FOR UPDATE SKIP LOCKED` + exponential
+backoff. **Vendor secrets live in the vendor module's own table/branch**, never
+in core; core only records which adapter serves which channel per clinic
+(`clinic_channel_settings`, non-secret).
+
+## Consequences
+
+### Good
+
+- Adding a channel is a new community module + one `register()` call — zero
+  core changes, passes `test_module_isolation.py` (only import is
+  `app.modules.notifications.channels`, which is in the vendor's `depends`).
+- No network in the request transaction; sends are retriable and observable
+  (status lifecycle on one row that is both queue entry and audit record).
+- Clean round-trip uninstall: dropping the vendor module drops its secrets and
+  its adapter unregisters; the channel simply falls back to email.
+- The outbox + registry are reusable substrate for future fan-out (telephony
+  #64, public webhooks #65) — to be extracted to core only when a second real
+  consumer exists (avoid speculative generalization now).
+
+### Bad / accepted trade-offs
+
+- Import-time registration is an import side-effect (the codebase otherwise
+  prefers explicit `BaseModule` hooks). Mitigated by dependency-ordered loading
+  (`topological_sort`) + idempotent `register`.
+- A process crash mid-send can leave a row in `sending` (visible in the logs
+  view). Upgrade path: sweep stale `sending` rows back to `failed`.
+- WhatsApp proactive sends are template-only (Meta 24h-window rule) in V1.
+
+## Alternatives considered
+
+- **Core-level `BaseModule.get_channel_adapters()` hook** — more idiomatic (no
+  import side-effect) but puts notification-flavoured types (`OutboundMessage`)
+  in core before a second consumer exists. Rejected as premature coupling.
+- **Vendor adapter in-core (no separate module)** — simpler install but violates
+  "non-core modules ship off, admin activates" and bloats the core module with
+  vendor HTTP + secrets. Rejected.
+- **Keep synchronous send, add a WhatsApp branch** — no durability/retry and
+  keeps network in the request. Rejected.
+
+## How to verify the rule still holds
+
+- `backend/tests/test_module_isolation.py` — fails if a vendor adapter imports
+  anything outside its `depends`.
+- `backend/tests/test_notifications_gateway.py` — adapter contract, registry
+  idempotency/unregister, outbox dispatch + backoff, consent hard-block.
+- Round-trip uninstall test for the vendor module (`whatsapp_kapso`, Phase 2).
+
+## References
+
+- `backend/app/modules/notifications/channels/` (contract + registry)
+- `backend/app/modules/notifications/gateway.py` (enqueue + dispatch)
+- `backend/app/modules/notifications/models.py` (`communication_messages`)
+- Issue #63; ADRs 0001 (modular contract), 0003 (event bus)

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -44,8 +44,8 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `document.archived` | `EventType.DOCUMENT_ARCHIVED` | — | — |
 | `document.deleted` | `EventType.DOCUMENT_DELETED` | `media` | — |
 | `document.uploaded` | `EventType.DOCUMENT_UPLOADED` | `media` | `patient_timeline` |
-| `email.failed` | `EventType.EMAIL_FAILED` | — | `patient_timeline` |
-| `email.sent` | `EventType.EMAIL_SENT` | — | `patient_timeline` |
+| `email.failed` | `EventType.EMAIL_FAILED` | `notifications` | `patient_timeline` |
+| `email.sent` | `EventType.EMAIL_SENT` | `notifications` | `patient_timeline` |
 | `invoice.cancelled` | `EventType.INVOICE_CANCELLED` | — | — |
 | `invoice.created` | `EventType.INVOICE_CREATED` | — | — |
 | `invoice.issued` | `EventType.INVOICE_ISSUED` | `billing` | `patient_timeline` |
@@ -63,6 +63,11 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `migration.job.completed` | `EventType.MIGRATION_JOB_COMPLETED` | `migration_import` | — |
 | `migration.job.failed` | `EventType.MIGRATION_JOB_FAILED` | `migration_import` | — |
 | `migration.job.started` | `EventType.MIGRATION_JOB_STARTED` | `migration_import` | — |
+| `notification.delivered` | `EventType.NOTIFICATION_DELIVERED` | — | — |
+| `notification.failed` | `EventType.NOTIFICATION_FAILED` | — | — |
+| `notification.queued` | `EventType.NOTIFICATION_QUEUED` | — | — |
+| `notification.reply_received` | `EventType.NOTIFICATION_REPLY_RECEIVED` | — | — |
+| `notification.sent` | `EventType.NOTIFICATION_SENT` | — | — |
 | `odontogram.condition.changed` | `EventType.ODONTOGRAM_CONDITION_CHANGED` | — | — |
 | `odontogram.surface.updated` | `EventType.ODONTOGRAM_SURFACE_UPDATED` | — | — |
 | `odontogram.tooth.updated` | `EventType.ODONTOGRAM_TOOTH_UPDATED` | — | — |
@@ -361,14 +366,16 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `email.failed`
 
 - **Constant:** `EventType.EMAIL_FAILED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `notifications` — `backend/app/modules/notifications/gateway.py:408`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `email.sent`
 
 - **Constant:** `EventType.EMAIL_SENT`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `notifications` — `backend/app/modules/notifications/gateway.py:406`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -491,6 +498,36 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.MIGRATION_JOB_STARTED`
 - **Publishers:**
   - `migration_import` — `backend/app/modules/migration_import/events.py:26`
+- **Subscribers:** —
+
+### `notification.delivered`
+
+- **Constant:** `EventType.NOTIFICATION_DELIVERED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `notification.failed`
+
+- **Constant:** `EventType.NOTIFICATION_FAILED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `notification.queued`
+
+- **Constant:** `EventType.NOTIFICATION_QUEUED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `notification.reply_received`
+
+- **Constant:** `EventType.NOTIFICATION_REPLY_RECEIVED`
+- **Publishers:** _none in tree — declared but unused_
+- **Subscribers:** —
+
+### `notification.sent`
+
+- **Constant:** `EventType.NOTIFICATION_SENT`
+- **Publishers:** _none in tree — declared but unused_
 - **Subscribers:** —
 
 ### `odontogram.condition.changed`

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -19,7 +19,7 @@ Maintained by `backend/scripts/generate_catalogs.py`. CI fails if a manifest cha
 | `copilot` | 0.1.0 | official | — | auto | yes | 5 | 3 | 1 | yes |
 | `media` | 0.2.0 | official | patients | auto | no | 4 | 7 | 1 | yes |
 | `migration_import` | 0.1.0 | official | patients, patients_clinical, clinical_notes, agenda, schedules, recalls, catalog, budget, odontogram, treatment_plan, billing, payments, media | manual | yes | 4 | 5 | 0 | yes |
-| `notifications` | 0.1.0 | official | patients, agenda, budget, billing, catalog | auto | no | 8 | 0 | 6 | yes |
+| `notifications` | 0.1.0 | official | patients, agenda, budget, billing, catalog | auto | no | 8 | 2 | 6 | yes |
 | `odontogram` | 0.3.0 | official | patients, catalog | auto | no | 4 | 4 | 0 | yes |
 | `patient_timeline` | 0.1.0 | official | patients | auto | no | 1 | 0 | 34 | yes |
 | `patients` | 0.1.0 | official | — | auto | no | 2 | 3 | 0 | yes |
@@ -257,7 +257,9 @@ Email templates, preferences, SMTP, event-driven sending.
   - `notifications.settings.write`
   - `notifications.templates.read`
   - `notifications.templates.write`
-- **Events emitted:** —
+- **Events emitted:**
+  - `email.failed`
+  - `email.sent`
 - **Events consumed:**
   - `appointment.cancelled`
   - `appointment.scheduled`

--- a/docs/technical/notifications/events.md
+++ b/docs/technical/notifications/events.md
@@ -12,18 +12,27 @@ Per-module slice of [`docs/events-catalog.md`](../../events-catalog.md)
 
 ## Published
 
-_This module does not publish any events._
+Published by the gateway (`gateway.py`) across the outbox lifecycle:
+
+| Event | When |
+|-------|------|
+| `notification.queued` | A message is enqueued for delivery. |
+| `notification.sent` | An adapter delivered the message. |
+| `notification.failed` | A send attempt failed (will retry until `max_attempts`). |
+| `notification.delivered` | Vendor webhook reports delivered/read. |
+| `notification.reply_received` | Inbound reply logged (vendor webhook, Phase 2). |
+| `email.sent` / `email.failed` | **Legacy, dual-published** for `channel=email` only, one release, so `patient_timeline` keeps working. |
 
 ## Subscribed
 
 | Event | Handler | Effect |
 |-------|---------|--------|
-| `appointment.cancelled` | _Handler module path._ | _What it does in response._ |
-| `appointment.scheduled` | _Handler module path._ | _What it does in response._ |
-| `budget.accepted` | _Handler module path._ | _What it does in response._ |
-| `budget.sent` | _Handler module path._ | _What it does in response._ |
-| `invoice.sent` | _Handler module path._ | _What it does in response._ |
-| `patient.created` | _Handler module path._ | _What it does in response._ |
+| `appointment.scheduled` | `handlers.on_appointment_scheduled` | Enqueue `appointment_confirmation`. |
+| `appointment.cancelled` | `handlers.on_appointment_cancelled` | Enqueue `appointment_cancelled`. |
+| `patient.created` | `handlers.on_patient_created` | Enqueue `welcome`. |
+| `budget.sent` | `handlers.on_budget_sent` | Enqueue `budget_sent` (only when `send_method=email`). |
+| `budget.accepted` | `handlers.on_budget_accepted` | Enqueue `budget_accepted`. |
+| `invoice.sent` | `handlers.on_invoice_sent` | Enqueue `invoice_sent` (only when `send_method=email`). |
 
 ## Adding a new event
 

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -1085,6 +1085,7 @@ export interface NotificationPreference {
   patient_id?: string
   user_id?: string
   email_enabled: boolean
+  whatsapp_enabled: boolean
   preferences: Record<string, boolean>
   preferred_locale: string
   created_at: string
@@ -1093,6 +1094,7 @@ export interface NotificationPreference {
 
 export interface NotificationPreferenceUpdate {
   email_enabled?: boolean
+  whatsapp_enabled?: boolean
   preferences?: Record<string, boolean>
   preferred_locale?: string
 }
@@ -1101,6 +1103,7 @@ export interface NotificationTypeSettings {
   auto_send: boolean
   enabled: boolean
   hours_before?: number
+  channels?: string[]
 }
 
 export interface ClinicNotificationSettings {
@@ -1118,16 +1121,19 @@ export interface ClinicNotificationSettingsUpdate {
 export interface EmailLog {
   id: string
   clinic_id: string
-  recipient_email: string
+  channel: string
+  to_address: string
   patient_id?: string
   template_key: string
-  subject: string
-  status: 'pending' | 'sent' | 'failed' | 'skipped'
-  provider: string
+  subject?: string
+  status: 'queued' | 'sending' | 'sent' | 'failed' | 'skipped' | 'delivered' | 'read'
+  attempts: number
+  provider?: string
   provider_message_id?: string
   error_message?: string
   created_at: string
   sent_at?: string
+  delivered_at?: string
   triggered_by_event?: string
 }
 


### PR DESCRIPTION
## Summary

Turns the email-only `notifications` module into a **channel-agnostic gateway** with pluggable outbound adapters and a durable outbox. Our communications logic (channel resolution, consent, templates, outbox, logging) stays in core; adapters only put a rendered message on the wire. Email ships built-in; WhatsApp via the `whatsapp_kapso` community module arrives in **Phase 2**.

Issue #63. Architecture: ADR 0016.

## What's in Phase 1

- **`channels/`** — `ChannelAdapter` protocol, `OutboundMessage`/`AdapterResult`, idempotent `channel_registry`, built-in `EmailAdapter` (wraps the core email service, no SMTP logic moved). Vendor modules register at import time.
- **`gateway.py`** — `NotificationGateway.enqueue` (consent gate → channel resolution → `queued` row, no network in-request) + `dispatch_outbox` scheduled job (`FOR UPDATE SKIP LOCKED` + exponential backoff). `do_not_contact` is a hard block on every channel.
- **Models** (Alembic `notif_0002`, data preserved, `channel` backfilled to `email`): `email_logs`→`communication_messages` (outbox + audit, one table); `email_templates`→`notification_templates` (`channel` + `provider_template_name` for WhatsApp HSM); per-channel WhatsApp opt-in on `notification_preferences`; new generic `clinic_channel_settings`.
- **Send-path** — handlers, reminder cron and manual-send route now `enqueue`; reminder dedup moved to a `dedup_key` unique index; dead `send_notification`/`create_log` removed.
- **Events** — `notification.queued/sent/failed/delivered/reply_received`. `EMAIL_SENT/FAILED` are dual-published for `channel=email` for one release so `patient_timeline` keeps working.
- **Agent tool** — `send_notification` (WRITE) wrapping the gateway; never bypasses consent.

## Out of scope (Phase 2)

`whatsapp_kapso` community module (Kapso adapter, signed webhook, HSM templates), the interactive per-channel routing UI + WhatsApp opt-in toggle, and `channels.read/write` permissions. Email-only Phase 1 has nothing to toggle yet.

## Verification

- Tests: `test_notifications` (11) + new `test_notifications_gateway` (9, adapter contract, registry idempotency, outbox dispatch + backoff, dedup, consent hard-block) + `test_module_isolation` — green. Timeline + copilot/tools/agents regression (98) green. Full suite collects (811) with no import errors.
- Migration `notif_0002` applies cleanly, no model/DB drift on the touched tables.
- Browser E2E on the running app: create patient → `patient.created` → enqueue (`queued`) → `dispatch_outbox` → `sent` (console provider) → patient timeline shows "Email enviado". Settings page + SMTP config render and persist.
- ruff check + format, eslint, docs-layout check, catalog regen — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)