### PR TITLE
fix(docs): repair docs-portal dead links + refresh events catalog

### DIFF
--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -367,7 +367,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.EMAIL_FAILED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:544`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:562`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -375,7 +375,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.EMAIL_SENT`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:542`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:560`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -522,7 +522,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.NOTIFICATION_REPLY_RECEIVED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:375`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:382`
 - **Subscribers:**
   - `patient_timeline`
 

--- a/docs/modules/whatsapp_kapso.md
+++ b/docs/modules/whatsapp_kapso.md
@@ -3,15 +3,15 @@
 WhatsApp delivery for the notifications gateway via **Kapso** (SaaS over the
 Meta WhatsApp Cloud API). Community, installable/removable. Issue #63.
 
-It is the thin vendor adapter under [ADR 0016](adr/0016-channel-adapter-architecture.md):
+It is the thin vendor adapter under [ADR 0016](../adr/0016-channel-adapter-architecture.md):
 a `KapsoAdapter` registered into the notifications channel registry, a public
 signed webhook (delivery status + inbound replies), and a connect/settings UI
 (credentials, template sync + mapping, test send). All comms logic — routing,
 consent, outbox, the conversation thread and 24h session window — lives in
-`notifications` ([ADR 0017](adr/0017-inbound-conversation.md)).
+`notifications` ([ADR 0017](../adr/0017-inbound-conversation.md)).
 
-- Technical: [`docs/technical/whatsapp_kapso/`](technical/whatsapp_kapso/overview.md)
-- User manual: [`docs/user-manual/es/whatsapp_kapso/`](user-manual/es/whatsapp_kapso/index.md)
+- Technical: [`docs/technical/whatsapp_kapso/`](../technical/whatsapp_kapso/overview.md)
+- User manual: [`docs/user-manual/es/whatsapp_kapso/`](../user-manual/es/whatsapp_kapso/index.md)
 - Per-module notes: `backend/app/modules/whatsapp_kapso/CLAUDE.md`
 
 **Prerequisite (legal/ops, not code):** a signed DPA with Kapso (data


### PR DESCRIPTION
CI on `main` went red after #89. Two doc-only fixes:

- **docs-portal-build**: 3 dead links in `docs/modules/whatsapp_kapso.md` were relative to `docs/` root (`adr/…`, `technical/…`) instead of to the file (`../adr/…`, `../technical/…`). VitePress build is green again (verified locally).
- **catalog-freshness**: `events-catalog.md` had stale `gateway.py` line numbers for the `email.sent/failed` + `notification.reply_received` publishers (the Phase 2A edits shifted them). Regenerated; `generate_catalogs.py --check` and `check_docs_coverage.py --strict` both pass locally.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)