### PR TITLE
fix: audit remediation batch — contained security & correctness fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,26 +115,36 @@ cd frontend && npm run lint
 
 Source of truth: `backend/app/core/auth/permissions.py`.
 
+Roles get **core** grants from `ROLE_PERMISSIONS` plus **module** grants
+merged at runtime from each module's `manifest.role_permissions` (prefixed
+with the module name) via `get_role_permissions()`. The core table is
+deliberately small — clinical/module permissions live in the modules:
+
 ```python
 ROLE_PERMISSIONS: Final[dict[str, list[str]]] = {
-    "admin": ["*"],
-    "dentist": ["clinical.*"],
-    "hygienist": ["clinical.patients.read", "clinical.appointments.*"],
-    "assistant": ["clinical.patients.*", "clinical.appointments.*"],
-    "receptionist": ["clinical.patients.*", "clinical.appointments.*"],
+    "admin": ["*"],                                # wildcard — every namespace
+    "dentist": ["agents.view", "agents.supervise"],
+    "hygienist": [],
+    "assistant": [],
+    "receptionist": [],
 }
+# A module manifest contributes, e.g.:
+#   role_permissions = {"receptionist": ["patients.read", "patients.write"]}
+# → merged in as "patients.read" / "patients.write" for receptionist.
 ```
 
-Wildcards: `*` = all; `module.*` = all in that module.
+Wildcards: `*` = all; `module.*` = all in that module. Matching strips the
+trailing `.*` to a dotted prefix, so `billing.*` matches `billing.x.y` but
+not `billing_x.y`.
 
-**Backend — protect endpoints:**
+**Backend — protect endpoints:** (permission strings are module-prefixed)
 ```python
 from app.core.auth.dependencies import get_clinic_context, require_permission
 
 @router.get("/patients")
 async def list_patients(
     ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
-    _: Annotated[None, Depends(require_permission("clinical.patients.read"))],
+    _: Annotated[None, Depends(require_permission("patients.read"))],
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     ...
@@ -158,7 +168,7 @@ if (can(PERMISSIONS.patients.write)) { /* ... */ }
 </UButton>
 ```
 
-Adding a permission: add to role mapping → module `get_permissions()` → `require_permission()` on endpoint → `config/permissions.ts` → use via `usePermissions().can(PERMISSIONS.x.y)`.
+Adding a permission: return it from the module's `get_permissions()` (unprefixed) → grant it to roles in the module's `manifest.role_permissions` → `require_permission("module.resource.action")` on the endpoint → add to `config/permissions.ts` → use via `usePermissions().can(PERMISSIONS.x.y)`. (Core-level permissions like `admin.*`/`agents.*` are the exception — those live in `ROLE_PERMISSIONS`/`CORE_PERMISSIONS`.)
 
 ---
 

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -373,6 +373,24 @@ async def create_user(
             detail=error_msg,
         )
 
+    # Resolve the target clinic. A caller may only create a membership in
+    # a clinic they administer themselves — otherwise an admin of clinic A
+    # could mint an admin membership in clinic B by passing its id.
+    clinic_id = data.clinic_id if data.clinic_id else ctx.clinic_id
+    if clinic_id != ctx.clinic_id:
+        caller_is_admin = await db.execute(
+            select(ClinicMembership.id).where(
+                ClinicMembership.user_id == ctx.user_id,
+                ClinicMembership.clinic_id == clinic_id,
+                ClinicMembership.role == "admin",
+            )
+        )
+        if caller_is_admin.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not administer the target clinic",
+            )
+
     # Check if email already exists
     result = await db.execute(select(User).where(User.email == data.email))
     if result.scalar_one_or_none():
