### PR TITLE
docs: add Telegram community channel to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Vendor-agnostic under the hood (an LLM-provider abstraction), with provider, mod
 
 Visit [**dentalpin.com**](https://www.dentalpin.com) for product info, features, and commercial details.
 
+## Community
+
+Join our [**Telegram channel**](https://t.me/dentalpin) for support, installation help, and questions.
+
 ## Screenshots
 
 ### AI Copilot


### PR DESCRIPTION
Adds the new Telegram channel (https://t.me/dentalpin) under a **Community** section in the README, right after **Website**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)