### PR TITLE
fix(ci,docs): S4 — the module-contract CI gates CLAUDE.md advertises (closes #94)

### DIFF
--- a/backend/scripts/check_docs_coverage.py
+++ b/backend/scripts/check_docs_coverage.py
@@ -162,7 +162,19 @@ HTTP_METHODS = ("get", "post", "put", "patch", "delete")
 ROUTER_DECORATOR_RE = re.compile(
     r"@router\.(?P<method>get|post|put|patch|delete)\(\s*[\"'](?P<path>[^\"']*)[\"']",
 )
-PUBLISH_RE = re.compile(r"event_bus\.publish\(\s*(?:EventType\.[A-Z_]+|[\"'](?P<lit>[\w.]+)[\"'])")
+# First arg of an event_bus.publish(...) call. Captures the four shapes a
+# module can publish through so the "events.md required" rule below fires
+# for enum-based and dynamic publishers too, not just string literals
+# (audit S4, #94 — the old regex only had a group for the literal case,
+# so EventType.X publishers were invisible and the rule never triggered).
+PUBLISH_RE = re.compile(
+    r"event_bus\.publish\(\s*(?:"
+    r"EventType\.(?P<const>[A-Z_]+)"
+    r"|(?P<enum>[A-Z]\w*\.[A-Z_]+)"
+    r"|[\"'](?P<lit>[\w.]+)[\"']"
+    r"|(?P<var>[a-z_]\w*)"
+    r")"
+)
 
 
 def _scan_module_endpoints(mod_dir: Path, mount_prefix: str) -> list[tuple[str, str]]:
@@ -188,9 +200,14 @@ def _scan_module_publishers(mod_dir: Path) -> set[str]:
         if "event_bus.publish" not in text:
             continue
         for match in PUBLISH_RE.finditer(text):
-            lit = match.group("lit")
-            if lit:
-                out.add(lit)
+            token = (
+                match.group("const")
+                or match.group("lit")
+                or match.group("enum")
+                or match.group("var")
+            )
+            if token:
+                out.add(token)
     return out
 
 

--- a/backend/scripts/generate_catalogs.py
+++ b/backend/scripts/generate_catalogs.py
@@ -79,32 +79,60 @@ from app.core.plugins.loader import discover_modules  # noqa: E402
 # Event publisher discovery (regex over source — good enough, no AST needed)
 # ---------------------------------------------------------------------------
 
-# Matches:
-#   event_bus.publish(EventType.PATIENT_CREATED, ...)
-#   event_bus.publish("patient.created", ...)
-#   await event_bus.publish(EventType.X, ...)
-PUBLISH_RE = re.compile(
-    r"event_bus\.publish\(\s*(?:EventType\.(?P<const>[A-Z_]+)|[\"'](?P<lit>[\w.]+)[\"'])"
-)
+# Captures the first argument of an ``event_bus.publish(...)`` call —
+# ``\s*`` spans newlines so multi-line calls work. The arg is one of:
+#   EventType.PATIENT_CREATED     -> dotted constant on the EventType enum
+#   OdontogramEventType.TOOTH_...  -> dotted constant on a module-local enum
+#   "patient.created"             -> string literal
+#   specific / event_name         -> a bare identifier (dynamic dispatch)
+PUBLISH_ARG_RE = re.compile(r"event_bus\.publish\(\s*(?P<arg>[A-Za-z_][\w.]*|[\"'][\w.]+[\"'])")
+# Any ``<Enum>.<CONST>`` reference, and any local ``CONST = "dotted.value"``
+# assignment (module-local event enums like ``OdontogramEventType``).
+ENUM_REF_RE = re.compile(r"\b([A-Za-z_]\w*)\.([A-Z][A-Z0-9_]*)\b")
+LOCAL_CONST_RE = re.compile(r"^\s*([A-Z][A-Z0-9_]*)\s*=\s*[\"']([\w.]+)[\"']", re.MULTILINE)
 
 
-def _event_value(name_or_const: str) -> str | None:
-    """Return the string event name from a constant name or literal."""
-    if hasattr(EventType, name_or_const):
-        value = getattr(EventType, name_or_const)
-        return value if isinstance(value, str) else None
-    # Already a literal value.
-    return name_or_const
+def _known_event_values() -> set[str]:
+    return {
+        v
+        for v in (getattr(EventType, a) for a in dir(EventType) if not a.startswith("_"))
+        if isinstance(v, str)
+    }
+
+
+def _resolve_token(arg: str, local_consts: dict[str, str]) -> str | None:
+    """Resolve a publish first-arg token to its event value, or None if it
+    is a bare identifier (dynamic dispatch that must be handled separately)."""
+    if arg[0] in "\"'":
+        return arg.strip("\"'")
+    if "." in arg:
+        cls, _, const = arg.rpartition(".")
+        if cls == "EventType":
+            value = getattr(EventType, const, None)
+            return value if isinstance(value, str) else None
+        # Module-local enum (e.g. OdontogramEventType.SURFACE_UPDATED):
+        # resolve by the constant's same-file string assignment.
+        return local_consts.get(const)
+    return None  # bare identifier → dynamic
 
 
 def _scan_publishers() -> dict[str, list[tuple[str, str, int]]]:
     """Walk source files, return {event_value: [(module, relpath, lineno)]}.
 
-    ``module`` is the module name when the file lives under
-    ``backend/app/modules/<name>/``; otherwise the segment after
-    ``backend/app/`` (e.g. ``core/agents``) for visibility into core.
+    Handles three publish shapes so the catalog never falsely reports a
+    live event as unpublished (audit S4, #94):
+      1. ``publish(EventType.X, ...)`` / string literal — direct.
+      2. ``publish(ModuleEnum.X, ...)`` — resolved via the constant's
+         same-file string assignment.
+      3. ``publish(<var>, ...)`` — dynamic dispatch (agenda status map,
+         clinical_notes note-type map, notifications gateway). Every event
+         constant *referenced in that file* is attributed to its module.
+
+    ``module`` is the module name for files under
+    ``backend/app/modules/<name>/``; otherwise ``core:<segment>``.
     """
-    publishers: dict[str, list[tuple[str, str, int]]] = defaultdict(list)
+    known_values = _known_event_values()
+    publishers: set[tuple[str, str, str, int]] = set()
     roots = [MODULES_ROOT, BACKEND_ROOT / "app" / "core"]
 
     for root in roots:
@@ -116,16 +144,44 @@ def _scan_publishers() -> dict[str, list[tuple[str, str, int]]]:
                 continue
             relpath = path.relative_to(REPO_ROOT).as_posix()
             module_name = _module_name_for(path)
-            for match in PUBLISH_RE.finditer(text):
-                lineno = text.count("\n", 0, match.start()) + 1
-                event = _event_value(match.group("const") or match.group("lit"))
-                if event is None:
-                    continue
-                publishers[event].append((module_name, relpath, lineno))
 
-    for entries in publishers.values():
-        entries.sort()
-    return publishers
+            # Same-file constant table (module-local event enums).
+            local_consts = {
+                name: value for name, value in LOCAL_CONST_RE.findall(text) if value in known_values
+            }
+
+            has_dynamic = False
+            for match in PUBLISH_ARG_RE.finditer(text):
+                lineno = text.count("\n", 0, match.start()) + 1
+                value = _resolve_token(match.group("arg"), local_consts)
+                if value is not None:
+                    publishers.add((value, module_name, relpath, lineno))
+                else:
+                    has_dynamic = True
+
+            if has_dynamic:
+                # Attribute every event constant referenced anywhere in the
+                # file — the dispatch variable is fed from these.
+                for m in re.finditer(r"EventType\.([A-Z_]+)", text):
+                    value = getattr(EventType, m.group(1), None)
+                    if isinstance(value, str):
+                        lineno = text.count("\n", 0, m.start()) + 1
+                        publishers.add((value, module_name, relpath, lineno))
+                for m in ENUM_REF_RE.finditer(text):
+                    value = local_consts.get(m.group(2))
+                    if value is not None:
+                        lineno = text.count("\n", 0, m.start()) + 1
+                        publishers.add((value, module_name, relpath, lineno))
+
+    result: dict[str, list[tuple[str, str, int]]] = defaultdict(list)
+    seen: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    for value, module_name, relpath, lineno in sorted(publishers):
+        # One row per (event, module, file) — keep the earliest line.
+        if (module_name, relpath) in seen[value]:
+            continue
+        seen[value].add((module_name, relpath))
+        result[value].append((module_name, relpath, lineno))
+    return result
 
 
 def _module_name_for(path: Path) -> str:

--- a/backend/tests/test_catalog_generator.py
+++ b/backend/tests/test_catalog_generator.py
@@ -1,0 +1,52 @@
+"""Guards for the events-catalog publisher scan (audit S4, #94).
+
+The catalog generator used to only resolve `event_bus.publish(EventType.X)`
+and string literals, so events published via a module-local enum
+(`OdontogramEventType`) or a dispatch variable (agenda status map,
+clinical_notes note-type map, notifications gateway) were reported as
+having *no publisher* — inviting someone to delete a live event. These
+tests lock in that each of those four mechanisms is now attributed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import app
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "generate_catalogs.py"
+
+
+def _load_generator():
+    # The generator derives its roots from the script location, which is
+    # wrong when the backend is mounted at a non-repo path (e.g. /app in
+    # the container). Pin the roots to the actual ``app`` package so the
+    # source scan works regardless of layout.
+    backend_root = Path(app.__file__).resolve().parents[1]
+    os.environ["DENTALPIN_BACKEND_ROOT"] = str(backend_root)
+    os.environ["DENTALPIN_REPO_ROOT"] = str(backend_root.parent)
+    spec = importlib.util.spec_from_file_location("_gen_catalogs", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dynamic_and_enum_publishers_are_attributed() -> None:
+    gen = _load_generator()
+    publishers = gen._scan_publishers()
+
+    # (event, expected owning module) — one representative per mechanism.
+    expectations = {
+        "appointment.completed": "agenda",  # variable dispatch (status map)
+        "odontogram.surface.updated": "odontogram",  # module-local enum
+        "clinical_notes.diagnosis_created": "clinical_notes",  # note-type map
+        "notification.sent": "notifications",  # gateway helper dispatch
+    }
+    for event, module in expectations.items():
+        sites = publishers.get(event)
+        assert sites, f"{event} resolved to NO publisher (regex regression)"
+        assert module in {m for m, _path, _line in sites}, (
+            f"{event} should be attributed to {module}, got {sites}"
+        )

--- a/backend/tests/test_module_fk_isolation.py
+++ b/backend/tests/test_module_fk_isolation.py
@@ -1,0 +1,142 @@
+"""Cross-module foreign-key guard (audit S4, #94).
+
+CLAUDE.md's modular contract states: "Cross-module FKs are allowed **only**
+when the target is in the module's ``manifest.depends``. CI rejects
+migrations otherwise." That CI check did not exist — the import guard in
+``test_module_isolation.py`` only looks at Python imports and explicitly
+skips ``migrations/``, so a migration adding a cross-module FK (or a model
+column pointing at another module's table) was invisible.
+
+This test closes that gap by introspecting the SQLAlchemy models: for
+every ``ForeignKey`` whose target table is owned by another module, that
+module must be in the source module's ``depends`` — unless the target is
+a core table (``clinics``, ``users``, …), which is always allowed.
+
+Ratchet, like the import guard: the actual set of cross-module FKs must
+equal ``KNOWN_FK_VIOLATIONS`` exactly. A new violation fails immediately;
+clearing one also fails until the allowlist is updated, forcing the
+cleanup to be explicit. Drain this set over time, never grow it.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import app.modules as _modules_pkg
+from app.database import Base
+
+MODULES_ROOT = Path(_modules_pkg.__file__).resolve().parent
+
+
+# Pre-existing cross-module FKs that are tracked tech debt.
+# ``(source_module, table, column, target_table, target_module)``.
+# agenda→treatment_plan mirrors the import already tracked in
+# test_module_isolation.KNOWN_VIOLATIONS (the appointment↔plan-item link).
+KNOWN_FK_VIOLATIONS: set[tuple[str, str, str, str, str]] = {
+    (
+        "agenda",
+        "appointment_treatments",
+        "planned_treatment_item_id",
+        "planned_treatment_items",
+        "treatment_plan",
+    ),
+}
+
+
+def _list_modules() -> list[str]:
+    return sorted(
+        p.name for p in MODULES_ROOT.iterdir() if p.is_dir() and (p / "__init__.py").exists()
+    )
+
+
+def _import_all_models() -> None:
+    """Ensure every module's models are registered on ``Base`` before we
+    walk the mapper registry."""
+    for name in _list_modules():
+        importlib.import_module(f"app.modules.{name}")
+        try:
+            importlib.import_module(f"app.modules.{name}.models")
+        except ModuleNotFoundError:
+            continue  # module owns no tables (e.g. accounting_export)
+
+
+def _manifest_depends(module_name: str) -> set[str]:
+    pkg = importlib.import_module(f"app.modules.{module_name}")
+    for attr in vars(pkg).values():
+        if (
+            isinstance(attr, type)
+            and getattr(attr, "manifest", None)
+            and isinstance(attr.manifest, dict)
+            and attr.manifest.get("name") == module_name
+        ):
+            return set(attr.manifest.get("depends", []))
+    raise AssertionError(f"Could not locate manifest for module {module_name}")
+
+
+def _table_owner_map() -> dict[str, str]:
+    """``tablename -> owning module`` for module-defined tables. Tables not
+    in this map are core (``app.core.*``) and always FK-legal."""
+    owner: dict[str, str] = {}
+    for mapper in Base.registry.mappers:
+        module = mapper.class_.__module__
+        if not module.startswith("app.modules."):
+            continue
+        tablename = getattr(mapper.class_, "__tablename__", None)
+        if tablename:
+            owner[tablename] = module.split(".")[2]
+    return owner
+
+
+def _scan_cross_module_fks() -> set[tuple[str, str, str, str, str]]:
+    owner = _table_owner_map()
+    depends_cache: dict[str, set[str]] = {}
+    found: set[tuple[str, str, str, str, str]] = set()
+
+    for mapper in Base.registry.mappers:
+        module = mapper.class_.__module__
+        if not module.startswith("app.modules."):
+            continue
+        source = module.split(".")[2]
+        depends = depends_cache.setdefault(source, _manifest_depends(source))
+        for column in mapper.class_.__table__.columns:
+            for fk in column.foreign_keys:
+                target_table = fk.column.table.name
+                target_module = owner.get(target_table)
+                if target_module and target_module != source and target_module not in depends:
+                    found.add(
+                        (
+                            source,
+                            mapper.class_.__tablename__,
+                            column.name,
+                            target_table,
+                            target_module,
+                        )
+                    )
+    return found
+
+
+def test_no_undeclared_cross_module_fks() -> None:
+    _import_all_models()
+    actual = _scan_cross_module_fks()
+
+    new = actual - KNOWN_FK_VIOLATIONS
+    resolved = KNOWN_FK_VIOLATIONS - actual
+
+    messages: list[str] = []
+    if new:
+        messages.append(
+            "New cross-module FKs detected — declare the target in the source "
+            "module's manifest.depends, or remove the FK:"
+        )
+        for src, table, col, tgt_table, tgt_mod in sorted(new):
+            messages.append(
+                f"  - {src}.{table}.{col} -> {tgt_table} (owned by {tgt_mod}); "
+                f"'{tgt_mod}' not in {src}.depends"
+            )
+    if resolved:
+        messages.append("Cross-module FK cleared. Remove from KNOWN_FK_VIOLATIONS:")
+        for src, table, col, tgt_table, tgt_mod in sorted(resolved):
+            messages.append(f"  - {src}.{table}.{col} -> {tgt_table} ({tgt_mod})")
+
+    assert not messages, "\n".join(messages)

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -12,12 +12,12 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 |-------|----------|------------|-------------|
 | `agenda.visit_note_updated` | `EventType.AGENDA_VISIT_NOTE_UPDATED` | `agenda` | `patient_timeline` |
 | `appointment.cabinet_changed` | `EventType.APPOINTMENT_CABINET_CHANGED` | `agenda` | — |
-| `appointment.cancelled` | `EventType.APPOINTMENT_CANCELLED` | — | `copilot`, `notifications`, `patient_timeline`, `recalls`, `schedules` |
-| `appointment.checked_in` | `EventType.APPOINTMENT_CHECKED_IN` | — | `patient_timeline` |
-| `appointment.completed` | `EventType.APPOINTMENT_COMPLETED` | — | `patient_timeline`, `recalls`, `treatment_plan` |
-| `appointment.confirmed` | `EventType.APPOINTMENT_CONFIRMED` | — | `patient_timeline` |
-| `appointment.in_treatment` | `EventType.APPOINTMENT_IN_TREATMENT` | — | `patient_timeline` |
-| `appointment.no_show` | `EventType.APPOINTMENT_NO_SHOW` | — | `patient_timeline` |
+| `appointment.cancelled` | `EventType.APPOINTMENT_CANCELLED` | `agenda` | `copilot`, `notifications`, `patient_timeline`, `recalls`, `schedules` |
+| `appointment.checked_in` | `EventType.APPOINTMENT_CHECKED_IN` | `agenda` | `patient_timeline` |
+| `appointment.completed` | `EventType.APPOINTMENT_COMPLETED` | `agenda` | `patient_timeline`, `recalls`, `treatment_plan` |
+| `appointment.confirmed` | `EventType.APPOINTMENT_CONFIRMED` | `agenda` | `patient_timeline` |
+| `appointment.in_treatment` | `EventType.APPOINTMENT_IN_TREATMENT` | `agenda` | `patient_timeline` |
+| `appointment.no_show` | `EventType.APPOINTMENT_NO_SHOW` | `agenda` | `patient_timeline` |
 | `appointment.scheduled` | `EventType.APPOINTMENT_SCHEDULED` | `agenda` | `notifications`, `patient_timeline`, `recalls`, `schedules` |
 | `appointment.status_changed` | `EventType.APPOINTMENT_STATUS_CHANGED` | `agenda` | — |
 | `appointment.updated` | `EventType.APPOINTMENT_UPDATED` | `agenda` | `schedules` |
@@ -29,12 +29,12 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `budget.renegotiated` | `EventType.BUDGET_RENEGOTIATED` | `budget` | `patient_timeline`, `treatment_plan` |
 | `budget.sent` | `EventType.BUDGET_SENT` | `budget` | `notifications`, `patient_timeline` |
 | `budget.viewed` | `EventType.BUDGET_VIEWED` | `budget` | `patient_timeline` |
-| `clinical_notes.administrative_created` | `EventType.CLINICAL_NOTE_ADMINISTRATIVE_CREATED` | — | `patient_timeline` |
-| `clinical_notes.appointment_administrative_created` | `EventType.CLINICAL_NOTE_APPOINTMENT_ADMINISTRATIVE_CREATED` | — | — |
-| `clinical_notes.appointment_clinical_created` | `EventType.CLINICAL_NOTE_APPOINTMENT_CLINICAL_CREATED` | — | — |
-| `clinical_notes.diagnosis_created` | `EventType.CLINICAL_NOTE_DIAGNOSIS_CREATED` | — | `patient_timeline` |
-| `clinical_notes.plan_created` | `EventType.CLINICAL_NOTE_PLAN_CREATED` | — | `patient_timeline` |
-| `clinical_notes.treatment_created` | `EventType.CLINICAL_NOTE_TREATMENT_CREATED` | — | `patient_timeline` |
+| `clinical_notes.administrative_created` | `EventType.CLINICAL_NOTE_ADMINISTRATIVE_CREATED` | `clinical_notes` | `patient_timeline` |
+| `clinical_notes.appointment_administrative_created` | `EventType.CLINICAL_NOTE_APPOINTMENT_ADMINISTRATIVE_CREATED` | `clinical_notes` | — |
+| `clinical_notes.appointment_clinical_created` | `EventType.CLINICAL_NOTE_APPOINTMENT_CLINICAL_CREATED` | `clinical_notes` | — |
+| `clinical_notes.diagnosis_created` | `EventType.CLINICAL_NOTE_DIAGNOSIS_CREATED` | `clinical_notes` | `patient_timeline` |
+| `clinical_notes.plan_created` | `EventType.CLINICAL_NOTE_PLAN_CREATED` | `clinical_notes` | `patient_timeline` |
+| `clinical_notes.treatment_created` | `EventType.CLINICAL_NOTE_TREATMENT_CREATED` | `clinical_notes` | `patient_timeline` |
 | `copilot.budget.threshold_reached` | `EventType.COPILOT_BUDGET_THRESHOLD_REACHED` | — | — |
 | `copilot.digest.sent` | `EventType.COPILOT_DIGEST_SENT` | `copilot` | — |
 | `copilot.session.ended` | `EventType.COPILOT_SESSION_ENDED` | `copilot` | — |
@@ -63,14 +63,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `migration.job.completed` | `EventType.MIGRATION_JOB_COMPLETED` | `migration_import` | — |
 | `migration.job.failed` | `EventType.MIGRATION_JOB_FAILED` | `migration_import` | — |
 | `migration.job.started` | `EventType.MIGRATION_JOB_STARTED` | `migration_import` | — |
-| `notification.delivered` | `EventType.NOTIFICATION_DELIVERED` | — | — |
-| `notification.failed` | `EventType.NOTIFICATION_FAILED` | — | — |
-| `notification.queued` | `EventType.NOTIFICATION_QUEUED` | — | — |
+| `notification.delivered` | `EventType.NOTIFICATION_DELIVERED` | `notifications` | — |
+| `notification.failed` | `EventType.NOTIFICATION_FAILED` | `notifications` | — |
+| `notification.queued` | `EventType.NOTIFICATION_QUEUED` | `notifications` | — |
 | `notification.reply_received` | `EventType.NOTIFICATION_REPLY_RECEIVED` | `notifications` | `patient_timeline` |
-| `notification.sent` | `EventType.NOTIFICATION_SENT` | — | — |
-| `odontogram.condition.changed` | `EventType.ODONTOGRAM_CONDITION_CHANGED` | — | — |
-| `odontogram.surface.updated` | `EventType.ODONTOGRAM_SURFACE_UPDATED` | — | — |
-| `odontogram.tooth.updated` | `EventType.ODONTOGRAM_TOOTH_UPDATED` | — | — |
+| `notification.sent` | `EventType.NOTIFICATION_SENT` | `notifications` | — |
+| `odontogram.condition.changed` | `EventType.ODONTOGRAM_CONDITION_CHANGED` | `odontogram` | — |
+| `odontogram.surface.updated` | `EventType.ODONTOGRAM_SURFACE_UPDATED` | `odontogram` | — |
+| `odontogram.tooth.updated` | `EventType.ODONTOGRAM_TOOTH_UPDATED` | `odontogram` | — |
 | `odontogram.treatment.added` | `EventType.ODONTOGRAM_TREATMENT_ADDED` | `odontogram` | — |
 | `odontogram.treatment.deleted` | `EventType.ODONTOGRAM_TREATMENT_DELETED` | `odontogram` | — |
 | `odontogram.treatment.performed` | `EventType.ODONTOGRAM_TREATMENT_PERFORMED` | `odontogram` | `budget`, `patient_timeline`, `payments`, `periodontogram`, `treatment_plan` |
@@ -125,7 +125,8 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `appointment.cancelled`
 
 - **Constant:** `EventType.APPOINTMENT_CANCELLED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `agenda` — `backend/app/modules/agenda/service.py:704`
 - **Subscribers:**
   - `copilot`
   - `notifications`
@@ -136,14 +137,16 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `appointment.checked_in`
 
 - **Constant:** `EventType.APPOINTMENT_CHECKED_IN`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `agenda` — `backend/app/modules/agenda/service.py:701`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `appointment.completed`
 
 - **Constant:** `EventType.APPOINTMENT_COMPLETED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `agenda` — `backend/app/modules/agenda/service.py:703`
 - **Subscribers:**
   - `patient_timeline`
   - `recalls`
@@ -152,21 +155,24 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `appointment.confirmed`
 
 - **Constant:** `EventType.APPOINTMENT_CONFIRMED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `agenda` — `backend/app/modules/agenda/service.py:700`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `appointment.in_treatment`
 
 - **Constant:** `EventType.APPOINTMENT_IN_TREATMENT`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `agenda` — `backend/app/modules/agenda/service.py:702`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `appointment.no_show`
 
 - **Constant:** `EventType.APPOINTMENT_NO_SHOW`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `agenda` — `backend/app/modules/agenda/service.py:705`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -266,40 +272,46 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `clinical_notes.administrative_created`
 
 - **Constant:** `EventType.CLINICAL_NOTE_ADMINISTRATIVE_CREATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `clinical_notes` — `backend/app/modules/clinical_notes/service.py:81`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `clinical_notes.appointment_administrative_created`
 
 - **Constant:** `EventType.CLINICAL_NOTE_APPOINTMENT_ADMINISTRATIVE_CREATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `clinical_notes` — `backend/app/modules/clinical_notes/service.py:87`
 - **Subscribers:** —
 
 ### `clinical_notes.appointment_clinical_created`
 
 - **Constant:** `EventType.CLINICAL_NOTE_APPOINTMENT_CLINICAL_CREATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `clinical_notes` — `backend/app/modules/clinical_notes/service.py:85`
 - **Subscribers:** —
 
 ### `clinical_notes.diagnosis_created`
 
 - **Constant:** `EventType.CLINICAL_NOTE_DIAGNOSIS_CREATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `clinical_notes` — `backend/app/modules/clinical_notes/service.py:82`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `clinical_notes.plan_created`
 
 - **Constant:** `EventType.CLINICAL_NOTE_PLAN_CREATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `clinical_notes` — `backend/app/modules/clinical_notes/service.py:84`
 - **Subscribers:**
   - `patient_timeline`
 
 ### `clinical_notes.treatment_created`
 
 - **Constant:** `EventType.CLINICAL_NOTE_TREATMENT_CREATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `clinical_notes` — `backend/app/modules/clinical_notes/service.py:83`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -503,19 +515,22 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `notification.delivered`
 
 - **Constant:** `EventType.NOTIFICATION_DELIVERED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `notifications` — `backend/app/modules/notifications/gateway.py:322`
 - **Subscribers:** —
 
 ### `notification.failed`
 
 - **Constant:** `EventType.NOTIFICATION_FAILED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `notifications` — `backend/app/modules/notifications/gateway.py:292`
 - **Subscribers:** —
 
 ### `notification.queued`
 
 - **Constant:** `EventType.NOTIFICATION_QUEUED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `notifications` — `backend/app/modules/notifications/gateway.py:191`
 - **Subscribers:** —
 
 ### `notification.reply_received`
@@ -529,25 +544,29 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 ### `notification.sent`
 
 - **Constant:** `EventType.NOTIFICATION_SENT`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `notifications` — `backend/app/modules/notifications/gateway.py:279`
 - **Subscribers:** —
 
 ### `odontogram.condition.changed`
 
 - **Constant:** `EventType.ODONTOGRAM_CONDITION_CHANGED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `odontogram` — `backend/app/modules/odontogram/service.py:173`
 - **Subscribers:** —
 
 ### `odontogram.surface.updated`
 
 - **Constant:** `EventType.ODONTOGRAM_SURFACE_UPDATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `odontogram` — `backend/app/modules/odontogram/service.py:207`
 - **Subscribers:** —
 
 ### `odontogram.tooth.updated`
 
 - **Constant:** `EventType.ODONTOGRAM_TOOTH_UPDATED`
-- **Publishers:** _none in tree — declared but unused_
+- **Publishers:**
+  - `odontogram` — `backend/app/modules/odontogram/service.py:275`
 - **Subscribers:** —
 
 ### `odontogram.treatment.added`
@@ -606,7 +625,6 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.PATIENT_MEDICAL_UPDATED`
 - **Publishers:**
   - `patients_clinical` — `backend/app/modules/patients_clinical/router.py:94`
-  - `patients_clinical` — `backend/app/modules/patients_clinical/router.py:593`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -711,7 +729,6 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.TREATMENT_PLAN_CLOSED`
 - **Publishers:**
   - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1691`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1829`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -767,13 +784,6 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.TREATMENT_PLAN_STATUS_CHANGED`
 - **Publishers:**
   - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:427`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1169`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1599`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1646`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1704`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1748`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1786`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1842`
 - **Subscribers:** —
 
 ### `treatment_plan.treatment_added`
@@ -789,7 +799,6 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED`
 - **Publishers:**
   - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:87`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:240`
   - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:955`
 - **Subscribers:**
   - `patient_timeline`

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -11,25 +11,25 @@ Maintained by `backend/scripts/generate_catalogs.py`. CI fails if a manifest cha
 | Module | Version | Category | Depends | Install | Removable | Permissions | Emits | Consumes | FE layer |
 |--------|---------|----------|---------|---------|-----------|-------------|-------|----------|----------|
 | `accounting_export` | 0.1.0 | official | billing, payments | manual | yes | 2 | 0 | 0 | yes |
-| `agenda` | 0.4.0 | official | patients, catalog, odontogram | auto | no | 4 | 5 | 0 | yes |
+| `agenda` | 0.4.0 | official | patients, catalog, odontogram | auto | no | 4 | 11 | 0 | yes |
 | `billing` | 0.1.0 | official | patients, catalog, budget, payments | auto | no | 3 | 3 | 1 | yes |
 | `budget` | 0.1.0 | official | patients, catalog, odontogram | auto | no | 5 | 7 | 4 | yes |
 | `catalog` | 0.1.0 | official | — | auto | no | 3 | 0 | 0 | yes |
-| `clinical_notes` | 0.2.0 | official | patients, odontogram, treatment_plan, media, agenda | auto | no | 2 | 0 | 0 | yes |
+| `clinical_notes` | 0.2.0 | official | patients, odontogram, treatment_plan, media, agenda | auto | no | 2 | 6 | 0 | yes |
 | `copilot` | 0.1.0 | official | — | auto | yes | 5 | 3 | 1 | yes |
 | `media` | 0.2.0 | official | patients | auto | no | 4 | 7 | 1 | yes |
 | `migration_import` | 0.1.0 | official | patients, patients_clinical, clinical_notes, agenda, schedules, recalls, catalog, budget, odontogram, treatment_plan, billing, payments, media | manual | yes | 4 | 5 | 0 | yes |
-| `notifications` | 0.1.0 | official | patients, agenda, budget, billing, catalog | auto | no | 8 | 3 | 6 | yes |
-| `odontogram` | 0.3.0 | official | patients, catalog | auto | no | 4 | 4 | 0 | yes |
+| `notifications` | 0.1.0 | official | patients, agenda, budget, billing, catalog | auto | no | 8 | 7 | 6 | yes |
+| `odontogram` | 0.3.0 | official | patients, catalog | auto | no | 4 | 7 | 0 | yes |
 | `patient_timeline` | 0.1.0 | official | patients | auto | no | 1 | 0 | 35 | yes |
 | `patients` | 0.1.0 | official | — | auto | no | 2 | 3 | 0 | yes |
-| `patients_clinical` | 0.1.0 | official | patients | auto | no | 4 | 2 | 0 | yes |
+| `patients_clinical` | 0.1.0 | official | patients | auto | no | 4 | 1 | 0 | yes |
 | `payments` | 0.1.0 | official | patients, budget | auto | no | 4 | 3 | 2 | yes |
 | `periodontogram` | 0.1.0 | official | patients, odontogram | manual | yes | 2 | 1 | 2 | yes |
 | `recalls` | 0.1.0 | official | patients, agenda | auto | yes | 3 | 4 | 5 | yes |
 | `reports` | 0.1.0 | official | patients, agenda, catalog, budget, billing, payments | auto | no | 3 | 0 | 0 | yes |
 | `schedules` | 0.1.0 | official | agenda | auto | yes | 8 | 0 | 3 | yes |
-| `treatment_plan` | 0.1.0 | official | patients, agenda, odontogram, catalog, budget, media | auto | no | 5 | 22 | 5 | yes |
+| `treatment_plan` | 0.1.0 | official | patients, agenda, odontogram, catalog, budget, media | auto | no | 5 | 13 | 5 | yes |
 | `verifactu` | 0.1.0 | official | billing, catalog | manual | yes | 5 | 1 | 1 | yes |
 | `whatsapp_kapso` | 0.1.0 | community | notifications, patients | manual | yes | 2 | 0 | 0 | yes |
 
@@ -70,6 +70,12 @@ Appointments, scheduling, cabinets.
 - **Events emitted:**
   - `agenda.visit_note_updated`
   - `appointment.cabinet_changed`
+  - `appointment.cancelled`
+  - `appointment.checked_in`
+  - `appointment.completed`
+  - `appointment.confirmed`
+  - `appointment.in_treatment`
+  - `appointment.no_show`
   - `appointment.scheduled`
   - `appointment.status_changed`
   - `appointment.updated`
@@ -160,7 +166,13 @@ Polymorphic clinical notes (administrative, diagnosis, treatment, treatment plan
 - **Permissions:**
   - `clinical_notes.notes.read`
   - `clinical_notes.notes.write`
-- **Events emitted:** —
+- **Events emitted:**
+  - `clinical_notes.administrative_created`
+  - `clinical_notes.appointment_administrative_created`
+  - `clinical_notes.appointment_clinical_created`
+  - `clinical_notes.diagnosis_created`
+  - `clinical_notes.plan_created`
+  - `clinical_notes.treatment_created`
 - **Events consumed:** —
 - **Module CLAUDE.md:** [`backend/app/modules/clinical_notes/CLAUDE.md`](../backend/app/modules/clinical_notes/CLAUDE.md)
 
@@ -261,7 +273,11 @@ Email templates, preferences, SMTP, event-driven sending.
 - **Events emitted:**
   - `email.failed`
   - `email.sent`
+  - `notification.delivered`
+  - `notification.failed`
+  - `notification.queued`
   - `notification.reply_received`
+  - `notification.sent`
 - **Events consumed:**
   - `appointment.cancelled`
   - `appointment.scheduled`
@@ -287,6 +303,9 @@ Dental charting, tooth state, clinical treatments.
   - `odontogram.treatments.write`
   - `odontogram.write`
 - **Events emitted:**
+  - `odontogram.condition.changed`
+  - `odontogram.surface.updated`
+  - `odontogram.tooth.updated`
   - `odontogram.treatment.added`
   - `odontogram.treatment.deleted`
   - `odontogram.treatment.performed`

--- a/docs/technical/agenda/events.md
+++ b/docs/technical/agenda/events.md
@@ -1,0 +1,47 @@
+---
+module: agenda
+last_verified_commit: 50cce0f
+---
+
+# Agenda — events
+
+Per-module slice of [`docs/events-catalog.md`](../../events-catalog.md)
+(auto-generated). Update both files when adding or removing events.
+
+## Published
+
+Appointment lifecycle. The specific `appointment.<status>` event is
+dispatched from a status→`EventType` map in
+`AppointmentService.transition_status` (`service.py`), so the publish
+call passes a variable — the catalog resolves it from the constants
+referenced in that file.
+
+| Event | When | Consumers |
+|-------|------|-----------|
+| `appointment.scheduled` | Appointment created | notifications, patient_timeline, recalls, schedules |
+| `appointment.updated` | Appointment fields edited | schedules |
+| `appointment.status_changed` | Any status transition (generic) | — |
+| `appointment.confirmed` | → confirmed | patient_timeline |
+| `appointment.checked_in` | → checked-in | patient_timeline |
+| `appointment.in_treatment` | → in-treatment | patient_timeline |
+| `appointment.completed` | → completed | patient_timeline, recalls, treatment_plan |
+| `appointment.cancelled` | → cancelled | copilot, notifications, patient_timeline, recalls, schedules |
+| `appointment.no_show` | → no-show | patient_timeline |
+| `appointment.cabinet_changed` | Cabinet reassigned | — |
+| `agenda.visit_note_updated` | Visit note / completion flag edited on an appointment-treatment | patient_timeline |
+
+Payloads carry `clinic_id`, `appointment_id`, and (where relevant)
+`patient_id` / `professional_id` / status fields. See the module
+`CLAUDE.md` for the per-event payload contract.
+
+## Subscribed
+
+_This module does not subscribe to any events._
+
+## Adding a new event
+
+1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
+2. Publish from a service method, **after the DB commit succeeds**.
+3. Add the row to the table above.
+4. Run `python backend/scripts/generate_catalogs.py` to refresh the
+   global catalog.

--- a/docs/technical/clinical_notes/events.md
+++ b/docs/technical/clinical_notes/events.md
@@ -1,0 +1,44 @@
+---
+module: clinical_notes
+last_verified_commit: 50cce0f
+---
+
+# Clinical-notes — events
+
+Per-module slice of [`docs/events-catalog.md`](../../events-catalog.md)
+(auto-generated). Update both files when adding or removing events.
+
+## Published
+
+One event per note type. The publish call passes a variable resolved
+from the `_NOTE_TYPE_TO_EVENT` map in `service.py`, so the catalog
+attributes these from the `EventType` constants referenced in that file.
+
+| Event | When | Consumers |
+|-------|------|-----------|
+| `clinical_notes.diagnosis_created` | A diagnosis note is created | patient_timeline |
+| `clinical_notes.treatment_created` | A treatment note is created | patient_timeline |
+| `clinical_notes.plan_created` | A treatment-plan note is created | patient_timeline |
+| `clinical_notes.administrative_created` | An administrative note is created | patient_timeline |
+| `clinical_notes.appointment_clinical_created` | A clinical note captured on an appointment | — |
+| `clinical_notes.appointment_administrative_created` | An administrative note captured on an appointment | — |
+
+> **Known gap (audit event-bus #7):** the two `appointment_*` note
+> events have no subscriber, so notes captured on an appointment do not
+> currently reach the patient timeline. Tracked separately from this
+> docs backfill.
+
+Payloads carry `clinic_id`, `patient_id`, and a `body_excerpt`.
+
+## Subscribed
+
+_This module does not subscribe to any events_ (`get_event_handlers`
+returns `{}`).
+
+## Adding a new event
+
+1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
+2. Publish from a service method, **after the DB commit succeeds**.
+3. Add the row to the table above.
+4. Run `python backend/scripts/generate_catalogs.py` to refresh the
+   global catalog.

--- a/docs/technical/odontogram/events.md
+++ b/docs/technical/odontogram/events.md
@@ -1,0 +1,44 @@
+---
+module: odontogram
+last_verified_commit: 50cce0f
+---
+
+# Odontogram — events
+
+Per-module slice of [`docs/events-catalog.md`](../../events-catalog.md)
+(auto-generated). Update both files when adding or removing events.
+
+## Published
+
+Two groups. The `odontogram.treatment.*` events are published via
+`EventType`; the tooth-state events (`surface`/`tooth`/`condition`) use
+the module-local `OdontogramEventType` class in `service.py` (kept for
+the legacy surface/tooth update path).
+
+| Event | When | Consumers |
+|-------|------|-----------|
+| `odontogram.treatment.performed` | A planned/charted treatment is marked performed | budget, patient_timeline, payments, periodontogram, treatment_plan |
+| `odontogram.treatment.added` | Treatment added to a tooth | — |
+| `odontogram.treatment.status_changed` | Treatment status transition | — |
+| `odontogram.treatment.deleted` | Treatment removed | — |
+| `odontogram.surface.updated` | A tooth surface condition changes | — |
+| `odontogram.tooth.updated` | A whole-tooth condition changes | — |
+| `odontogram.condition.changed` | A tooth condition is (re)assigned | — |
+
+`odontogram.treatment.performed` feeds the payments earned ledger — its
+payload carries the `unit_price`/`price_snapshot` the payments handler
+needs. See the module `CLAUDE.md` for the full payload contract.
+
+## Subscribed
+
+_This module does not subscribe to any events_ (`get_event_handlers`
+returns `{}`; plan→treatment propagation lives in
+`TreatmentPlanService.complete_item`).
+
+## Adding a new event
+
+1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
+2. Publish from a service method, **after the DB commit succeeds**.
+3. Add the row to the table above.
+4. Run `python backend/scripts/generate_catalogs.py` to refresh the
+   global catalog.

--- a/docs/technical/patients_clinical/events.md
+++ b/docs/technical/patients_clinical/events.md
@@ -1,0 +1,32 @@
+---
+module: patients_clinical
+last_verified_commit: 50cce0f
+---
+
+# Patients-clinical — events
+
+Per-module slice of [`docs/events-catalog.md`](../../events-catalog.md)
+(auto-generated). Update both files when adding or removing events.
+
+## Published
+
+| Event | When | Consumers |
+|-------|------|-----------|
+| `patient.medical_updated` | A patient's medical history (allergies, conditions, medications) is created or edited | patient_timeline |
+
+Published from `router.py` after the update commits. Payload carries
+`clinic_id` and `patient_id`. Note the event name is under the
+`patient.*` namespace even though it is emitted by `patients_clinical`,
+not `patients`.
+
+## Subscribed
+
+_This module does not subscribe to any events._
+
+## Adding a new event
+
+1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
+2. Publish from a service method, **after the DB commit succeeds**.
+3. Add the row to the table above.
+4. Run `python backend/scripts/generate_catalogs.py` to refresh the
+   global catalog.


### PR DESCRIPTION
Closes #94. Makes real the CI gates the modular contract claims exist, and fixes the catalog drift they were supposed to prevent (`docs/technical/audit-2026-07-03.md` §S4).

## What was broken

CLAUDE.md: *"Cross-module FKs are allowed only when the target is in `depends`. CI rejects migrations otherwise."* — **no such check existed**, and the import guard skips `migrations/`. Separately, the catalog generator's `PUBLISH_RE` only matched `event_bus.publish(EventType.X)` / string literals, so ~19 live events showed **"publisher: none"** in `events-catalog.md`, and the docs-coverage script had the same bug so the *"events.md required"* rule never fired for enum-based publishers.

## Fixes (3 granular commits)

| Commit | What |
|---|---|
| `bd69287` | **Cross-module-FK CI gate** — `test_module_fk_isolation.py` introspects every model's `ForeignKey`; a target owned by another module must be in the source's `manifest.depends` (core tables exempt). Ratchet allowlist seeded with the one existing violation (`agenda→treatment_plan`), mirroring the tracked import debt. |
| `6bd0510` | **Catalog publisher resolution** — `_scan_publishers` now resolves module-local enums (`OdontogramEventType.X`) and variable dispatch (agenda status map, clinical_notes note-type map, notifications gateway). `appointment.*`, `odontogram.*`, `clinical_notes.*`, `notification.*` are attributed to their real modules; the 13 remaining "no publisher" events are genuinely dead/reserved. `test_catalog_generator` locks it in. |
| `c158ce4` | **events.md backfill + coverage gate** — fix `check_docs_coverage`'s `PUBLISH_RE` (it only captured the literal case), which correctly flags the 4 modules with no `events.md`; backfilled `agenda`, `odontogram`, `patients_clinical`, `clinical_notes` with real docs. |

## Verification

- New/affected tests green: `test_module_fk_isolation`, `test_catalog_generator`, `test_module_isolation`, `test_module_docs`, `test_module_manifests_consistency`, `test_alembic_branches`.
- CI doc gates pass: `catalog-freshness` ✓, `check_docs_coverage --strict` ✓ (0 errors), `docs-layout` ✓.

The FK gate and coverage gate now **fail loudly** on a new cross-module FK or a module that emits events without an `events.md` — which is exactly what #94 asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)