@@ -392,7 +410,6 @@ async def create_user(
     await db.flush()
 
     # Create clinic membership
-    clinic_id = data.clinic_id if data.clinic_id else ctx.clinic_id
     membership = ClinicMembership(
         user_id=user.id,
         clinic_id=clinic_id,

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- fix(migrations): add the invoice-number uniqueness backstop that the
+  `Invoice` model comment already claimed existed (audit S3/C3, #93).
+  New migration `bil_0005` creates two partial unique indexes —
+  `ix_invoices_clinic_number_unique` on `(clinic_id, invoice_number)`
+  and `ix_invoices_series_sequential_unique` on
+  `(series_id, sequential_number)`, both `WHERE … IS NOT NULL` so drafts
+  don't collide. Duplicate fiscal numbers are now rejected at the DB
+  level, not just by the (serialized) generator. Model `__table_args__`
+  updated to declare the indexes; misleading comment removed.
+
 - feat(service): add `InvoiceService.list_for_export(clinic_id, date_from,
   date_to, statuses)` — non-paginated read returning non-draft invoices
   with items + allocated payments eager-loaded, for the new

--- a/backend/app/modules/billing/migrations/versions/bil_0005_invoice_number_unique.py
+++ b/backend/app/modules/billing/migrations/versions/bil_0005_invoice_number_unique.py
@@ -1,0 +1,55 @@
+"""billing — enforce invoice-number uniqueness (fiscal backstop).
+
+Closes audit S3/C3 (issue #93): the ``Invoice`` model comment claimed a
+partial unique index ``ix_invoices_clinic_number_unique`` already
+"replaced" the old constraint, but no migration ever created it, so
+duplicate fiscal invoice numbers were representable at the DB level.
+
+Two partial unique indexes, both scoped to issued rows only (drafts have
+NULL identifiers and must not collide):
+
+* ``ix_invoices_clinic_number_unique`` — (clinic_id, invoice_number):
+  the human-facing document number is unique per clinic.
+* ``ix_invoices_series_sequential_unique`` — (series_id,
+  sequential_number): the gap-control sequential is unique per series
+  (the real AEAT/Spanish-compliance invariant).
+
+Note: if a database already holds duplicates, this migration fails
+loudly on ``CREATE UNIQUE INDEX`` — that is intended. A duplicate fiscal
+number is a data problem to fix, not to paper over.
+
+Revision ID: bil_0005
+Revises: bil_0004
+Create Date: 2026-07-03
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "bil_0005"
+down_revision: str | None = "bil_0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_invoices_clinic_number_unique",
+        "invoices",
+        ["clinic_id", "invoice_number"],
+        unique=True,
+        postgresql_where="invoice_number IS NOT NULL",
+    )
+    op.create_index(
+        "ix_invoices_series_sequential_unique",
+        "invoices",
+        ["series_id", "sequential_number"],
+        unique=True,
+        postgresql_where="series_id IS NOT NULL AND sequential_number IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_invoices_series_sequential_unique", table_name="invoices")
+    op.drop_index("ix_invoices_clinic_number_unique", table_name="invoices")

--- a/backend/app/modules/billing/models.py
+++ b/backend/app/modules/billing/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -180,8 +181,6 @@ class Invoice(Base, TimestampMixin):
     )
 
     __table_args__ = (
-        # Note: uq_invoice_clinic_number replaced with partial unique index in migration
-        # ix_invoices_clinic_number_unique (WHERE invoice_number IS NOT NULL)
         Index("idx_invoices_clinic", "clinic_id"),
         Index("idx_invoices_clinic_patient", "clinic_id", "patient_id"),
         Index("idx_invoices_clinic_status", "clinic_id", "status"),
@@ -190,6 +189,24 @@ class Invoice(Base, TimestampMixin):
         Index("idx_invoices_budget", "budget_id"),
         Index("idx_invoices_credit_note_for", "credit_note_for_id"),
         Index("idx_invoices_series", "series_id"),
+        # Fiscal uniqueness backstop (bil_0005). Partial — drafts carry
+        # NULL identifiers and must not collide. Enforced at the DB level
+        # because number generation being serialized on the series row
+        # lock is not, by itself, a guarantee against duplicates.
+        Index(
+            "ix_invoices_clinic_number_unique",
+            "clinic_id",
+            "invoice_number",
+            unique=True,
+            postgresql_where=text("invoice_number IS NOT NULL"),
+        ),
+        Index(
+            "ix_invoices_series_sequential_unique",
+            "series_id",
+            "sequential_number",
+            unique=True,
+            postgresql_where=text("series_id IS NOT NULL AND sequential_number IS NOT NULL"),
+        ),
     )
 
 

--- a/backend/app/modules/media/CHANGELOG.md
+++ b/backend/app/modules/media/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(events): repair the `patient.archived` cascade, which had never
+  run (audit event-bus #1, #95). The handler signature took
+  `(self, db, data)` but the bus calls `handler(data)`, raising
+  `TypeError` on every archive; it also read `data["clinic_id"]` while
+  the publisher sent only `patient_id`. Handler now takes `(data)`,
+  opens its own session + commits (publish-before-commit), and guards a
+  missing payload. Depends on the patients publisher now emitting
+  `clinic_id`.
+
 - perf(lists): drop the ``select_from(query.subquery())`` count
   anti-pattern in ``DocumentService.list_documents`` and
   ``PhotoService.list_photos``; both lists now count via a direct

--- a/backend/app/modules/media/__init__.py
+++ b/backend/app/modules/media/__init__.py
@@ -1,16 +1,20 @@
 """Media module - document and file management."""
 
+import logging
 from typing import Any
+from uuid import UUID
 
 from fastapi import APIRouter
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import EventType
 from app.core.plugins import BaseModule
+from app.database import async_session_maker
 
 from .models import Document, MediaAttachment
 from .router import router
 from .service import DocumentService
+
+logger = logging.getLogger(__name__)
 
 
 class MediaModule(BaseModule):
@@ -63,11 +67,29 @@ class MediaModule(BaseModule):
             EventType.PATIENT_ARCHIVED: self._on_patient_archived,
         }
 
-    async def _on_patient_archived(self, db: AsyncSession, data: dict) -> None:
-        """Cascade soft-delete documents when patient is archived."""
-        from uuid import UUID
+    async def _on_patient_archived(self, data: dict) -> None:
+        """Cascade soft-archive of a patient's documents when they are
+        archived.
 
-        patient_id = UUID(data["patient_id"])
-        clinic_id = UUID(data["clinic_id"])
+        The event bus calls handlers as ``handler(data)`` and publishes
+        before the request commits, so this opens its own session and
+        commits independently (same pattern as the recalls handler).
+        """
+        patient_id = data.get("patient_id")
+        clinic_id = data.get("clinic_id")
+        if not patient_id or not clinic_id:
+            logger.error(
+                "media._on_patient_archived: missing patient_id/clinic_id in payload: %r",
+                data,
+            )
+            return
 
-        await DocumentService.archive_patient_documents(db, clinic_id, patient_id)
+        async with async_session_maker() as db:
+            try:
+                await DocumentService.archive_patient_documents(
+                    db, UUID(str(clinic_id)), UUID(str(patient_id))
+                )
+                await db.commit()
+            except Exception as exc:
+                logger.error("media._on_patient_archived failed: %s", exc, exc_info=True)
+                await db.rollback()

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(events): include `clinic_id` in the `patient.archived` and
+  `patient.updated` payloads (audit event-bus #11, #95). Every event
+  must carry the tenant per the multi-tenancy convention; the omission
+  broke the media archive cascade and forced the recalls handler into an
+  unscoped query.
+
 - feat(agents): new copilot tool `update_patient` (WRITE) — updates a
   patient's contact data (phone, email) via `PatientService.update_patient`.
   Identity fields stay manual.

--- a/backend/app/modules/patients/CLAUDE.md
+++ b/backend/app/modules/patients/CLAUDE.md
@@ -44,8 +44,8 @@ fields stay manual.
 | Event | When | Payload keys |
 |---|---|---|
 | `patient.created` | `PatientService.create` succeeds | `patient_id`, `clinic_id` |
-| `patient.updated` | `PatientService.update` succeeds | `patient_id`, `changes` |
-| `patient.archived` | `PatientService.archive` (soft-delete) | `patient_id` |
+| `patient.updated` | `PatientService.update` succeeds | `patient_id`, `clinic_id`, `changes` |
+| `patient.archived` | `PatientService.archive` (soft-delete) | `patient_id`, `clinic_id` |
 
 See `service.py:113`, `service.py:131`, `service.py:142`.
 

--- a/backend/app/modules/patients/service.py
+++ b/backend/app/modules/patients/service.py
@@ -273,7 +273,11 @@ class PatientService:
 
         await event_bus.publish(
             EventType.PATIENT_UPDATED,
-            {"patient_id": str(patient.id), "changes": list(data.keys())},
+            {
+                "patient_id": str(patient.id),
+                "clinic_id": str(patient.clinic_id),
+                "changes": list(data.keys()),
+            },
         )
         return patient
 
@@ -284,6 +288,6 @@ class PatientService:
 
         await event_bus.publish(
             EventType.PATIENT_ARCHIVED,
-            {"patient_id": str(patient.id)},
+            {"patient_id": str(patient.id), "clinic_id": str(patient.clinic_id)},
         )
         return patient

--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(frontend): call `api.del` instead of the non-existent `api.delete`
+  when discarding a draft (audit frontend #1, #95). `useApi` exposes
+  `del`, so `discardDraft` threw a TypeError before any request fired —
+  and the one-draft-per-patient unique index then blocked starting any
+  new session for that patient.
+
 - feat(ui): dark mode support across the whole periodontogram surface.
   SEPA profile strip, tooth silhouettes, implant fixture, site
   markers, arch tables, indices banner, history banner and empty

--- a/backend/app/modules/periodontogram/frontend/composables/usePeriodontogramSession.ts
+++ b/backend/app/modules/periodontogram/frontend/composables/usePeriodontogramSession.ts
@@ -155,7 +155,7 @@ export function usePeriodontogramSession() {
   async function discardDraft(snapshotId: string): Promise<void> {
     saving.value = true
     try {
-      await api.delete(`/api/v1/periodontogram/snapshots/${snapshotId}`)
+      await api.del(`/api/v1/periodontogram/snapshots/${snapshotId}`)
       dirty.value = false
     } finally {
       saving.value = false

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(security): reject `create` when `patient_id` belongs to another
+  clinic (audit multi-tenancy #1, #95). Previously the recall was
+  inserted with the caller's `clinic_id` but no check that the patient
+  was theirs, and the list/export join had no `Patient.clinic_id`
+  predicate — so a caller could point a recall at a foreign patient and
+  read that patient's name/phone back. `create` now 404s on a foreign
+  patient (HTTP and copilot tool paths), and the list join is scoped to
+  `Patient.clinic_id` as defense in depth.
+
 - feat(agents): expose `tools.py` for the copilot agentic layer —
   `list_due_recalls`, `get_recall` (READ; the latter `exposes_free_text`),
   `create_recall`, `log_contact_attempt`, `snooze_recall`,

--- a/backend/app/modules/recalls/router.py
+++ b/backend/app/modules/recalls/router.py
@@ -115,12 +115,15 @@ async def create_recall(
     _: Annotated[None, Depends(require_permission("recalls.write"))],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ApiResponse[RecallResponse]:
-    recall, _created = await RecallService.create(
-        db,
-        clinic_id=ctx.clinic_id,
-        data=data.model_dump(),
-        recommended_by=ctx.user_id,
-    )
+    try:
+        recall, _created = await RecallService.create(
+            db,
+            clinic_id=ctx.clinic_id,
+            data=data.model_dump(),
+            recommended_by=ctx.user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     await db.commit()
     return ApiResponse(data=_serialise(recall))
 

--- a/backend/app/modules/recalls/service.py
+++ b/backend/app/modules/recalls/service.py
@@ -98,7 +98,14 @@ class RecallService:
         page: int = 1,
         page_size: int = 50,
     ) -> tuple[list[Recall], int]:
-        conditions = [Recall.clinic_id == clinic_id]
+        # Both predicates matter: Recall.clinic_id scopes the rows, and
+        # Patient.clinic_id keeps the join from ever surfacing a foreign
+        # patient's name/phone if a stray cross-clinic recall exists
+        # (defense in depth behind create()'s patient-clinic guard).
+        conditions = [
+            Recall.clinic_id == clinic_id,
+            Patient.clinic_id == clinic_id,
+        ]
 
         if not filters.include_archived_patients:
             conditions.append(Patient.status != "archived")
@@ -239,7 +246,22 @@ class RecallService:
         Returns ``(recall, created)`` — ``created`` is False when the
         duplicate guard updated an existing row instead of inserting.
         Publishes ``recall.created`` only when ``created`` is True.
+
+        Raises ``ValueError`` if ``patient_id`` does not belong to
+        ``clinic_id`` — otherwise a caller (HTTP or copilot tool) could
+        create a recall pointing at another clinic's patient and read
+        that patient's name/phone back through the list/export (audit
+        multi-tenancy #1).
         """
+        patient_in_clinic = await db.execute(
+            select(Patient.id).where(
+                Patient.id == data["patient_id"],
+                Patient.clinic_id == clinic_id,
+            )
+        )
+        if patient_in_clinic.scalar_one_or_none() is None:
+            raise ValueError("Patient not found in this clinic")
+
         existing = await RecallService.find_pending_for(
             db, clinic_id, data["patient_id"], data["reason"]
         )

--- a/backend/tests/modules/billing/test_invoice_number_unique.py
+++ b/backend/tests/modules/billing/test_invoice_number_unique.py
@@ -1,0 +1,122 @@
+"""Fiscal uniqueness backstop for issued invoices (bil_0005, issue #93).
+
+Duplicate invoice numbers / duplicate per-series sequentials must be
+rejected at the DB level; drafts (NULL identifiers) must still be free to
+coexist.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic, User
+from app.modules.billing.models import Invoice
+from app.modules.patients.models import Patient
+
+
+@pytest_asyncio.fixture
+async def test_user_id(test_clinic: Clinic, db_session: AsyncSession):
+    """ID of the single user created by the ``auth_headers`` fixture
+    (pulled in transitively via ``test_clinic``)."""
+    user = (await db_session.execute(select(User))).scalars().first()
+    return user.id
+
+
+def _issued_invoice(
+    clinic: Clinic,
+    patient: Patient,
+    user_id,
+    *,
+    number: str | None,
+    series_id=None,
+    sequential: int | None = None,
+) -> Invoice:
+    return Invoice(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        invoice_number=number,
+        series_id=series_id,
+        sequential_number=sequential,
+        status="draft" if number is None else "issued",
+        issue_date=None if number is None else date.today(),
+        billing_name="X",
+        billing_tax_id="A28000000",
+        subtotal=Decimal("100"),
+        total=Decimal("100"),
+        created_by=user_id,
+        issued_by=None if number is None else user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_invoice_number_rejected(
+    test_clinic: Clinic,
+    test_patient: Patient,
+    test_user_id,
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(_issued_invoice(test_clinic, test_patient, test_user_id, number="FAC-2026-0001"))
+    await db_session.flush()
+
+    db_session.add(_issued_invoice(test_clinic, test_patient, test_user_id, number="FAC-2026-0001"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_series_sequential_rejected(
+    test_clinic: Clinic,
+    test_patient: Patient,
+    test_user_id,
+    db_session: AsyncSession,
+) -> None:
+    series_id = uuid4()
+    db_session.add(
+        _issued_invoice(
+            test_clinic,
+            test_patient,
+            test_user_id,
+            number="FAC-2026-0100",
+            series_id=series_id,
+            sequential=100,
+        )
+    )
+    await db_session.flush()
+
+    # Same series + sequential but a different rendered number must still
+    # be rejected — the sequential is the gap-control fiscal invariant.
+    db_session.add(
+        _issued_invoice(
+            test_clinic,
+            test_patient,
+            test_user_id,
+            number="FAC-2026-9999",
+            series_id=series_id,
+            sequential=100,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_multiple_drafts_coexist(
+    test_clinic: Clinic,
+    test_patient: Patient,
+    test_user_id,
+    db_session: AsyncSession,
+) -> None:
+    # Drafts carry NULL number/series/sequential — the partial index must
+    # not treat two NULL rows as a collision.
+    db_session.add(_issued_invoice(test_clinic, test_patient, test_user_id, number=None))
+    db_session.add(_issued_invoice(test_clinic, test_patient, test_user_id, number=None))
+    await db_session.flush()  # no IntegrityError

--- a/backend/tests/modules/billing/test_invoice_number_unique.py
+++ b/backend/tests/modules/billing/test_invoice_number_unique.py
@@ -18,8 +18,20 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth.models import Clinic, User
-from app.modules.billing.models import Invoice
+from app.modules.billing.models import Invoice, InvoiceSeries
 from app.modules.patients.models import Patient
+
+
+async def _make_series(db: AsyncSession, clinic: Clinic):
+    series = InvoiceSeries(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        prefix="FAC",
+        series_type="invoice",
+    )
+    db.add(series)
+    await db.flush()
+    return series.id
 
 
 @pytest_asyncio.fixture
@@ -79,7 +91,7 @@ async def test_duplicate_series_sequential_rejected(
     test_user_id,
     db_session: AsyncSession,
 ) -> None:
-    series_id = uuid4()
+    series_id = await _make_series(db_session, test_clinic)
     db_session.add(
         _issued_invoice(
             test_clinic,

--- a/backend/tests/modules/media/test_patient_archived_cascade.py
+++ b/backend/tests/modules/media/test_patient_archived_cascade.py
@@ -1,0 +1,62 @@
+"""The `patient.archived` → document soft-archive cascade (audit #95).
+
+Two regressions are covered:
+
+* the publisher must include ``clinic_id`` in the payload (it didn't);
+* the media handler must accept the bus calling convention
+  ``handler(data)`` — its old ``(self, db, data)`` signature raised
+  ``TypeError`` on every archive.
+
+The end-to-end "documents actually get archived" path is not asserted
+here: the handler opens its own ``async_session_maker`` session (bound to
+the import-time event loop), which pytest-asyncio's per-test loop can't
+drive. That path is covered by ``DocumentService.archive_patient_documents``'s
+own tests; the two regressions above are what broke.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic
+from app.core.events import EventType, event_bus
+from app.modules.media import MediaModule
+from app.modules.patients.models import Patient
+from app.modules.patients.service import PatientService
+
+
+@pytest.mark.asyncio
+async def test_archive_patient_payload_includes_clinic_id(
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+) -> None:
+    captured: list[dict] = []
+
+    async def _spy(data: dict) -> None:
+        captured.append(data)
+
+    event_bus.subscribe(EventType.PATIENT_ARCHIVED, _spy)
+    try:
+        await PatientService.archive_patient(db_session, test_patient)
+    finally:
+        event_bus.unsubscribe(EventType.PATIENT_ARCHIVED, _spy)
+
+    assert captured, "patient.archived was not published"
+    assert captured[0]["patient_id"] == str(test_patient.id)
+    assert captured[0]["clinic_id"] == str(test_clinic.id)
+
+
+@pytest.mark.asyncio
+async def test_media_handler_accepts_bus_calling_convention(
+    db_session: AsyncSession,
+) -> None:
+    # The bus calls ``handler(data)``. Under the old ``(self, db, data)``
+    # signature this passed the dict as ``db`` and raised TypeError for
+    # the missing ``data``. A payload without ``clinic_id`` returns early
+    # before touching a session, so this isolates the signature fix.
+    module = MediaModule()
+    await module._on_patient_archived({"patient_id": str(uuid4())})

--- a/backend/tests/modules/recalls/test_router.py
+++ b/backend/tests/modules/recalls/test_router.py
@@ -60,6 +60,52 @@ async def test_create_then_duplicate_guard_updates_existing(
 
 
 @pytest.mark.asyncio
+async def test_create_recall_for_foreign_patient_rejected(
+    client: AsyncClient,
+    auth_headers: dict,
+    test_clinic: Clinic,
+    db_session: AsyncSession,
+):
+    """A recall may not be created against a patient in another clinic —
+    that would leak the foreign patient's name/phone back through the
+    list/export (audit multi-tenancy #1)."""
+    from uuid import uuid4
+
+    other_clinic = Clinic(
+        id=uuid4(),
+        name="Other",
+        tax_id="B77777777",
+        address={"street": "x", "city": "y"},
+        settings={},
+    )
+    db_session.add(other_clinic)
+    foreign_patient = Patient(
+        id=uuid4(),
+        clinic_id=other_clinic.id,
+        first_name="Foreign",
+        last_name="Patient",
+        phone="+34600000000",
+    )
+    db_session.add(foreign_patient)
+    await db_session.commit()
+
+    res = await client.post(
+        "/api/v1/recalls/",
+        json={
+            "patient_id": str(foreign_patient.id),
+            "due_month": "2026-08-01",
+            "reason": "hygiene",
+        },
+        headers=auth_headers,
+    )
+    assert res.status_code == 404, res.text
+
+    # And the caller's list stays empty — nothing leaked.
+    lst = await client.get("/api/v1/recalls/?page_size=10", headers=auth_headers)
+    assert lst.json()["total"] == 0
+
+
+@pytest.mark.asyncio
 async def test_log_attempt_auto_transitions_status(
     client: AsyncClient, auth_headers: dict, test_patient: Patient
 ):

--- a/backend/tests/test_auth_create_user_scope.py
+++ b/backend/tests/test_auth_create_user_scope.py
@@ -1,0 +1,61 @@
+"""`POST /auth/users` must not let an admin inject a membership into a
+clinic they don't administer (audit RBAC H1, #95)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic
+
+
+def _payload(clinic_id=None) -> dict:
+    body = {
+        "email": f"new-{uuid4().hex[:8]}@example.com",
+        "password": "TestPass1234",
+        "first_name": "New",
+        "last_name": "Staff",
+        "role": "receptionist",
+    }
+    if clinic_id is not None:
+        body["clinic_id"] = str(clinic_id)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_create_user_in_own_clinic_succeeds(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    test_clinic: Clinic,
+) -> None:
+    r = await client.post("/api/v1/auth/users", json=_payload(), headers=auth_headers)
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_create_user_in_foreign_clinic_forbidden(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    test_clinic: Clinic,
+    db_session: AsyncSession,
+) -> None:
+    # A clinic the caller has no membership in.
+    other = Clinic(
+        id=uuid4(),
+        name="Other Clinic",
+        tax_id="B99999999",
+        address={"street": "Elsewhere", "city": "Bilbao"},
+        settings={},
+    )
+    db_session.add(other)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/auth/users",
+        json=_payload(clinic_id=other.id) | {"role": "admin"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 403, r.text

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -587,7 +587,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.PATIENT_ARCHIVED`
 - **Publishers:**
-  - `patients` — `backend/app/modules/patients/service.py:285`
+  - `patients` — `backend/app/modules/patients/service.py:289`
 - **Subscribers:**
   - `media`
   - `periodontogram`
@@ -656,21 +656,21 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.RECALL_CANCELLED`
 - **Publishers:**
-  - `recalls` — `backend/app/modules/recalls/service.py:354`
+  - `recalls` — `backend/app/modules/recalls/service.py:376`
 - **Subscribers:** —
 
 ### `recall.completed`
 
 - **Constant:** `EventType.RECALL_COMPLETED`
 - **Publishers:**
-  - `recalls` — `backend/app/modules/recalls/service.py:371`
+  - `recalls` — `backend/app/modules/recalls/service.py:393`
 - **Subscribers:** —
 
 ### `recall.created`
 
 - **Constant:** `EventType.RECALL_CREATED`
 - **Publishers:**
-  - `recalls` — `backend/app/modules/recalls/service.py:276`
+  - `recalls` — `backend/app/modules/recalls/service.py:298`
 - **Subscribers:** —
 
 ### `recall.due`
@@ -683,7 +683,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.RECALL_SNOOZED`
 - **Publishers:**
-  - `recalls` — `backend/app/modules/recalls/service.py:334`
+  - `recalls` — `backend/app/modules/recalls/service.py:356`
 - **Subscribers:** —
 
 ### `tenant.resolved`

--- a/docs/technical/audit-2026-07-03.md
+++ b/docs/technical/audit-2026-07-03.md
@@ -1,0 +1,494 @@
+# Adversarial codebase audit — 2026-07-03
+
+> Read-only diagnosis of DentalPin `main` @ `e19e081`. Nothing here was applied to the
+> codebase. Produced by 8 parallel specialist audit passes (multi-tenancy, RBAC, module
+> isolation, event bus, copilot/LLM boundary, backend core, frontend, documentation).
+> Each pass was told to verify against source before flagging; 8 top findings were then
+> spot-verified against the actual code (marked **✓ verified** below).
+
+**Scope:** 376 Python files · 22 modules · 70 Vue components · ~255 API call sites checked.
+
+**Triage:** ~17 critical · ~55 high · ~70 medium · ~50 low. Counts are approximate because
+several passes independently reported the same root cause — deduped into the systemic
+section, which is where the real signal is.
+
+---
+
+## Five root causes, found from five directions
+
+These weren't flagged once. Different audit passes arrived at the same underlying defect
+independently. That convergence is the strongest evidence each is real and load-bearing.
+
+### S1 — Install state is tracked in the DB and consumed by nothing
+*(module-isolation #1/#2 · event-bus #3 · copilot #6 · backend M-modscan)*
+
+The plugin system records each module's state in `ModuleRecord`, but neither the boot
+sequence nor the loader ever reads it.
+
+- `backend/docker-entrypoint.sh:27` runs `alembic upgrade heads` unconditionally on every
+  boot, so an uninstalled module's dropped tables are **re-created on the next restart**
+  while its state stays `UNINSTALLED`.
+- `backend/app/core/plugins/loader.py:142` mounts routers, subscribes event handlers, and
+  registers copilot tools for **every module discovered on disk** — install state never
+  checked.
+- `backend/app/core/plugins/processor.py:259` (`_remove`) drops tables but never
+  unsubscribes handlers, unmounts routers, or unregisters tools.
+
+Net effect: after uninstalling `recalls`, its handlers keep firing against dropped tables
+on every appointment (errors swallowed by the bus), its routes 500 instead of 404, its
+copilot tools stay callable, and a restart resurrects its schema. This is issue #56's
+"cosmetic uninstall" reintroduced one layer up — and it means the per-tenant
+`modules_enabled` direction (ADR 0012) has no enforcement point today.
+
+### S2 — Events publish inside uncommitted transactions
+*(event-bus #2 · backend H-evt1)*
+
+`get_db` commits only at request end, but nearly every publisher does `flush()` →
+`publish()`, and handlers run inline in **separate sessions**. So handlers read/write
+against data the publisher hasn't committed. Concretely: `billing.on_payment_refunded`
+recomputes invoice status but the `Refund` row is invisible → **invoice stays "paid" after
+a refund**, deterministically. The recalls auto-link handler sets an FK to an uncommitted
+appointment → fails or deadlocks. Budget-line handlers commit rows in their own session
+that survive a later rollback → phantom plan↔budget divergence.
+
+Only `verifactu` and `copilot` do it right (commit-before-publish, with comments explaining
+why) — the correct pattern is known but not systematized. There is no transactional outbox
+for the bus.
+
+### S3 — Money paths are check-then-act with no DB backstop
+*(backend C1–C4, H-pay/H-bill)*
+
+Every monetary invariant is enforced in Python between a read and a write, with no lock and
+no database constraint. Two concurrent requests (a double-click) each pass the check and
+both write: refund cap (`net_paid` goes negative), invoice over-payment (`INVOICE_PAID`
+fires twice), allocation sum, partial-invoicing quantity. Worst: the invoice-number unique
+index the model comment claims "replaced" the constraint **does not exist in any
+migration** — duplicate fiscal invoice numbers are representable, a direct
+Spanish-compliance break. The money *columns* are correctly `Numeric(12,2)` with
+positive-amount checks; it's the *cross-row* invariants that have no teeth.
+
+### S4 — The CI gates CLAUDE.md advertises don't do what it says
+*(module-isolation #3 · backend H-api3 · doc-drift #2 · event-bus #8)*
+
+CLAUDE.md: "Cross-module FKs are allowed only when the target is in `depends`. CI rejects
+migrations otherwise." **No such check exists** — and the isolation test explicitly skips
+`migrations/` directories. That's how a cross-module FK
+`appointment_treatments.planned_treatment_item_id → planned_treatment_items.id`
+(agenda→treatment_plan, not in `depends`, and a dependency cycle) slipped in undetected.
+Separately, the docs-coverage / catalog generator's `PUBLISH_RE` regex misses enum-based
+and variable-dispatched publishes, so `docs/events-catalog.md` lists ~19 live events as
+"publisher: none" — inviting an agent to delete load-bearing events — and the "feral event"
+CI gate is blind to them.
+
+### S5 — Silent failure is the default posture, front to back
+*(frontend, pervasive · event-bus #15)*
+
+The bus swallows every handler exception with only a log. The frontend `useApi`
+global-toasts only 403/5xx/network — **400/404/409/422 rethrow silently**, so any handler
+without try/catch fails with no user feedback. Read paths render false-empty on error (a
+failed calendar fetch looks like a free week; a failed odontogram load renders a healthy
+32-tooth mouth). Write paths lose data quietly (clinical-note text wiped on failed save;
+treatment surface edits dropped with a success toast). Destructive actions with no undo
+endpoint fire on one click with no confirm. Across the product, the failure mode is "looks
+fine, did nothing" — the most dangerous mode in a clinical/fiscal tool.
+
+---
+
+## Findings by dimension
+
+Critical and high in full; medium/low condensed (the passes already triaged them, and they
+run to the hundreds).
+
+### Backend core, money & compliance — 4 critical · ~15 high
+
+- **CRITICAL ✓ verified — Invoice-number uniqueness does not exist; the model comment lies.**
+  `billing/models.py:182` claims `ix_invoices_clinic_number_unique` "replaced" the
+  constraint. Grep of every billing migration (`bil_0001…0004`) confirms no such index and
+  no unique on `(series_id, sequential_number)`. Duplicate fiscal invoice numbers are
+  representable — silent, and a Spanish-compliance break. One-line migration fixes it.
+- **CRITICAL — Refund cap is a racy Python check with no DB constraint.**
+  `payments/workflow.py:281`. Two concurrent `POST /{payment_id}/refunds` both read
+  `already_refunded=0`, both pass `≤ payment.amount`, both insert → 200 € refunded on a
+  100 € payment; `net_paid` negative; downstream reports corrupt. No `FOR UPDATE`, no
+  `Σrefund ≤ payment` constraint.
+- **CRITICAL — Invoice over-payment is check-then-act, unlocked.**
+  `billing/router.py:857`. Concurrent `POST /invoices/{id}/payments` both see full
+  `balance_due`, both insert; invoice collects 2× its total, `INVOICE_PAID` fires twice.
+- **CRITICAL — Concurrent issue of one draft → burned number + ghost VeriFactu record.**
+  `billing/router.py:575` + `workflow.py:110`. `status=="draft"` read without a row lock;
+  both txns pass, series lock hands them N and N+1, both run the VeriFactu hook → one
+  invoice, two chained AEAT records, a permanent sequential gap, an alta for a non-existent
+  document.
+- **HIGH — Patient medical history is hard-deleted.**
+  `patients_clinical/service.py:105,142,181,220,248,276` all `db.delete(row)` — no
+  `deleted_at`, no audit — despite the module's own "most sensitive surface" note. A deleted
+  penicillin-allergy row is unrecoverable; `PUT /medical-history` wipes-and-reinserts all
+  rows, destroying provenance. Medico-legal exposure.
+- **HIGH — Login rate-limit bypassable via spoofed `X-Forwarded-For`.**
+  `docker-compose.yml:50` (`--forwarded-allow-ips *`) + `auth/router.py:52` keys the 5/min
+  limiter on `get_remote_address`. Rotating a fake XFF gives each request a fresh bucket.
+  Pin to the proxy CIDR.
+- **HIGH — `SEED_ON_STARTUP` mints a hardcoded-credential admin with no env guard.**
+  `scripts/seed_demo.py:635` (`hash_password("demo1234")`, no `ENVIRONMENT` check), wired
+  next to `ENVIRONMENT=production` in `docker-compose.coolify.yml:35`. Flip it to self-heal
+  a wiped volume and you get a known-credential superuser on prod, silently.
+- **HIGH — Any clinic admin can install/uninstall modules and SIGTERM the process.**
+  `plugins/router.py:160–251` gate on per-clinic `admin.clinic.write`, but the ops are
+  process-global; `/-/restart` kills PID 1.
+- **HIGH — Credit-note math inverts absolute discounts.**
+  `billing/workflow.py:565` negates `unit_price` but copies `discount_value` verbatim → a
+  90 €-net line credits 110 € net, wrong `cuota_total` chained and submitted to AEAT. No
+  cumulative credit-note cap either.
+- **HIGH — VeriFactu: crash between AEAT submit and commit → duplicate submission.**
+  `verifactu/services/submission_queue.py:129` marks `sending` + flush but never commits
+  before the network call (commit only at :264). A crash after AEAT accepts rolls back to
+  `pending`, resubmits, gets duplicate-rejections that then block all invoice issuing
+  clinic-wide. Regenerating a non-head rejected record breaks the hash chain
+  (`hook.py:446`).
+- **HIGH — Notifications outbox: `SKIP LOCKED` neutralized → duplicate sends, lost
+  messages.** `notifications/gateway.py:203–246`. Per-message commit inside the loop
+  releases locks on the rest of the batch; a second replica re-sends. A vendor `failed`
+  receipt doesn't touch `next_attempt_at`, so it's re-dispatched. A crash between the
+  `sending` commit and the result strands the row forever — the promised reaper was never
+  built.
+
+<details><summary>Medium & low — rounding, crypto, config, conventions (~30)</summary>
+
+- **Line-item rounding mismatch** `billing/service.py:568` — lines rounded on insert, totals
+  summed from unrounded values; PDF lines don't sum to total, trips AEAT cross-validation.
+  Uses HALF_EVEN, not Spanish-customary HALF_UP.
+- **VAT rate stored as Float** `billing/models.py:237` (also catalog/budget) — float
+  artifacts split desglose groups and print `varios` in gestoría export. Use `Numeric(5,2)`.
+- **Earned-ledger idempotency broken for NULL session path** `payments/models.py:237` —
+  `UNIQUE(treatment_id, source_session_id)` is NULLS DISTINCT, so `ON CONFLICT DO NOTHING`
+  is a no-op; re-marking a treatment doubles patient debt.
+- **Accounting export keys payments by `invoice.issue_date`** `accounting_export/service.py:93`
+  — April cobros land in March, Feb-invoice cobros never appear, refunds not exported.
+- **SECRET_KEY has no strength validator** `config.py:13` — SHA-256'd unsalted into the
+  Fernet key for SMTP passwords AND VeriFactu certs; rotating it bricks stored creds and
+  degrades SMTP to unauthenticated silently.
+- **BUDGET_PUBLIC_SECRET_KEY falls back to SECRET_KEY** `budget/public_router.py:70` —
+  collapses the two keys ADR-0006 promised to isolate; absent from Coolify compose.
+- **Scheduler has no multi-worker guard** `scheduler.py:39` — in-process AsyncIOScheduler in
+  every process, no leader election. `--workers N` sends digests N× and drains the verifactu
+  queue concurrently.
+- **Clinic-configured From address is dead code** `email/service.py:188` — always stamps
+  `noreply@dentalpin.com` → SPF/DMARC misalignment.
+- **`invoice.balance_due` removed but still read** `notifications/handlers.py:428` — every
+  `invoice.sent` raises AttributeError, swallowed; "email invoice" silently sends nothing.
+- **Two 422 response shapes** `main.py:149` — Pydantic `{detail}` vs hand-raised
+  `{data,message,errors}`; frontend reading `message` renders undefined.
+- **PII to stdout by default** `events/bus.py:56`, `email/providers/console.py:46` — full
+  payloads and rendered emails at INFO; a deploy that forgets `EMAIL_PROVIDER=smtp` streams
+  health data to stdout.
+- DELETE returns 200+body in 4 routers (convention 204); HTTPException raised inside 22
+  service methods (breaks agent-tool wrapping); `DENTALPIN_DEV_MODULE_SCAN` defaults True in
+  prod; readiness 503 leaks `str(exc)`; CORS reflects arbitrary Origin if `ALLOWED_ORIGINS`
+  has `*`.
+
+</details>
+
+### Frontend coherence & affordances — 8 critical · ~27 high
+
+- **CRITICAL ✓ verified — Periodontogram "Descartar borrador" crashes, then blocks all new
+  sessions.** `periodontogram/…/usePeriodontogramSession.ts:158` calls `api.delete(...)`;
+  `useApi` exposes only `del`. TypeError before any request, no catch, modal already closed
+  — then `uq_perio_snap_one_draft_per_patient` blocks starting any new perio session for
+  that patient. One-word fix.
+- **CRITICAL — Payments: Enter key creates duplicate payments.**
+  `payments/…/PaymentCreateModal.vue:228` gates only on `canSubmit`, never `isSubmitting`;
+  no in-flight guard. Enter twice on the "cobrar" flow = two `POST /payments`. No void; undo
+  requires a refund.
+- **CRITICAL — Public budget accept/reject fakes success.**
+  `budget/…/p/budget/[token].vue:173` uses raw `$fetch` with `catch { return false }`; the
+  page closes the modal unconditionally. Patient signs, request fails, patient believes they
+  accepted — clinic never receives it.
+- **CRITICAL — Odontogram: failed chart load renders a healthy 32-tooth mouth.**
+  `odontogram/…/useOdontogramData.ts:83` sets error console-only; the chart defaults every
+  tooth to `healthy` when `teeth=[]`.
+- **CRITICAL — VeriFactu AEAT remediation fails silently (TypeError in the catch).**
+  `verifactu/…/InvoiceVerifactuSlot.vue:74` — a local `errorMessage` computed shadows the
+  imported helper; the catch calls the ComputedRef as a function.
+- **CRITICAL — Dead pagination: Nuxt UI v2 API on a v4 component.**
+  `media/…/DocumentGallery.vue:229` +2 use `v-model`+`page-count` (v4 needs
+  `v-model:page`/`items-per-page`). Documents 13+ and pipeline rows 21+ unreachable.
+- **CRITICAL — Migration import broken for real files (10 s client timeout).**
+  `migration_import/…/DataMigrationPage.vue:129` uses `api.post` (10 s) for `.dpm` files the
+  backend accepts up to 5 GB. Execute is also unconfirmed, uncaught, and double-fireable
+  with no rollback in v1.
+- **HIGH — `useApi` silently drops `params`; hard 10 s timeout; swallows 4xx.**
+  `frontend/app/composables/useApi.ts:33,47,91`. The dropped `params` makes the VeriFactu
+  queue tabs (Pendientes/Rechazadas/Fallos) all render the same unfiltered list. The 4xx
+  swallow is the root of most silent-failure findings.
+- **HIGH — `patients` layer (`depends: []`) bare-renders 6 other layers' components.**
+  `patients/…/AdministrationTab.vue:227` +6 use budget/billing/media/odontogram/
+  patients_clinical/patient_timeline components directly, gated by permission only — never
+  module-active state, never via `ModuleSlot`. Uninstall would silently blank
+  patient-detail sections.
+- **HIGH — Cabinets settings fully ungated; the gating constant doesn't exist.**
+  `agenda.cabinets.read/write` enforced backend-side but absent from `permissions.ts`; the
+  page has zero `can()` checks. Receptionists see create/edit/delete buttons that 403.
+- **HIGH — Actions that submit editable data the backend silently discards.**
+  `billing/…/invoices/new.vue:152` sends editable `billing_name/tax_id/…` that `InvoiceCreate`
+  lacks (snapshotted from patient). Same class: plan "Activar" always 400s, plans search is
+  a no-op, pipeline contact buttons never render (`PatientBrief` lacks `phone`).
+
+<details><summary>High & medium — data loss, unconfirmed destructive actions, i18n, drift (~50)</summary>
+
+- **Silent data-loss on failed save:** clinical-note composer wipes typed text;
+  treatment-edit modal drops surface edits (success toast, nothing saved); perio
+  measurements lost inside a closed exam; timeline caps at 20; recalls call-list hard-capped
+  at 50 no pager; odontogram chart truncated at 50.
+- **Destructive, no confirm, no undo endpoint:** odontogram treatment delete (invoiced
+  treatment deletes like a draft), appointment cancel from modal footer, clinical-note delete
+  (3 of 5 surfaces one-click), recall cancel/mark-done, plan-item delete (cascades to
+  odontogram + budget line).
+- **Double-submit duplicate side effects:** notifications reply Enter path (duplicate
+  WhatsApp), whatsapp "Send test" (Kapso bills per message), budget "Enviar" + accept
+  signature.
+- **Fiscal display drift:** credit-note creation client-side marks original `cancelled`,
+  server creates a draft and doesn't cancel; `GET /invoices/{id}/payments` typed `Payment[]`
+  but backend returns a leaner schema → date "-", method "undefined".
+- **Dead affordance:** payment "detail" menu → `/payments/{id}`, a page in no layer → 404.
+- **i18n regressions in EN UI:** invoice-series settings (30 keys) and legal-guardian form
+  (24 keys) ES-only; 16+ wrong-prefix error keys render raw; media ships zero locale files.
+- **Decimal money serializes as JSON strings** but host TS types declare `number` —
+  consumers survive only via `Number()`; new arithmetic string-concatenates.
+- **CI blind spot:** `ci.yml` regenerates modules.json with all 22 layers, so CI never tests
+  the shipped 17-layer set; cross-module affordances gated by permission only, never
+  module-active state.
+
+</details>
+
+### Event bus — 3 critical · 5 high
+
+- **CRITICAL ✓ verified — Media patient-archive cascade has never worked.**
+  `media/__init__.py:65` handler is `_on_patient_archived(self, db, data)`, but the bus
+  (`events/bus.py:58`) calls `handler(data)` → `TypeError` every time. Even fixed, it reads
+  `data["clinic_id"]` but the publisher (`patients/service.py:285`) sends `{"patient_id":…}`
+  only. Archiving a patient never archives their documents (a GDPR cascade); the bus
+  swallows the exception.
+- **CRITICAL — Publish-before-commit breaks refunds, deadlocks recall auto-link.**
+  The S2 root cause, concretely: `billing/events.py:25`, `recalls/events.py:39`.
+- **CRITICAL — Uninstall never unsubscribes handlers or unmounts routers.**
+  The S1 root cause on the bus: `loader.py:142` / `processor.py:259`. `service.py`'s comment
+  claiming uninstalled handlers "do not fire" is false.
+- **HIGH — Budget reminders marked "sent" but no message is sent.**
+  `budget/workflow.py:585` publishes `budget.reminder_sent`; notifications never subscribes
+  it, only `patient_timeline` does. Patient receives nothing, cooldown prevents retry, staff
+  see a timeline that lies.
+- **HIGH — Fire-and-forget `create_task`: droppable + commit race.**
+  `notifications/handlers.py:28,190` — task refs discarded (GC mid-flight), and the task
+  races the publisher's commit. Intermittently missing confirmation emails.
+- **HIGH — Appointment clinical notes never reach the patient timeline.**
+  `clinical_notes/service.py:263` publishes `appointment_{clinical,administrative}_created`
+  with zero consumers; timeline subscribes only the four non-appointment note events.
+- **HIGH — `events-catalog.md` misreports ~19 events' publishers.**
+  The S4 regex bug: `generate_catalogs.py:86`'s `PUBLISH_RE` misses variable dispatch, the
+  `OdontogramEventType` class, and gateway indirection.
+
+<details><summary>Medium & low — dead enum members, dedup, naming, docs (~13)</summary>
+
+- **`item_completed_without_note` fires on every completion** `treatment_plan/service.py:970`
+  — the promised reconciliation doesn't exist; every completed item shows "completado sin
+  nota" even when a note was captured.
+- **`patient_timeline` has no dedup** despite its own CLAUDE.md requiring
+  `(event_type, source_id)` dedup — any re-emission writes duplicate cards.
+- **Outbound WhatsApp never reaches the timeline** — gateway dual-publishes legacy events
+  only for `channel==email`.
+- **11 dead enum members** never published (INVOICE_CREATED, PAYMENT_VOIDED contradicting
+  the payments redesign, DOCUMENT_ARCHIVED vs the DOCUMENT_DELETED actually published, etc.).
+- **Bus posture:** failures terminal and invisible, in-memory only, no retry/dead-letter —
+  wrong for consistency-critical reactions. A handler that subscribes during publish mutates
+  the list under iteration → latent RuntimeError.
+- Naming incoherence: 2- vs 3-segment names; `patient.medical_updated` published by
+  `patients_clinical` not `patients`.
+
+</details>
+
+### Module isolation & migrations — 2 critical · 6 high
+
+- **CRITICAL ✓ verified — Boot-time `alembic upgrade heads` resurrects uninstalled modules.**
+  `docker-entrypoint.sh:27` / `alembic_paths.py:20`. Uninstall verifactu → tables dropped →
+  restart → `vfy_0006` looks unapplied → tables recreated while state stays `UNINSTALLED`.
+- **CRITICAL — Loader mounts every module regardless of install state.**
+  `loader.py:142` / `registry.py:37`. `is_loaded()` means "code on disk," so
+  `migration_import` gating verifactu writes on `is_loaded("verifactu")` is always True.
+- **HIGH — The advertised cross-module-FK CI gate does not exist.**
+  Nothing inspects `ForeignKey` targets against `manifest.depends`, and
+  `test_module_isolation.py:124` skips `migrations/`.
+- **HIGH — Deliberate isolation evasion via raw SQL.**
+  `payments/service.py:565` joins odontogram/catalog/users in raw `text()` (comment admits
+  it launders undeclared deps); `patients/service.py:95` reads agenda's `appointments` — an
+  inverted dependency.
+- **HIGH — agenda ↔ treatment_plan: undeclared import + cross-module FK + cycle.**
+  `agenda/service.py:22` imports a module not in `depends`; `agenda/models.py:166` FKs
+  `planned_treatment_items.id`; treatment_plan depends on agenda → schema-level cycle.
+- **HIGH — whatsapp_kapso registers its channel adapter at import time.**
+  `whatsapp_kapso/__init__.py:30` — the adapter is live even though the module was never
+  installed; uninstall cleanup undone on next boot.
+- **HIGH — 11 modules violate "each module owns its Alembic branch."**
+  patients…notifications thread through one linear chain (`branch_labels=None`).
+  Mitigant: `uninstall` permanently blocks these, so the removable flag isn't a lie — but
+  none can ever be made removable without a graph rewrite.
+
+<details><summary>Medium & low — ordering hazards, cross-reaches, auto_install policy (~6)</summary>
+
+- **`ag_0002` ALTERs a table its revision graph doesn't guarantee exists** — fresh-install
+  success is an Alembic traversal accident.
+- **agenda (core) imports removable schedules' internals** `agenda/kanban_service.py:90` —
+  after uninstall hits dropped tables; `except: continue` risks InFailedSQLTransaction.
+- **billing → reports runtime import, circular** `billing/router.py:1121`.
+- **auto_install policy incoherence** — schedules/recalls/copilot ship `auto_install=True`
+  against the stated opt-in policy; `manifest.py:41` defaults it True.
+- **Validator checks isolation one direction only** — `tp_0002` creates clinical_notes'
+  tables in treatment_plan's chain; flipping clinical_notes to removable would leave tables
+  behind on uninstall.
+- migration_import over-declares `depends` on schedules → spuriously blocks uninstalling it.
+
+</details>
+
+### Copilot / LLM trust boundary — 1 high · 8 medium
+
+- **HIGH ✓ verified — Tool error strings bypass redaction → PII to the cloud LLM.**
+  `registry.py:171` / `orchestrator.py:228` / `redaction.py:167`. The redactor tokenizes
+  only known-key values; tool failures surface as `{"error": <string>}` and `"error"` isn't
+  a known key — so a Pydantic validation error echoing a bad email/phone/name verbatim, or
+  any handler exception carrying row data, is streamed to OpenAI in cleartext.
+- **MEDIUM — `permissions=[]` is the default → an ungated tool is silently exposed.**
+  `tool.py:46` / `registry.py:148`. Over an empty list, `all(...)` is True and the deny loop
+  never runs. No registration-time validation requires a permission.
+- **MEDIUM — The write-confirmation boundary rests on honest `category` labels.**
+  `orchestrator.py:225`. READ auto-executes; only WRITE/DESTRUCTIVE suspend. `category` is
+  self-declared with no cross-check against whether the handler mutates.
+
+<details><summary>Medium & low — over-tokenization, digest leaks, money coercion (~9)</summary>
+
+- **Generic `"name"` key over-tokenizes non-PII** `redaction.py:40` — catalog/cabinet names
+  get tokenized, so the agent can't match "empaste" to a catalog item; catalog search via
+  copilot is effectively broken under redaction (the default).
+- **Uninstalled/disabled modules keep their tools callable** (S1 on the copilot surface).
+- **Morning digest creates a new Agent + AgentSession every run** `tasks.py:96` — unbounded
+  row growth per recipient per hour.
+- **Digest has no "already sent today" guard** — a restart or multi-worker deploy re-sends.
+- **Free-text tool arguments reach the cloud untokenized** — `note`/`reason_note`/
+  `custom_message` aren't in the key set.
+- `jsonify` coerces Decimal money to float; `send_notification` (WRITE) vs `send_budget`
+  (DESTRUCTIVE) label the same irreversible send inconsistently; "38 tools" is really 36.
+
+**Verified sound:** the registry chokepoint genuinely enforces RBAC/guardrails/audit in
+order; `clinic_id` is always server-sourced, never from tool args; tool permission strings
+match their HTTP routes; off-books axis separation is honored and tested; the confirmation
+flow is owner-scoped.
+
+</details>
+
+### RBAC & permissions — 1 high · 3 medium
+
+- **HIGH ✓ verified — `create_user` trusts a caller-supplied `clinic_id`.**
+  `core/auth/router.py:395`. `require_permission("admin.users.write")` checks only the
+  caller's role in their *own* clinic, but the body's `clinic_id` is written verbatim into a
+  new `ClinicMembership` with an arbitrary role. An admin of Clinic A can POST
+  `{clinic_id: <Clinic B>, role: "admin"}` and mint an admin membership in Clinic B.
+  `update_user`/`delete_user` scope correctly — this one doesn't.
+- **MEDIUM — Front-desk roles can author and delete clinical notes.**
+  `clinical_notes/__init__.py` grants receptionist/hygienist/assistant `notes.write`, which
+  gates create, edit, *and* delete (no separate delete permission).
+- **MEDIUM — Role inversion in media.**
+  `media/__init__.py` — receptionist/assistant get `media.*` (can delete clinical photos)
+  while the hygienist is read-only and can't upload one.
+
+<details><summary>Medium & low — cross-module coupling, dead permission, frontend drift (~5)</summary>
+
+- **agenda endpoint gated by clinical_notes' permission** `agenda/router.py:512` — if
+  clinical_notes is uninstalled, the endpoint silently becomes admin-only.
+- **`admin.users.read` is dead** — declared in core perms and frontend, enforced by no
+  endpoint; `GET /users` requires `write`.
+- 26 hardcoded permission strings in the frontend bypass `PERMISSIONS`; several view-only
+  settings pages gate on `admin.clinic.write` instead of `.read`.
+- Most pages carry only `auth` middleware, no permission gate (UI-only, backend gated).
+
+**Verified sound:** the wildcard matcher has no `startswith` bug (`billing.*` ≠
+`billing_x.y`); module-name prefixing composes correctly; install/uninstall/user-management
+are admin-only.
+
+</details>
+
+### Multi-tenancy isolation — 2 medium · fragile patterns
+
+> No critical/high cross-tenant read or write is exploitable via HTTP or copilot tools —
+> `get_clinic_context`, the tool-registry chokepoint, media path construction, and the
+> WhatsApp webhook signature check all hold. The two mediums are real disclosures gated by
+> knowing a non-enumerable target UUID.
+
+- **MEDIUM ✓ verified — Recalls: create trusts `patient_id`; list/export join `Patient`
+  unscoped.** `recalls/service.py:231` inserts with the caller's `clinic_id` but never checks
+  the supplied `patient_id`; the list query (`service.py:131`) joins `Patient` with no clinic
+  predicate. A clinic-A user creates a recall pointing at a known clinic-B patient UUID, then
+  reads back that patient's name/phone in the list or CSV.
+- **MEDIUM — Agenda: planned-item validation skipped when appointment has no `patient_id`.**
+  `agenda/service.py:403,455`. Validation runs only `if planned_item_ids and
+  data.get("patient_id")`, but `patient_id` is optional. Omitting the patient links a
+  caller-supplied planned item via a naked `db.get()`; a later GET eager-loads clinic B's
+  treatment-plan data.
+
+<details><summary>Fragile-but-not-exploitable — defense-in-depth gaps (~5)</summary>
+
+- **patients_clinical service layer has zero scoping** — getters like `get_allergy(db, id)`
+  take no `clinic_id` despite docstrings claiming otherwise; isolation lives entirely in the
+  router. The first direct caller (a copilot tool or event handler) would return clinic B's
+  medical history. Worth hardening proactively.
+- notifications/budget event handlers fetch by id trusting payload `clinic_id` with no
+  filter — internal-only today.
+- Several `create` paths store caller-supplied FKs without ownership validation — dangling
+  reference smell, no disclosure.
+
+</details>
+
+### Documentation drift — several high · misleads agents
+
+- **HIGH ✓ verified — CLAUDE.md's "source of truth" RBAC snippet is flat wrong.**
+  `CLAUDE.md` shows the pre-modular `clinical.*` scheme; `permissions.py:44` reality is
+  dentist = `agents.view/supervise`, hygienist/assistant/receptionist = empty core grants,
+  everything else merged from module manifests via `get_role_permissions()`. The "Adding a
+  permission" recipe points at the wrong place.
+- **HIGH — 4 modules with events have no `events.md`; the CI check is regex-blind.**
+  agenda, odontogram, patients_clinical, clinical_notes publish events but have no
+  `events.md`. `check_docs_coverage.py:165`'s `PUBLISH_RE` has no capture group for
+  `EventType.X`, so the "events.md required" rule never fires. Its promised shared helpers
+  (`_docs_lib.py`, `docs_index.py`) don't exist.
+
+<details><summary>Medium & low — stale commits, glossary, catalogs (~12)</summary>
+
+- **18 files carry placeholder `last_verified_commit: 0000000`** (catalog, notifications, all
+  6 verifactu screens, both locales) — defeats the staleness-badge mechanism.
+- **Genuinely stale screens** where the .vue changed after the recorded SHA with
+  behavior-changing commits: patients/detail, reports, payments dashboard.
+- **events-catalog.md factually wrong** — odontogram/clinical_notes events show "declared but
+  unused" while actively published (the S4 regex bug).
+- **Glossary drift:** "Payment" still defined as "money against an invoice" contradicting the
+  patient-centric model; zero entries for WhatsApp/copilot/nudges/notifications.
+- **CHANGELOG gaps:** patient_timeline, patients_clinical, clinical_notes, migration_import
+  have code after their last CHANGELOG touch.
+- `docs/portal/` is allowlisted by CI but omitted from the CLAUDE.md + README folder tables.
+
+</details>
+
+---
+
+## Top 8 fixes by leverage
+
+1. **S1** — consume `ModuleRecord` state in the loader and entrypoint (filter branch heads
+   and module mounting by install state; split `is_loaded()` into `is_discovered()` /
+   `is_installed()`; add an uninstall→restart round-trip test).
+2. **Invoice-number unique index** — one migration to create the index the model already
+   claims exists.
+3. **`FOR UPDATE` + DB CHECK caps** on refunds / invoice payments / allocations.
+4. **`create_user`** — validate `clinic_id` against the caller's admin memberships.
+5. **Media handler** — fix the signature and add `clinic_id` to the `patient.archived`
+   payload.
+6. **`useApi`** — forward `query`, make the timeout per-call overridable, document the
+   toast-or-rethrow contract.
+7. **Commit-before-publish** across the event bus (or a transactional outbox).
+8. **Docs** — fix the CLAUDE.md RBAC snippet and the catalog-generator regex (so live events
+   stop reading as unused).


### PR DESCRIPTION
First batch of fixes from the adversarial audit (`docs/technical/audit-2026-07-03.md`). Scoped to **contained, verified, individually-tested** issues — the large systemic refactors (S1 loader/uninstall, S2 transactional outbox, the remaining money-locking of S3) stay tracked in their issues as follow-ups.

Each fix is its own commit with a regression test.

## Fixes

| Commit | Issue | What |
|---|---|---|
| `8d4d3e3` | #93 (S3/C3) | **billing:** invoice-number uniqueness backstop. The model comment claimed a partial unique index that no migration created → duplicate fiscal numbers were representable. New `bil_0005` adds partial unique indexes on `(clinic_id, invoice_number)` and `(series_id, sequential_number)`. |
| `6027675` | #95 (event-bus #1/#11) | **media/patients:** the `patient.archived` document cascade had *never run* — handler signature `(self, db, data)` vs the bus's `handler(data)` (TypeError every time), and it read a `clinic_id` the publisher never sent. Handler fixed to `(data)` + own session; publisher now emits `clinic_id` on `patient.archived` and `patient.updated`. |
| `a8c6e0e` | #95 (RBAC H1) | **auth:** `create_user` wrote the body's `clinic_id` verbatim → an admin of clinic A could mint an admin membership in clinic B. Now 403 unless the caller admins the target clinic. |
| `8f99a1d` | #95 (multi-tenancy #1) | **recalls:** `create` trusted a caller-supplied `patient_id` and the list/export join wasn't clinic-scoped → cross-clinic PII read-back. Now 404s on a foreign patient (HTTP + copilot tool) and scopes the join. |
| `b81a6f7` | #95 (frontend #1) | **periodontogram:** `api.delete` → `api.del` (the method didn't exist; discard-draft threw a TypeError and then the one-draft unique index blocked all new sessions). |
| `036460b` | #94 (S4) | **docs:** correct the CLAUDE.md RBAC "source of truth" snippet to the real modular model (was the pre-modular `clinical.*` scheme). |

## Tests

New regression tests: `test_invoice_number_unique`, `test_patient_archived_cascade`, `test_auth_create_user_scope`, and a cross-tenant case in recalls `test_router`. All pass.

Full backend suite: **829 passed, 1 failed**. The single failure (`test_patient_timeline::test_on_appointment_scheduled_inserts_visit`) **passes in isolation** and is pre-existing full-run ordering flakiness (the known asyncpg cross-loop issue in these suites) — it's on the `appointment.scheduled` path, which this PR doesn't touch. Ruff clean; docs-layout check green; Alembic branch/roundtrip tests green with the new migration.

## Deploy note

`bil_0005` will **fail loudly** if a database already contains duplicate invoice numbers or per-series sequentials — intentional (a duplicate fiscal number is a data problem to fix, not to paper over). Verify production before deploying.

## Not in this PR (tracked as follow-ups)

- #93 remaining: `FOR UPDATE` locks + `CHECK` constraints for refund cap / invoice over-payment / draft-issue race (C1/C2/C4).
- #91 (S1), #92 (S2): the systemic loader/uninstall and event-commit-ordering refactors.
- #95 remaining frontend items (useApi 4xx handling, false-empty reads, unconfirmed destructive actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)