### PR TITLE
fix(frontend): S5 silent-failure fixes, tranche 1 (useApi query + odontogram error state)

### DIFF
--- a/backend/app/modules/odontogram/CHANGELOG.md
+++ b/backend/app/modules/odontogram/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- fix(frontend): render an error state with retry when the odontogram
+  fetch fails, instead of falling through to a fabricated all-healthy
+  32-tooth chart (audit S5, #95). Adds `odontogram.messages.loadError`.
+
 - feat(ux): ``DiagnosisMode`` now publishes a ``treatmentsToothById`` map
   and an ``onTeethHover`` callback through the
   ``odontogram.diagnosis.sidebar`` slot ctx, so the clinical-notes

--- a/backend/app/modules/odontogram/frontend/components/odontogram/OdontogramChart.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/OdontogramChart.vue
@@ -65,6 +65,7 @@ const toast = useToast()
 
 const {
   loading,
+  error,
   fetchOdontogram,
   fetchPatientHistory,
   getToothRecord,
@@ -181,12 +182,16 @@ const pendingTreatment = computed(() => {
 // Lifecycle
 // ============================================================================
 
-onMounted(async () => {
+async function loadAll(patientId: string) {
   await Promise.all([
-    fetchOdontogram(props.patientId),
-    fetchTreatments(props.patientId),
-    fetchTimeline(props.patientId)
+    fetchOdontogram(patientId),
+    fetchTreatments(patientId),
+    fetchTimeline(patientId)
   ])
+}
+
+onMounted(async () => {
+  await loadAll(props.patientId)
   window.addEventListener('keydown', handleKeydown)
 })
 
@@ -707,6 +712,21 @@ defineExpose({
         class="w-8 h-8 animate-spin text-subtle"
       />
     </div>
+
+    <!-- Load error — never fall through to a fabricated healthy mouth. -->
+    <UAlert
+      v-else-if="error"
+      icon="i-lucide-triangle-alert"
+      color="error"
+      variant="subtle"
+      :title="t('odontogram.messages.loadError')"
+      :actions="[{
+        label: t('common.retry'),
+        color: 'error',
+        variant: 'soft',
+        onClick: () => loadAll(props.patientId)
+      }]"
+    />
 
     <!-- Chart -->
     <div

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(frontend): the queue tabs (Pendientes/Rechazadas/Fallos) rendered
+  the same unfiltered list — `listQueue` passed `{ params }`, which
+  `useApi` dropped. Switched to the new `useApi` `query` option so the
+  `?state=` filter is actually sent (audit S5, #95).
+
 - refactor(perms): migrate hardcoded ``can('verifactu.{settings.read, settings.configure, queue.manage, records.read, environment.promote}')`` strings across the settings pages, queue, ``InvoiceVerifactuSlot`` and ``RejectedGlobalBanner`` to the typed ``PERMISSIONS.verifactu.*`` (new entries in the host permissions config).
 - refactor(errors): switch ``catch (e: any)`` to ``catch (e: unknown)`` across ``producer`` / ``queue`` / ``vat-mapping`` / ``certificate`` / settings index / ``InvoiceVerifactuSlot`` and route messages through the shared ``errorMessage`` / ``errorStatus`` helpers.
 - chore(migrations): isolate ``vfy_0001`` from the main upgrade

--- a/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
+++ b/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
@@ -209,7 +209,7 @@ export const useVerifactu = () => {
       return r.data
     },
     async listQueue(state?: string) {
-      const r = await api.get<ApiResponse<VerifactuQueueItem[]>>('/api/v1/verifactu/queue', { params: state ? { state } : undefined })
+      const r = await api.get<ApiResponse<VerifactuQueueItem[]>>('/api/v1/verifactu/queue', { query: state ? { state } : undefined })
       return r.data
     },
     async retryRecord(id: string, opts: { regenerate?: boolean } = {}) {

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -10,9 +10,25 @@ interface UseApiOptions {
   body?: object | null
   headers?: Record<string, string>
   skipAuth?: boolean
+  // Query-string params appended to the path. Undefined/null values are
+  // skipped. Provided because $fetch's own ``query`` was not wired here,
+  // so callers that passed ``{ params: … }`` had it silently dropped
+  // (e.g. the Veri*Factu queue tabs all rendered the same list).
+  query?: Record<string, string | number | boolean | undefined | null>
   // Optional AbortSignal so callers can cancel in-flight requests
   // (debounced lookups, component unmount, etc.).
   signal?: AbortSignal
+}
+
+function _withQuery(path: string, query?: UseApiOptions['query']): string {
+  if (!query) return path
+  const qs = new URLSearchParams()
+  for (const [k, v] of Object.entries(query)) {
+    if (v !== undefined && v !== null) qs.set(k, String(v))
+  }
+  const s = qs.toString()
+  if (!s) return path
+  return path.includes('?') ? `${path}&${s}` : `${path}?${s}`
 }
 
 export function useApi() {
@@ -30,7 +46,7 @@ export function useApi() {
     path: string,
     options: UseApiOptions = {}
   ): Promise<T> {
-    const { skipAuth, method, body, headers: optionHeaders, signal } = options
+    const { skipAuth, method, body, headers: optionHeaders, signal, query } = options
 
     const headers: Record<string, string> = {
       ...(optionHeaders || {})
@@ -41,8 +57,10 @@ export function useApi() {
       headers.Authorization = `Bearer ${auth.accessToken.value}`
     }
 
+    const url = _withQuery(path, query)
+
     try {
-      return await $fetch<T>(path, {
+      return await $fetch<T>(url, {
         baseURL: apiBaseUrl.value,
         timeout: 10000, // 10 seconds
         method,
@@ -67,7 +85,7 @@ export function useApi() {
         if (refreshed) {
           // Retry the request with new token
           headers.Authorization = `Bearer ${auth.accessToken.value}`
-          return await $fetch<T>(path, {
+          return await $fetch<T>(url, {
             baseURL: apiBaseUrl.value,
             method,
             body,

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -461,7 +461,8 @@
     },
     "messages": {
       "updated": "Dental chart updated",
-      "error": "Error updating dental chart"
+      "error": "Error updating dental chart",
+      "loadError": "Couldn't load the dental chart"
     },
     "actions": {
       "save": "Save",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -489,7 +489,8 @@
     },
     "messages": {
       "updated": "Odontograma actualizado",
-      "error": "Error al actualizar odontograma"
+      "error": "Error al actualizar odontograma",
+      "loadError": "No se pudo cargar el odontograma"
     },
     "actions": {
       "save": "Guardar",


### PR DESCRIPTION
First tranche of S5 (#95) — the two highest-impact, lowest-risk silent-failure bugs. Scoped tight and verifiable; the broader posture sweep continues in a follow-up.

## Fixes

| Commit | What |
|---|---|
| `94dfda5` | **useApi dropped query params.** `useApi` never read a `query`/`params` option, so callers passing `{ params: … }` had it silently dropped — the Veri*Factu queue tabs (Pendientes/Rechazadas/Fallos) all sent the same unfiltered request and rendered identical lists. Added a `query` option (skips null/undefined, preserved across the 401-refresh retry); switched `listQueue` to it. |
| `9a493ea` | **Odontogram fabricated a healthy mouth on load failure.** When the fetch failed the composable set `error` but the chart fell through and rendered every tooth as `healthy` — a clinically wrong, plausible chart. Now renders a `UAlert` + retry when `error` is set (matching the periodontogram view), never painting teeth from absent data. Adds `odontogram.messages.loadError` (EN+ES). |

## Verification

- `useApi.ts` (host) passes eslint.
- The odontogram `.vue` follows the existing `PeriodontogramView` error-state pattern and the `settings/modules` `:actions` retry pattern; module-layer files aren't covered by CI lint/typecheck (empty `modules.json`), so this was verified by matching established patterns, not a typecheck.
- i18n keys added to **both** locales; JSON validated, trailing newline preserved.

## Not in this tranche (follow-up)

Tracked for a next PR: `useApi` 4xx toast-or-rethrow contract (surface backend `detail` on 400/422), the remaining false-empty reads (blank calendar = free week; reports 0 € on error), clinical-note / treatment-surface text preserved on failed save, and confirmation dialogs on one-click destructive actions. These need per-caller review and are best done as their own reviewed batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)