### PR TITLE
fix(billing,payments): S3 money-path concurrency guards (C1/C2/C4) — closes #97

### DIFF
--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- fix(security): lock the invoice row `FOR UPDATE` on the payment and
+  issue endpoints (audit S3/C2 + C4, #97). Two concurrent payments could
+  both read the full `balance_due` and over-collect past the total; two
+  concurrent issues of one draft could both pass the draft-only guard,
+  burning a sequential number and chaining a duplicate AEAT record. The
+  issue path also refreshes `status` under the lock so the second caller
+  sees `issued`. Guard tests in `test_issue_and_payment_guards`.
+
 - fix(migrations): add the invoice-number uniqueness backstop that the
   `Invoice` model comment already claimed existed (audit S3/C3, #93).
   New migration `bil_0005` creates two partial unique indexes —

--- a/backend/app/modules/billing/router.py
+++ b/backend/app/modules/billing/router.py
@@ -581,11 +581,27 @@ async def issue_invoice(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ApiResponse[InvoiceResponse]:
     """Issue an invoice or credit note (transition from draft to issued)."""
+    from sqlalchemy import select
+
+    from .models import Invoice
+
     invoice = await InvoiceService.get_invoice(
         db, ctx.clinic_id, invoice_id, include_items=True, include_payments=False
     )
     if not invoice:
         raise HTTPException(status_code=404, detail="Invoice not found")
+
+    # Serialize concurrent issue of the same draft (audit S3/C4, #97): lock
+    # the row and refresh status, so a second request sees the committed
+    # "issued" state and the workflow's draft-only guard rejects it —
+    # instead of both burning a sequential number + chaining a duplicate
+    # AEAT record.
+    await db.execute(
+        select(Invoice.id)
+        .where(Invoice.id == invoice_id, Invoice.clinic_id == ctx.clinic_id)
+        .with_for_update()
+    )
+    await db.refresh(invoice, attribute_names=["status"])
 
     # If this is a credit note, load the original invoice for the hook
     original_invoice = None
@@ -839,9 +855,11 @@ async def apply_payment_to_invoice(
     # Lazy imports: billing imports payments (depends), but payments
     # doesn't import billing — keeping the top-level imports clean
     # prevents circular initialisation through catalog/budget.
+    from sqlalchemy import select
+
     from app.modules.payments.workflow import PaymentWorkflowError, record_payment
 
-    from .models import InvoicePayment
+    from .models import Invoice, InvoicePayment
 
     invoice = await InvoiceService.get_invoice(
         db, ctx.clinic_id, invoice_id, include_items=False, include_payments=False
@@ -853,6 +871,15 @@ async def apply_payment_to_invoice(
             status_code=400,
             detail=f"Cannot record payment for invoice with status '{invoice.status}'",
         )
+
+    # Serialize concurrent payments against this invoice (audit S3/C2, #97):
+    # lock the invoice row so two requests can't both read the full balance
+    # and each record a payment, over-collecting past the total.
+    await db.execute(
+        select(Invoice.id)
+        .where(Invoice.id == invoice_id, Invoice.clinic_id == ctx.clinic_id)
+        .with_for_update()
+    )
 
     total_paid, balance_due = await compute_paid_summary(db, ctx.clinic_id, invoice_id)
     if payload.amount > balance_due:

--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(security): lock the payment row `FOR UPDATE` before the refund
+  cap check (audit S3/C1, #97). Two concurrent refunds could both read
+  `already_refunded` before either inserted, letting Σrefund exceed
+  `payment.amount` and driving `net_paid` negative. The row lock
+  serializes them so the cap holds.
+
 - feat(agents): two new copilot tools — `record_payment` (WRITE, wraps
   `workflow.record_payment`, allocation-sum errors surfaced structurally)
   and `patient_payment_history` (READ, collection axis only: drops

--- a/backend/app/modules/payments/workflow.py
+++ b/backend/app/modules/payments/workflow.py
@@ -278,6 +278,11 @@ async def refund_payment(
     if amount <= 0:
         raise PaymentWorkflowError("Refund amount must be > 0")
 
+    # Serialize concurrent refunds on the same payment (audit S3/C1, #97):
+    # lock the payment row so the sum-and-cap check below can't race with
+    # another refund and let Σrefund exceed payment.amount.
+    await db.execute(select(Payment.id).where(Payment.id == payment.id).with_for_update())
+
     result = await db.execute(
         select(func.coalesce(func.sum(Refund.amount), Decimal("0"))).where(
             Refund.payment_id == payment.id

--- a/backend/tests/modules/billing/test_issue_and_payment_guards.py
+++ b/backend/tests/modules/billing/test_issue_and_payment_guards.py
@@ -1,0 +1,122 @@
+"""Money-path guards on the invoice issue + payment endpoints (audit
+S3/C2 + C4, #97).
+
+These assert the *sequential* rejection behaviour that the row locks in
+`issue_invoice` / `record_payment_for_invoice` protect under concurrency:
+a draft can't be issued twice, and an invoice can't be over-collected.
+(True concurrent races aren't reproducible in the single-session test
+harness; the locks serialize them so the checks below hold.)
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic, User
+from app.modules.billing.models import Invoice, InvoiceItem, InvoiceSeries
+from app.modules.patients.models import Patient
+
+
+async def _draft_invoice(db: AsyncSession, clinic: Clinic, patient: Patient, user_id) -> Invoice:
+    db.add(
+        InvoiceSeries(
+            id=uuid4(),
+            clinic_id=clinic.id,
+            prefix="FAC",
+            series_type="invoice",
+            is_default=True,
+        )
+    )
+    inv = Invoice(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        status="draft",
+        # Pre-set billing data so issue() skips the patient snapshot.
+        billing_name="Cliente Test",
+        billing_tax_id="B12345678",
+        subtotal=Decimal("100.00"),
+        total=Decimal("100.00"),
+        created_by=user_id,
+    )
+    db.add(inv)
+    await db.flush()
+    db.add(
+        InvoiceItem(
+            id=uuid4(),
+            clinic_id=clinic.id,
+            invoice_id=inv.id,
+            description="Servicio",
+            unit_price=Decimal("100.00"),
+            quantity=1,
+            vat_rate=0.0,
+            line_subtotal=Decimal("100.00"),
+            line_tax=Decimal("0.00"),
+            line_total=Decimal("100.00"),
+            display_order=0,
+        )
+    )
+    await db.commit()
+    return inv
+
+
+async def _user_id(db: AsyncSession):
+    return (await db.execute(select(User))).scalars().first().id
+
+
+@pytest.mark.asyncio
+async def test_draft_cannot_be_issued_twice(
+    client: AsyncClient,
+    auth_headers: dict,
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+) -> None:
+    inv = await _draft_invoice(db_session, test_clinic, test_patient, await _user_id(db_session))
+
+    first = await client.post(
+        f"/api/v1/billing/invoices/{inv.id}/issue", json={}, headers=auth_headers
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["data"]["status"] == "issued"
+
+    second = await client.post(
+        f"/api/v1/billing/invoices/{inv.id}/issue", json={}, headers=auth_headers
+    )
+    assert second.status_code == 400, second.text
+
+
+@pytest.mark.asyncio
+async def test_invoice_cannot_be_overpaid(
+    client: AsyncClient,
+    auth_headers: dict,
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+) -> None:
+    inv = await _draft_invoice(db_session, test_clinic, test_patient, await _user_id(db_session))
+    issued = await client.post(
+        f"/api/v1/billing/invoices/{inv.id}/issue", json={}, headers=auth_headers
+    )
+    assert issued.status_code == 200, issued.text
+
+    pay = {"amount": "100.00", "method": "cash", "payment_date": date.today().isoformat()}
+    r1 = await client.post(
+        f"/api/v1/billing/invoices/{inv.id}/payments", json=pay, headers=auth_headers
+    )
+    assert r1.status_code == 201, r1.text
+
+    # Balance is now 0 — any further payment must be rejected.
+    r2 = await client.post(
+        f"/api/v1/billing/invoices/{inv.id}/payments",
+        json={"amount": "1.00", "method": "cash", "payment_date": date.today().isoformat()},
+        headers=auth_headers,
+    )
+    assert r2.status_code == 400, r2.text

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -418,7 +418,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.INVOICE_SENT`
 - **Publishers:**
-  - `billing` — `backend/app/modules/billing/router.py:681`
+  - `billing` — `backend/app/modules/billing/router.py:697`
 - **Subscribers:**
   - `notifications`
 
@@ -635,7 +635,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.PAYMENT_REFUNDED`
 - **Publishers:**
-  - `payments` — `backend/app/modules/payments/workflow.py:324`
+  - `payments` — `backend/app/modules/payments/workflow.py:329`
 - **Subscribers:**
   - `billing`
 


### PR DESCRIPTION
Closes #97 (follow-up to the S3 root cause, #93). Adds the row-lock serialization the money paths were missing — the check-then-act races the audit flagged (`docs/technical/audit-2026-07-03.md` §S3).

## Fixes

| Commit | Item | What |
|---|---|---|
| `fb5e641` | **C1** refund cap | `refund_payment` now takes `SELECT … FOR UPDATE` on the payment row before summing existing refunds. Concurrent refunds could both read `already_refunded` and let Σrefund exceed the payment (net_paid negative). |
| `2c2fd3a` | **C2** over-payment | `record_payment_for_invoice` locks the invoice row before `compute_paid_summary`, so two payments can't both see the full balance and over-collect. |
| `2c2fd3a` | **C4** draft-issue race | `issue_invoice` locks the invoice row and refreshes `status`, so a second concurrent issue sees `issued` and the draft-only guard rejects it — instead of burning a sequential number and chaining a duplicate AEAT record. |

The lock pattern matches the existing precedent in `InvoiceNumberService.generate_number` (`FOR UPDATE` on the series row).

## Tests

- New `test_issue_and_payment_guards`: double-issue → 400, over-payment → 400 (the sequential rejections the locks protect).
- Existing `test_refund_partial_then_full` covers the refund cap.
- Affected suites (payments, billing, budget, verifactu, accounting_export, module_tools): **165 passed**. Catalog freshness regenerated.

True concurrent races aren't reproducible in the single-session test harness; the locks serialize them so the guards above hold. Sequential behaviour is unchanged, so the happy-path issue/payment/refund flows keep passing.

## Not included

Related same-family items called out in the audit but lower-severity / broader (allocation-sum `reallocate_payment`, partial-invoicing `invoiced_quantity`) stay in the audit doc; can spin a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)