### PR TITLE
feat(i18n): add French translation

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,272 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+
+Software open source de gestión de clínicas dentales. Construido con arquitectura modular para la extensibilidad.
+
+## ¿Por qué DentalPin?
+
+Las clínicas dentales de todo el mundo comparten las mismas necesidades fundamentales: gestionar pacientes, programar citas, hacer seguimiento de tratamientos y dirigir su práctica de manera eficiente. Sin embargo, el panorama del software está fragmentado en docenas de soluciones localizadas y de código cerrado que encierran a las clínicas en contratos costosos y tecnología obsoleta.
+
+**Creemos que es hora de cambiar.**
+
+DentalPin se construye sobre una premisa simple: **una plataforma abierta para clínicas dentales en todas partes**. No otra solución regional, sino una base global que cualquier clínica pueda adoptar, cualquier desarrollador pueda extender y cualquier comunidad pueda localizar.
+
+### ¿Por qué ahora?
+
+La IA ha cambiado fundamentalmente lo que los equipos pequeños pueden construir. Funcionalidades que antes requerían grandes departamentos de desarrollo ahora pueden implementarse en días. Esta es nuestra ventana para crear el software dental de código cerrado que debería haber existido hace años — antes de que las clínicas quedaran encerradas en sistemas legacy de los que no pueden escapar.
+
+### Nuestros principios
+
+- **Código Abierto** — Los datos de su clínica le pertenecen. Su software también.
+- **Modular** — Comience simple, añada lo que necesite. No pague por funcionalidades que nunca usará.
+- **Global por Diseño** — Construido para la localización desde el primer día. Mismo núcleo, cualquier idioma, cualquier país.
+- **API-Primero** — Cada funcionalidad es una API. Integre con todo, automatice todo.
+- **Preparado para IA** — Estructurado para la era de la IA. Listo para programación inteligente, apoyo a la decisión clínica y automatización de flujos de trabajo.
+
+### La visión
+
+No solo estamos construyendo software — estamos construyendo la base de un ecosistema. Una plataforma donde los desarrolladores contribuyen módulos, las clínicas comparten mejoras y toda la comunidad dental se beneficia de la innovación colectiva.
+
+Las clínicas merecen algo mejor que software cerrado y costoso de la década pasada. DentalPin es la alternativa abierta.
+
+## ✨ Copiloto IA
+
+DentalPin incluye un **asistente IA agentic integrado** que convierte toda la clínica en algo con lo que simplemente puede conversar. Pídale encontrar un paciente, liberar un espacio, perseguir un presupuesto sin respuesta, o informarle sobre el día por delante — en español o inglés — y actúa sobre sus datos reales.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+Esto no es un chatbot añadido a posteriori. El Copiloto es un agente real que **planifica y ejecuta tareas multi-paso** llamando a las mismas operaciones que la interfaz de usuario, a través de pacientes, agenda, recordatorios, presupuestos, pagos y reportes.
+
+- **Hace, no solo responde.** El agente ejecuta herramientas reales — buscar pacientes, reservar o reprogramar citas, registrar un pago, extraer los cobros del mes — y las encadena para completar una tarea de principio a fin.
+- **Nunca excede su rol.** Cada llamada a herramienta se re-verifica contra los permisos RBAC del usuario que llama en el punto de control de ejecución. El Copiloto puede ver y hacer *exactamente* lo que ese usuario podría hacer a través de la interfaz — nada más, limitado a su clínica.
+- **Sus datos están protegidos.** Los datos de salud se enmascaran antes de enviarlos al proveedor LLM: nombres, teléfonos, correos electrónicos e identificadores se reemplazan por tokens deterministas, y las herramientas clínicas de texto libre se excluyen del camino cloud. El enmascaramiento está activado por defecto.
+- **Las escrituras preguntan primero.** Cualquier acción que modifique datos (reservas, pagos, ediciones) hace una pausa en medio de la conversación para su confirmación explícita antes de ejecutarse.
+- **Flujos de trabajo guiados.** Playbooks listos para usar — *Resumen matinal*, *Preparar una consulta*, *Llenar un espacio*, *Recordatorios pendientes*, *Presupuestos sin respuesta* — inician tareas multi-paso comunes con un solo clic.
+- **Briefings proactivos.** Elija recibir un resumen matinal determinista enviado por correo electrónico a su equipo, resumiendo el agenda del día, recordatorios pendientes y presupuestos abiertos — sin LLM, sin datos de salud fuera del sitio.
+- **Modular por diseño.** El Copiloto consume herramientas publicadas por cada módulo a través de un registro compartido; cada módulo contribuye sus propias capacidades, por lo que el agente crece automáticamente a medida que se instalan nuevos módulos.
+
+Agnóstico al proveedor en las capas internas (abstracción del proveedor LLM), con proveedor, modelo y presupuestos de tokens por clínica configurables por despliegue. Arquitectura: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Sitio web
+
+Visite [**dentalpin.com**](https://www.dentalpin.com) para información del producto, características y detalles comerciales.
+
+## Comunidad
+
+Únase a nuestro [**canal de Telegram**](https://t.me/dentalpin) para soporte, ayuda con la instalación y preguntas.
+
+## Capturas de pantalla
+
+### Copilot IA
+![AI Copilot](docs/screenshots/ia.png)
+
+### Panel de control
+![Dashboard](docs/screenshots/home.png)
+
+### Gestión de pacientes
+![Patients](docs/screenshots/patients.png)
+
+### Agenda semanal
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Planificación Kanban
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Gráfico de pagos
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Configuración
+![Settings](docs/screenshots/settings.png)
+
+## Inicio rápido
+
+```bash
+# Iniciar servicios
+docker-compose up -d
+
+# Sembrar datos de demostración (inglés por defecto)
+./scripts/seed-demo.sh
+
+# O sembrar en español
+./scripts/seed-demo.sh --lang es
+
+# O sembrar en francés
+./scripts/seed-demo.sh --lang fr
+```
+
+Abrir http://localhost:3000
+
+### Credenciales de demostración
+
+Todos los usuarios tienen contraseña: `demo1234`
+
+| Email | Rol | Nombre (EN) | Nombre (ES) |
+|-------|-----|-------------|-------------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
+
+Consulte [docs/user-manual/demo.md](docs/user-manual/demo.md) para detalles completos sobre los datos de demostración.
+
+## Stack tecnológico
+
+| Capa | Tecnología |
+|------|-----------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Base de datos | PostgreSQL 15 |
+| Autenticación | JWT con refresh tokens |
+
+## Características
+
+### Copilot IA
+- **Asistente agentic** — Agente conversacional que planifica y ejecuta tareas multi-paso a través de pacientes, agenda, recordatorios, presupuestos, pagos y reportes llamando a operaciones reales
+- **Paridad RBAC** — Cada acción re-verificada contra los permisos del usuario; el agente solo puede hacer lo que ese usuario podría hacer a través de la interfaz, limitado a su clínica
+- **Enmascaramiento de datos de salud** — Identificadores de pacientes tokenizados antes de llegar al LLM; los datos clínicos de texto libre permanecen fuera del camino cloud. Activado por defecto
+- **Escrituras confirmadas** — Las acciones que modifican datos hacen una pausa para confirmación explícita del usuario en medio de la conversación
+- **Flujos de trabajo y resumen** — Playbooks con un clic (resumen matinal, preparar una consulta, llenar un espacio) más un resumen matinal por correo electrónico proactivo opcional
+- **Bilingüe y agnóstico al proveedor** — Funciona en español, francés e inglés; proveedor LLM, modelo y presupuesto de tokens por clínica configurables
+
+### Gestión clínica
+- **Historiales de pacientes** — Perfiles completos con datos personales, información de contacto, historial médico y notas
+- **Carta dental (Odontograma)** — Diagrama dentario interactivo con seguimiento de tratamientos por diente/superficie
+- **Calendario de citas** — Vistas semanal y diaria con arrastrar y soltar, columnas profesionales, detección de conflictos
+- **Catálogo de tratamientos** — Catálogo personalizable con códigos, precios, tipos de IVA y categorías
+
+### Gestión financiera
+- **Presupuestos** — Creación de presupuestos de tratamiento, seguimiento del flujo de aprobación (borrador → pendiente → aprobado/rechazado), captura de firma del paciente, generación de PDF
+- **Facturas** — Generación de facturas a partir de presupuestos o de manera independiente, numeración automática, múltiples métodos de pago, exportación PDF
+- **Pagos** — Seguimiento de pagos parciales, historial de pagos, cálculo de saldo
+
+### Gestión de la práctica
+- **Control de acceso basado en roles** — Cinco roles (admin, dentista, higienista, asistente, recepcionista) con permisos granulares
+- **Gabinete/Sala de tratamiento** — Definición de salas de tratamiento con horarios y colores
+- **Gestión de profesionales** — Asignación de citas a dentistas/higienistas específicos
+
+### Experiencia de usuario
+- **Selectores visuales** — Menús desplegables inteligentes mostrando pacientes recientes y tratamientos populares
+- **Interfaz bilingüe** — Localización completa en español, francés e inglés
+- **Modo oscuro** — Cambio de tema adaptado al sistema
+- **Diseño responsive** — Funciona en escritorio y tableta
+
+### Características técnicas
+- **Arquitectura modular** — Sistema basado en plugins para una facilidad de extensión
+- **Bus de eventos** — Comunicación entre módulos para notificaciones e integraciones
+- **API REST** — API completa con documentación OpenAPI
+- **Actualizaciones en tiempo real** — Interfaz reactiva con actualizaciones optimistas
+
+## Desarrollo
+
+### Prerrequisitos
+
+- Docker y Docker Compose
+- Python 3.11+ (para desarrollo local del backend)
+- Node.js 18+ (para desarrollo local del frontend)
+
+### Ejecución local
+
+```bash
+# Iniciar todos los servicios
+docker-compose up
+
+# O ejecutar el backend por separado
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# O ejecutar el frontend por separado
+cd frontend
+npm install
+npm run dev
+```
+
+### Gestión de la base de datos
+
+```bash
+# Resetear la base de datos y ejecutar migraciones
+./scripts/reset-db.sh
+
+# Sembrar datos de demostración (inglés - por defecto)
+./scripts/seed-demo.sh
+
+# Sembrar datos de demostración (español)
+./scripts/seed-demo.sh --lang es
+
+# Sembrar datos de demostración (francés)
+./scripts/seed-demo.sh --lang fr
+
+# Configuración completa (reset + siembra en un solo comando)
+./scripts/setup-demo.sh
+```
+
+### Ejecución de pruebas
+
+```bash
+# Unitarias + integración del backend (en Docker)
+docker-compose exec backend python -m pytest -v
+
+# Round-trip Alembic lento (opcional, ver docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Unitarias del frontend (vitest)
+cd frontend
+npm run test
+```
+
+**E2E en navegador (Playwright)** se encuentra en `frontend/tests/e2e/` y dirige
+la pila completa en `localhost:3000` → `:8000`. Se ejecuta en el host porque
+el contenedor frontend Alpine no puede lanzar Chromium.
+
+```bash
+# Configuración inicial
+(cd frontend && npm install && npx playwright install chromium)
+
+# Asegúrese de que la pila esté arriba y con datos primero
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Suite E2E completa (nav + RBAC + smoke test de detalle de paciente)
+./scripts/e2e.sh
+
+# Un solo archivo
+./scripts/e2e.sh rbac
+
+# Interfaz interactiva
+./scripts/e2e.sh --ui
+```
+
+Runbook completo + referencia de fixtures: [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Arquitectura
+
+DentalPin utiliza una arquitectura modular tipo plugin. Cada funcionalidad es un módulo autónomo que:
+- Declara sus modelos SQLAlchemy
+- Proporciona un router FastAPI
+- Puede suscribirse a eventos de otros módulos
+
+Consulte [docs/architecture.md](docs/architecture.md) para más detalles.
+
+## Licencia
+
+Business Source License 1.1 (BSL 1.1)
+
+**Limitación de uso:** No puede ofrecer DentalPin como un SaaS comercial para la gestión de clínicas dentales.
+
+**Fecha de cambio:** 4 años desde el lanzamiento
+
+**Licencia de cambio:** Apache 2.0
+
+Consulte [LICENSE](LICENSE) para los términos completos.
+
+## Contribuir
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para las directrices.
+
+---
+
+Respaldado por [Dentaltix](https://www.dentaltix.com)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,272 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+
+Logiciel open source de gestion de cliniques dentaires. Conçu avec une architecture modulaire pour l'extensibilité.
+
+## Pourquoi DentalPin ?
+
+Les cliniques dentaires du monde entier partagent les mêmes besoins fondamentaux : gérer les patients, planifier les rendez-vous, suivre les traitements et exploiter leur pratique efficacement. Pourtant, le paysage logiciel est fragmenté en dizaines de solutions localisées et propriétaires qui enferment les cliniques dans des contrats coûteux et des technologies obsolètes.
+
+**Nous croyons qu'il est temps d'agir.**
+
+DentalPin repose sur un principe simple : **une plateforme ouverte pour les cliniques dentaires partout**. Pas une autre solution régionale, mais une base mondiale que toute clinique peut adopter, que tout développeur peut étendre, et que toute communauté peut localiser.
+
+### Pourquoi maintenant ?
+
+L'IA a fondamentalement changé ce que les petites équipes peuvent construire. Des fonctionnalités qui nécessitaient autrefois de grands départements de développement peuvent désormais être implémentées en quelques jours. C'est notre fenêtre pour créer le logiciel dentaire open source qui aurait dû exister il y a des années — avant que les cliniques ne soient enfermées dans des systèmes hérités dont elles ne peuvent plus s'extraire.
+
+### Nos principes
+
+- **Open Source** — Les données de votre clinique vous appartiennent. Votre logiciel aussi.
+- **Modulaire** — Commencez simplement, ajoutez ce dont vous avez besoin. Ne payez pas pour des fonctionnalités que vous n'utiliserez jamais.
+- **Global dès la conception** — Conçu pour la localisation dès le premier jour. Même cœur, n'importe quelle langue, n'importe quel pays.
+- **API-First** — Chaque fonctionnalité est une API. Intégrez tout, automatisez tout.
+- **Prêt pour l'IA** — Structuré pour l'ère de l'IA. Prêt pour la planification intelligente, l'aide à la décision clinique et l'automatisation des flux de travail.
+
+### La vision
+
+Nous ne construisons pas seulement un logiciel — nous posons les fondations d'un écosystème. Une plateforme où les développeurs contribuent des modules, les cliniques partagent des améliorations, et toute la communauté dentaire bénéficie de l'innovation collective.
+
+Les cliniques méritent mieux que des logiciels propriétaires et coûteux de la décennie précédente. DentalPin est l'alternative ouverte.
+
+## ✨ Copilot IA
+
+DentalPin est livré avec un **assistant IA agentic intégré** qui transforme toute la clinique en quelque chose avec quoi vous pouvez simplement discuter. Demandez-lui de trouver un patient, libérer un créneau, relancer un devis sans réponse, ou vous faire un briefing de la journée — en français, espagnol ou anglais — et il agit sur vos données réelles.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+Ce n'est pas un chatbot ajouté en catastrophe. Le Copilot est un véritable agent qui **planifie et exécute des tâches multi-étapes** en appelant les mêmes opérations que l'interface utilisateur, à travers les patients, l'agenda, les rappels, les devis, les paiements et les rapports.
+
+- **Il agit, pas seulement il répond.** L'agent exécute de vrais outils — rechercher des patients, réserver ou déplacer des rendez-vous, enregistrer un paiement, extraire les encaissements du mois — et les enchaîne pour achever une tâche de bout en bout.
+- **Il ne dépasse jamais votre rôle.** Chaque appel d'outil est re-vérifié par rapport aux permissions RBAC de l'utilisateur appelant au point de contrôle d'exécution. Le Copilot peut voir et faire *exactement* ce que cet utilisateur pourrait faire via l'interface — rien de plus, limité à sa clinique.
+- **Vos données sont protégées.** Les données de santé sont masquées avant tout envoi vers le fournisseur LLM : noms, téléphones, e-mails et identifiants sont remplacés par des jetons déterministes, et les outils cliniques en texte libre sont exclus du chemin cloud. Le masquage est activé par défaut.
+- **Les écritures demandent d'abord.** Toute action modifiant des données (réservation, paiements, modifications) fait une pause en milieu de conversation pour votre confirmation explicite avant de s'exécuter.
+- **Flux de travail guidés.** Des playbooks prêts à l'emploi — *Briefing matinal*, *Préparer une consultation*, *Remplir un créneau*, *Rappels dus*, *Devis sans réponse* — lancent des tâches multi-étapes courantes en un tap.
+- **Briefings proactifs.** Optez pour un digest matinal déterministe envoyé par e-mail à votre équipe, résumant l'agenda du jour, les rappels dus et les devis en attente — sans LLM, sans données de santé hors site.
+- **Modulaire par design.** Le Copilot consomme des outils publiés par chaque module via un registre partagé ; chaque module contribue ses propres capacités, donc l'agent croît automatiquement à mesure que de nouveaux modules sont installés.
+
+Agnostique au fournisseur en couche interne (abstraction du fournisseur LLM), avec modèle, fournisseur et budgets de jetons par clinique configurables par déploiement. Architecture : [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Site web
+
+Rendez-vous sur [**dentalpin.com**](https://www.dentalpin.com) pour des informations produit, des fonctionnalités et des détails commerciaux.
+
+## Communauté
+
+Rejoignez notre [**chaîne Telegram**](https://t.me/dentalpin) pour du support, de l'aide à l'installation et des questions.
+
+## Captures d'écran
+
+### Copilot IA
+![AI Copilot](docs/screenshots/ia.png)
+
+### Tableau de bord
+![Dashboard](docs/screenshots/home.png)
+
+### Gestion des patients
+![Patients](docs/screenshots/patients.png)
+
+### Agenda hebdomadaire
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Planning Kanban
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Graphique des paiements
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Paramètres
+![Settings](docs/screenshots/settings.png)
+
+## Démarrage rapide
+
+```bash
+# Démarrer les services
+docker-compose up -d
+
+# Peupler les données démo (anglais par défaut)
+./scripts/seed-demo.sh
+
+# Ou en espagnol
+./scripts/seed-demo.sh --lang es
+
+# Ou en français
+./scripts/seed-demo.sh --lang fr
+```
+
+Ouvrir http://localhost:3000
+
+### Identifiants de démo
+
+Tous les utilisateurs ont le mot de passe : `demo1234`
+
+| Email | Rôle | Nom (EN) | Nom (ES) | Nom (FR) |
+|-------|------|----------|----------|----------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López | Dr. Marie Dubois |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez | Thomas Moreau |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz | Camille Petit |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez | Julie Bernard |
+
+Voir [docs/user-manual/demo.md](docs/user-manual/demo.md) pour les détails complets sur les données démo.
+
+## Stack technique
+
+| Couche | Technologie |
+|--------|-------------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Base de données | PostgreSQL 15 |
+| Authentification | JWT avec refresh tokens |
+
+## Fonctionnalités
+
+### Copilot IA
+- **Assistant agentic** — Agent conversationnel qui planifie et exécute des tâches multi-étapes à travers les patients, l'agenda, les rappels, les devis, les paiements et les rapports en appelant de vraies opérations
+- **Parité RBAC** — Chaque action re-vérifiée par rapport aux permissions de l'utilisateur ; l'agent ne peut faire que ce que cet utilisateur pourrait faire via l'interface, limité à sa clinique
+- **Masquage des données de santé** — Identifiants des patients tokenisés avant d'atteindre le LLM ; les données cliniques en texte libre restent hors du chemin cloud. Activé par défaut
+- **Écritures confirmées** — Les actions modifiant des données font une pause pour confirmation explicite de l'utilisateur en milieu de conversation
+- **Flux de travail et digest** — Playbooks en un tap (briefing matinal, préparer une consultation, remplir un créneau) plus un digest matinal par e-mail proactif optionnel
+- **Bilingue et agnostique au fournisseur** — Fonctionne en français, espagnol et anglais ; fournisseur LLM, modèle et budget de jetons par clinique configurables
+
+### Gestion clinique
+- **Dossiers patients** — Profils complets avec données personnelles, coordonnées, antécédents médicaux et notes
+- **Carte dentaire (Odontogramme)** — Diagramme dentaire interactif avec suivi des traitements par dent/surface
+- **Calendrier des rendez-vous** — Vues hebdomadaire et journalière avec glisser-déposer, colonnes professionnelles, détection de conflits
+- **Catalogue de traitements** — Catalogue personnalisable avec codes, prix, types de TVA et catégories
+
+### Gestion financière
+- **Devis** — Création de devis de traitement, suivi du workflow d'approbation (brouillon → en attente → approuvé/rejeté), capture de signature patient, génération PDF
+- **Factures** — Génération de factures à partir de devis ou de manière autonome, numérotation automatique, modes de paiement multiples, export PDF
+- **Paiements** — Suivi des paiements partiels, historique des paiements, calcul du solde
+
+### Gestion de la pratique
+- **Contrôle d'accès basé sur les rôles** — Cinq rôles (admin, dentiste, hygiéniste, assistant, réceptionniste) avec permissions granulaires
+- **Gestion des cabinets/cabinets** — Définition des salles de traitement avec emplois du temps et couleurs
+- **Gestion des professionnels** — Attribution des rendez-vous à des dentistes/hygénistes spécifiques
+
+### Expérience utilisateur
+- **Sélecteurs visuels** — Menus déroulants intelligents affichant les patients récents et les traitements populaires
+- **Interface bilingue** — Localisation complète en français, espagnol et anglais
+- **Mode sombre** — Basculement de thème adapté au système
+- **Design réactif** — Fonctionne sur ordinateur et tablette
+
+### Fonctionnalités techniques
+- **Architecture modulaire** — Système basé sur des plugins pour une extensibilité facile
+- **Bus d'événements** — Communication inter-modules pour les notifications et intégrations
+- **API REST** — API complète avec documentation OpenAPI
+- **Mises à jour en temps réel** — Interface réactive avec mises à jour optimistes
+
+## Développement
+
+### Prérequis
+
+- Docker et Docker Compose
+- Python 3.11+ (pour le développement local du backend)
+- Node.js 18+ (pour le développement local du frontend)
+
+### Exécution locale
+
+```bash
+# Démarrer tous les services
+docker-compose up
+
+# Ou exécuter le backend séparément
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Ou exécuter le frontend séparément
+cd frontend
+npm install
+npm run dev
+```
+
+### Gestion de la base de données
+
+```bash
+# Réinitialiser la base et appliquer les migrations
+./scripts/reset-db.sh
+
+# Peupler les données démo (anglais - par défaut)
+./scripts/seed-demo.sh
+
+# Peupler les données démo (espagnol)
+./scripts/seed-demo.sh --lang es
+
+# Peupler les données démo (français)
+./scripts/seed-demo.sh --lang fr
+
+# Configuration complète (réinitialisation + peuplement en une commande)
+./scripts/setup-demo.sh
+```
+
+### Exécution des tests
+
+```bash
+# Tests unitaires + intégration backend (dans Docker)
+docker-compose exec backend python -m pytest -v
+
+# Round-trip Alembic lent (optionnel, voir docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Tests unitaires frontend (vitest)
+cd frontend
+npm run test
+```
+
+**E2E navigateur (Playwright)** se trouve dans `frontend/tests/e2e/` et pilote
+la pile complète sur `localhost:3000` → `:8000`. S'exécute sur l'hôte car
+le conteneur frontend Alpine ne peut pas lancer Chromium.
+
+```bash
+# Configuration initiale
+(cd frontend && npm install && npx playwright install chromium)
+
+# Assurez-vous que la pile est démarrée et peuplée d'abord
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Suite E2E complète (nav + RBAC + smoke test détail patient)
+./scripts/e2e.sh
+
+# Un seul fichier
+./scripts/e2e.sh rbac
+
+# Interface interactive
+./scripts/e2e.sh --ui
+```
+
+Runbook complet + référence des fixtures : [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Architecture
+
+DentalPin utilise une architecture modulaire de type plugin. Chaque fonctionnalité est un module autonome qui :
+- Déclare ses modèles SQLAlchemy
+- Fournit un routeur FastAPI
+- Peut s'abonner aux événements d'autres modules
+
+Voir [docs/architecture.md](docs/architecture.md) pour les détails.
+
+## Licence
+
+Business Source License 1.1 (BSL 1.1)
+
+**Limitation d'utilisation :** Vous ne pouvez pas proposer DentalPin en tant que SaaS commercial pour la gestion de cliniques dentaires.
+
+**Date de conversion :** 4 ans après la publication
+
+**Licence de conversion :** Apache 2.0
+
+Voir [LICENSE](LICENSE) pour les conditions complètes.
+
+## Contribuer
+
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour les directives.
+
+---
+
+Porté par [Dentaltix](https://www.dentaltix.com)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DentalPin
 
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+
 Open source dental clinic management software. Built with modular architecture for extensibility.
 
 ## Why DentalPin?

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -729,7 +729,7 @@ async def update_budget_settings(
 
 
 class _CommunicationsSettingsPatch(BaseModel):
-    language: str | None = Field(default=None, pattern="^(es|en)$")
+    language: str | None = Field(default=None, pattern="^(es|en|fr)$")
 
 
 class _CommunicationsSettingsResponse(BaseModel):

--- a/backend/app/modules/accounting_export/CHANGELOG.md
+++ b/backend/app/modules/accounting_export/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - Initial release. Optional, removable, model-free module that exports
   billing data for the accountant (*gestoría*) — issue #73.
 - Endpoints `GET /preview` (counts + totals + sample) and `GET /run`

--- a/backend/app/modules/accounting_export/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/accounting_export/frontend/i18n/locales/fr.json
@@ -1,0 +1,40 @@
+{
+  "nav": {
+    "accountingExport": "Export comptable"
+  },
+  "accountingExport": {
+    "title": "Export comptable",
+    "subtitle": "Téléchargez les factures et paiements de la période pour les transmettre à votre comptable.",
+    "period": "Période",
+    "from": "Du",
+    "to": "Au",
+    "presets": {
+      "currentMonth": "Mois en cours",
+      "previousMonth": "Mois précédent",
+      "currentQuarter": "Trimestre en cours",
+      "previousQuarter": "Trimestre précédent",
+      "yearToDate": "Année en cours",
+      "custom": "Personnalisé"
+    },
+    "actions": {
+      "preview": "Aperçu",
+      "download": "Télécharger (.zip)"
+    },
+    "counters": {
+      "invoices": "Factures",
+      "payments": "Paiements",
+      "base": "Base",
+      "total": "Total"
+    },
+    "cols": {
+      "numero": "Numéro",
+      "fecha_emision": "Date",
+      "cliente": "Client",
+      "nif": "Numéro fiscal",
+      "base": "Base",
+      "cuota_iva": "TVA",
+      "total": "Total",
+      "estado": "Statut"
+    }
+  }
+}

--- a/backend/app/modules/accounting_export/frontend/nuxt.config.ts
+++ b/backend/app/modules/accounting_export/frontend/nuxt.config.ts
@@ -3,7 +3,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: add `fr` fallback to invoice description resolution in
+  service layer so French-localized treatment names appear on invoices.
+
 - fix(security): lock the invoice row `FOR UPDATE` on the payment and
   issue endpoints (audit S3/C2 + C4, #97). Two concurrent payments could
   both read the full `balance_due` and over-collect past the total; two

--- a/backend/app/modules/billing/service.py
+++ b/backend/app/modules/billing/service.py
@@ -1081,7 +1081,7 @@ class InvoiceService:
             internal_code = None
             if budget_item.catalog_item:
                 names = budget_item.catalog_item.names or {}
-                description = names.get("es") or names.get("en") or description
+                description = names.get("es") or names.get("en") or names.get("fr") or description
                 internal_code = budget_item.catalog_item.internal_code
 
             # Create invoice item

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- i18n: add French translations to seed data (Moroccan VAT rates).
+- i18n: add French names/descriptions to seed data (categories,
+  treatment items, session labels, VAT type names).
 
 - feat(tools): expose `list_catalog_items` + `get_catalog_item` READ
   agent tools (wrap `CatalogService`) so the copilot can read the

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French translations to seed data (Moroccan VAT rates).
+
 - feat(tools): expose `list_catalog_items` + `get_catalog_item` READ
   agent tools (wrap `CatalogService`) so the copilot can read the
   treatment catalog — name, code, category, price, duration, scope.

--- a/backend/app/modules/catalog/frontend/composables/useTreatmentCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useTreatmentCatalog.ts
@@ -18,6 +18,7 @@ import {
 
 export function useTreatmentCatalog() {
   const api = useApi()
+  const { locale } = useLocale()
 
   // State
   const treatments = useState<OdontogramTreatment[]>('treatmentCatalog:treatments', () => [])
@@ -96,7 +97,7 @@ export function useTreatmentCatalog() {
         },
         clinical_category: category.key,
         category_key: category.key,
-        category_names: { es: category.labelKey, en: category.labelKey }
+        category_names: { es: category.labelKey, en: category.labelKey, fr: category.labelKey }
       }))
     }
     return grouped
@@ -162,7 +163,7 @@ export function useTreatmentCatalog() {
         },
         clinical_category: categoryKey,
         category_key: categoryKey,
-        category_names: { es: constantCategory.labelKey, en: constantCategory.labelKey }
+        category_names: { es: constantCategory.labelKey, en: constantCategory.labelKey, fr: constantCategory.labelKey }
       }))
     }
 
@@ -199,7 +200,7 @@ export function useTreatmentCatalog() {
           },
           clinical_category: category.key,
           category_key: category.key,
-          category_names: { es: category.labelKey, en: category.labelKey }
+          category_names: { es: category.labelKey, en: category.labelKey, fr: category.labelKey }
         }
       }
     }
@@ -226,11 +227,12 @@ export function useTreatmentCatalog() {
    */
   function getTreatmentName(
     treatmentType: string,
-    locale = 'es'
+    overrideLocale?: string
   ): string {
+    const loc = overrideLocale || locale.value
     const treatment = getTreatmentByType(treatmentType)
     if (treatment) {
-      return treatment.names[locale] || treatment.names.es || treatmentType
+      return treatment.names[loc] || treatment.names.es || treatment.names.en || treatmentType
     }
     return treatmentType
   }
@@ -277,11 +279,12 @@ export function useTreatmentCatalog() {
     return layers
   }
 
-  function getCategoryLabel(categoryKey: string, locale = 'es'): string {
+  function getCategoryLabel(categoryKey: string, overrideLocale?: string): string {
+    const loc = overrideLocale || locale.value
     if (useCatalog.value) {
       const treatments = treatmentsByCategory.value[categoryKey]
       if (treatments && treatments.length > 0) {
-        return treatments[0].category_names[locale] || categoryKey
+        return treatments[0].category_names[loc] || treatments[0].category_names.es || treatments[0].category_names.en || categoryKey
       }
     }
 

--- a/backend/app/modules/catalog/seed.py
+++ b/backend/app/modules/catalog/seed.py
@@ -38,19 +38,19 @@ from .models import (
 VAT_TYPES: list[dict[str, Any]] = [
     {
         "key": "exempt",
-        "names": {"es": "Exento", "en": "Exempt"},
+        "names": {"es": "Exento", "en": "Exempt", "fr": "Exonéré"},
         "rate": 0.0,
         "is_default": True,
     },
     {
         "key": "reduced",
-        "names": {"es": "Reducido (10%)", "en": "Reduced (10%)"},
+        "names": {"es": "Reducido (10%)", "en": "Reduced (10%)", "fr": "Réduit (10%)"},
         "rate": 10.0,
         "is_default": False,
     },
     {
         "key": "standard",
-        "names": {"es": "General (21%)", "en": "Standard (21%)"},
+        "names": {"es": "General (21%)", "en": "Standard (21%)", "fr": "Général (21%)"},
         "rate": 21.0,
         "is_default": False,
     },
@@ -63,100 +63,110 @@ VAT_TYPES: list[dict[str, Any]] = [
 CATEGORIES: list[dict[str, Any]] = [
     {
         "key": "diagnostico",
-        "names": {"es": "Diagnóstico", "en": "Diagnostic"},
+        "names": {"es": "Diagnóstico", "en": "Diagnostic", "fr": "Diagnostique"},
         "descriptions": {
             "es": "Servicios de diagnóstico y evaluación",
             "en": "Diagnostic and evaluation services",
+            "fr": "Services de diagnostique et d'évaluation",
         },
         "display_order": 1,
         "icon": "i-lucide-stethoscope",
     },
     {
         "key": "preventivo",
-        "names": {"es": "Preventivo", "en": "Preventive"},
+        "names": {"es": "Preventivo", "en": "Preventive", "fr": "Préventif"},
         "descriptions": {
             "es": "Prevención e higiene dental",
             "en": "Preventive and hygiene",
+            "fr": "Prévention et hygiène dentaire",
         },
         "display_order": 2,
         "icon": "i-lucide-shield-check",
     },
     {
         "key": "restauradora",
-        "names": {"es": "Restauradora", "en": "Restorative"},
+        "names": {"es": "Restauradora", "en": "Restorative", "fr": "Restauration"},
         "descriptions": {
             "es": "Restauración dental",
             "en": "Dental restoration",
+            "fr": "Restauration dentaire",
         },
         "display_order": 3,
         "icon": "i-lucide-brush",
     },
     {
         "key": "endodoncia",
-        "names": {"es": "Endodoncia", "en": "Endodontics"},
+        "names": {"es": "Endodoncia", "en": "Endodontics", "fr": "Endodontie"},
         "descriptions": {
             "es": "Tratamientos de conducto radicular",
             "en": "Root canal treatments",
+            "fr": "Traitements des canaux radiculaires",
         },
         "display_order": 4,
         "icon": "i-lucide-activity",
     },
     {
         "key": "periodoncia",
-        "names": {"es": "Periodoncia", "en": "Periodontics"},
+        "names": {"es": "Periodoncia", "en": "Periodontics", "fr": "Parodontie"},
         "descriptions": {
             "es": "Encías y tejidos de soporte",
             "en": "Gums and supporting tissues",
+            "fr": "Gencives et tissus de soutien",
         },
         "display_order": 5,
         "icon": "i-lucide-heart-pulse",
     },
     {
         "key": "cirugia",
-        "names": {"es": "Cirugía", "en": "Surgery"},
+        "names": {"es": "Cirugía", "en": "Surgery", "fr": "Chirurgie"},
         "descriptions": {
             "es": "Procedimientos quirúrgicos dentales",
             "en": "Dental surgical procedures",
+            "fr": "Procédures chirurgicales dentaires",
         },
         "display_order": 6,
         "icon": "i-lucide-scissors",
     },
     {
         "key": "ortodoncia",
-        "names": {"es": "Ortodoncia", "en": "Orthodontics"},
+        "names": {"es": "Ortodoncia", "en": "Orthodontics", "fr": "Orthodontie"},
         "descriptions": {
             "es": "Ortodoncia y alineación",
             "en": "Orthodontics and alignment",
+            "fr": "Orthodontie et alignement",
         },
         "display_order": 7,
         "icon": "i-lucide-align-center",
     },
     {
         "key": "estetica",
-        "names": {"es": "Estética", "en": "Cosmetic"},
+        "names": {"es": "Estética", "en": "Cosmetic", "fr": "Esthétique"},
         "descriptions": {
             "es": "Estética dental",
             "en": "Cosmetic dentistry",
+            "fr": "Esthétique dentaire",
         },
         "display_order": 8,
         "icon": "i-lucide-sparkles",
     },
     {
         "key": "protesis",
-        "names": {"es": "Prótesis", "en": "Prosthetics"},
+        "names": {"es": "Prótesis", "en": "Prosthetics", "fr": "Prothèses"},
         "descriptions": {
             "es": "Prótesis y férulas",
             "en": "Prosthetics and splints",
+            "fr": "Prothèses et gouttières",
         },
         "display_order": 9,
         "icon": "i-lucide-puzzle",
     },
     {
         "key": "pediatrica",
-        "names": {"es": "Odontopediatría", "en": "Pediatric"},
+        "names": {"es": "Odontopediatría", "en": "Pediatric", "fr": "Odontologie pédiatrique"},
         "descriptions": {
             "es": "Tratamientos para niños",
             "en": "Treatments for children",
+            "fr": "Traitements pour enfants",
         },
         "display_order": 10,
         "icon": "i-lucide-baby",
@@ -200,10 +210,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "diagnostico": [
         {
             "internal_code": "DX-VISIT",
-            "names": {"es": "Primera Visita", "en": "First Visit"},
+            "names": {"es": "Primera Visita", "en": "First Visit", "fr": "Première visite"},
             "descriptions": {
                 "es": "Consulta inicial con exploración y diagnóstico",
                 "en": "Initial consultation with examination and diagnosis",
+                "fr": "Consulte initiale avec examen et diagnostique",
             },
             "treatment_scope": "global_mouth",
             "is_diagnostic": False,
@@ -215,7 +226,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-REVIEW",
-            "names": {"es": "Revisión", "en": "Follow-up"},
+            "names": {"es": "Revisión", "en": "Follow-up", "fr": "Contrôle"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("20.00"),
             "default_duration_minutes": 20,
@@ -224,7 +235,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-RXPA",
-            "names": {"es": "Radiografía Periapical", "en": "Periapical X-Ray"},
+            "names": {
+                "es": "Radiografía Periapical",
+                "en": "Periapical X-Ray",
+                "fr": "Radiographie périapicale",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("15.00"),
             "default_duration_minutes": 10,
@@ -233,7 +248,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-RXPAN",
-            "names": {"es": "Radiografía Panorámica", "en": "Panoramic X-Ray"},
+            "names": {
+                "es": "Radiografía Panorámica",
+                "en": "Panoramic X-Ray",
+                "fr": "Radiographie panoramique",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("45.00"),
             "default_duration_minutes": 10,
@@ -242,7 +261,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-CBCT",
-            "names": {"es": "CBCT (TAC 3D)", "en": "CBCT (3D Scan)"},
+            "names": {
+                "es": "CBCT (TAC 3D)",
+                "en": "CBCT (3D Scan)",
+                "fr": "CBCT (Tomodensitométrie 3D)",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("120.00"),
             "default_duration_minutes": 20,
@@ -251,7 +274,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-STUDY",
-            "names": {"es": "Estudio Ortodóncico", "en": "Orthodontic Study"},
+            "names": {
+                "es": "Estudio Ortodóncico",
+                "en": "Orthodontic Study",
+                "fr": "Étude orthodontique",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("90.00"),
             "default_duration_minutes": 45,
@@ -260,7 +287,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-PHOTO",
-            "names": {"es": "Fotografías intraorales", "en": "Intraoral Photos"},
+            "names": {
+                "es": "Fotografías intraorales",
+                "en": "Intraoral Photos",
+                "fr": "Photographies intraorales",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("30.00"),
             "default_duration_minutes": 15,
@@ -269,7 +300,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-URGENT",
-            "names": {"es": "Visita de urgencia", "en": "Emergency visit"},
+            "names": {
+                "es": "Visita de urgencia",
+                "en": "Emergency visit",
+                "fr": "Visite d'urgence",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("60.00"),
             "default_duration_minutes": 30,
@@ -278,7 +313,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-2ND-OPINION",
-            "names": {"es": "Segunda opinión", "en": "Second opinion"},
+            "names": {"es": "Segunda opinión", "en": "Second opinion", "fr": "Deuxième avis"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("50.00"),
             "default_duration_minutes": 30,
@@ -287,7 +322,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "DX-TELE",
-            "names": {"es": "Telerradiografía lateral", "en": "Lateral cephalogram"},
+            "names": {
+                "es": "Telerradiografía lateral",
+                "en": "Lateral cephalogram",
+                "fr": "Téléradiographie latérale",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("45.00"),
             "default_duration_minutes": 15,
@@ -299,8 +338,12 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "preventivo": [
         {
             "internal_code": "PREV-CLEAN",
-            "names": {"es": "Limpieza dental", "en": "Dental Cleaning"},
-            "descriptions": {"es": "Tartrectomía y pulido", "en": "Scaling and polishing"},
+            "names": {"es": "Limpieza dental", "en": "Dental Cleaning", "fr": "Détartrage"},
+            "descriptions": {
+                "es": "Tartrectomía y pulido",
+                "en": "Scaling and polishing",
+                "fr": "Détartrage et polissage",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("60.00"),
             "default_duration_minutes": 45,
@@ -309,7 +352,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PREV-FLUOR",
-            "names": {"es": "Fluorización", "en": "Fluoride Application"},
+            "names": {"es": "Fluorización", "en": "Fluoride Application", "fr": "Fluoruration"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("25.00"),
             "default_duration_minutes": 15,
@@ -318,8 +361,12 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PREV-CHECKUP",
-            "names": {"es": "Revisión", "en": "Checkup"},
-            "descriptions": {"es": "Revisión general", "en": "General checkup"},
+            "names": {"es": "Revisión", "en": "Checkup", "fr": "Contrôle"},
+            "descriptions": {
+                "es": "Revisión general",
+                "en": "General checkup",
+                "fr": "Contrôle général",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("30.00"),
             "default_duration_minutes": 20,
@@ -328,7 +375,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PREV-SEAL",
-            "names": {"es": "Sellador de fosas y fisuras", "en": "Pit and Fissure Sealant"},
+            "names": {
+                "es": "Sellador de fosas y fisuras",
+                "en": "Pit and Fissure Sealant",
+                "fr": "Sillonnage des fissures",
+            },
             "treatment_scope": "tooth",
             "requires_surfaces": True,
             "default_price": Decimal("30.00"),
@@ -341,7 +392,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PREV-HYGIENE-EDU",
-            "names": {"es": "Instrucciones de higiene", "en": "Oral Hygiene Instruction"},
+            "names": {
+                "es": "Instrucciones de higiene",
+                "en": "Oral Hygiene Instruction",
+                "fr": "Instructions d'hygiène buccale",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("20.00"),
             "default_duration_minutes": 20,
@@ -353,6 +408,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Tartrectomía con curetaje",
                 "en": "Scaling with curettage",
+                "fr": "Détartrage avec curetage",
             },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("110.00"),
@@ -362,7 +418,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PREV-CLEAN-PED",
-            "names": {"es": "Profilaxis infantil", "en": "Pediatric prophylaxis"},
+            "names": {
+                "es": "Profilaxis infantil",
+                "en": "Pediatric prophylaxis",
+                "fr": "Prophylaxie pédiatrique",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("40.00"),
             "default_duration_minutes": 30,
@@ -380,6 +440,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Obturación composite",
                 "en": "Composite filling",
+                "fr": "Obturation composite",
             },
             "treatment_scope": "tooth",
             "requires_surfaces": True,
@@ -400,7 +461,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-AMAL",
-            "names": {"es": "Obturación amalgama", "en": "Amalgam filling"},
+            "names": {
+                "es": "Obturación amalgama",
+                "en": "Amalgam filling",
+                "fr": "Obturation amalgame",
+            },
             "treatment_scope": "tooth",
             "requires_surfaces": True,
             "default_price": Decimal("55.00"),
@@ -420,7 +485,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-TEMP",
-            "names": {"es": "Obturación temporal", "en": "Temporary filling"},
+            "names": {
+                "es": "Obturación temporal",
+                "en": "Temporary filling",
+                "fr": "Obturation temporaire",
+            },
             "treatment_scope": "tooth",
             "requires_surfaces": True,
             "default_price": Decimal("40.00"),
@@ -434,7 +503,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         # Incrustaciones
         {
             "internal_code": "REST-INLAY-COMP",
-            "names": {"es": "Inlay composite", "en": "Composite inlay"},
+            "names": {"es": "Inlay composite", "en": "Composite inlay", "fr": "Inlay composite"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 60,
@@ -446,7 +515,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-INLAY-CER",
-            "names": {"es": "Inlay cerámico", "en": "Ceramic inlay"},
+            "names": {"es": "Inlay cerámico", "en": "Ceramic inlay", "fr": "Inlay céramique"},
             "treatment_scope": "tooth",
             "default_price": Decimal("350.00"),
             "default_duration_minutes": 60,
@@ -458,7 +527,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-OVER-COMP",
-            "names": {"es": "Overlay composite", "en": "Composite overlay"},
+            "names": {
+                "es": "Overlay composite",
+                "en": "Composite overlay",
+                "fr": "Overlay composite",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("240.00"),
             "default_duration_minutes": 75,
@@ -470,7 +543,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-OVER-CER",
-            "names": {"es": "Overlay cerámico", "en": "Ceramic overlay"},
+            "names": {"es": "Overlay cerámico", "en": "Ceramic overlay", "fr": "Overlay céramique"},
             "treatment_scope": "tooth",
             "default_price": Decimal("450.00"),
             "default_duration_minutes": 75,
@@ -483,7 +556,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         # Carillas (per_tooth pricing — ideal for "carillas múltiples")
         {
             "internal_code": "REST-VEN-COMP",
-            "names": {"es": "Carilla composite", "en": "Composite veneer"},
+            "names": {
+                "es": "Carilla composite",
+                "en": "Composite veneer",
+                "fr": "Facette composite",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("280.00"),
             "default_duration_minutes": 60,
@@ -495,7 +572,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-VEN-PORC",
-            "names": {"es": "Carilla porcelana", "en": "Porcelain veneer"},
+            "names": {
+                "es": "Carilla porcelana",
+                "en": "Porcelain veneer",
+                "fr": "Facette céramique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("480.00"),
             "default_duration_minutes": 90,
@@ -507,7 +588,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-VEN-ZIR",
-            "names": {"es": "Carilla zirconio", "en": "Zirconia veneer"},
+            "names": {"es": "Carilla zirconio", "en": "Zirconia veneer", "fr": "Facette zircone"},
             "treatment_scope": "tooth",
             "default_price": Decimal("550.00"),
             "default_duration_minutes": 90,
@@ -520,7 +601,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         # Coronas unitarias / múltiples (per_tooth pricing)
         {
             "internal_code": "REST-CROWN-MC",
-            "names": {"es": "Corona metal-cerámica", "en": "Metal-ceramic crown"},
+            "names": {
+                "es": "Corona metal-cerámica",
+                "en": "Metal-ceramic crown",
+                "fr": "Couronne métal-céramique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("400.00"),
             "default_duration_minutes": 90,
@@ -531,18 +616,22 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#F59E0B"},
             "sessions": [
                 {
-                    "labels": {"es": "Toma de medidas", "en": "Impressions"},
+                    "labels": {
+                        "es": "Toma de medidas",
+                        "en": "Impressions",
+                        "fr": "Prise d'empreinte",
+                    },
                     "default_price": Decimal("150.00"),
                 },
                 {
-                    "labels": {"es": "Colocación", "en": "Placement"},
+                    "labels": {"es": "Colocación", "en": "Placement", "fr": "Pose"},
                     "default_price": Decimal("250.00"),
                 },
             ],
         },
         {
             "internal_code": "REST-CROWN-ZIR",
-            "names": {"es": "Corona zirconio", "en": "Zirconia crown"},
+            "names": {"es": "Corona zirconio", "en": "Zirconia crown", "fr": "Couronne zircone"},
             "treatment_scope": "tooth",
             "default_price": Decimal("550.00"),
             "default_duration_minutes": 90,
@@ -553,18 +642,26 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#FBBF24"},
             "sessions": [
                 {
-                    "labels": {"es": "Toma de medidas", "en": "Impressions"},
+                    "labels": {
+                        "es": "Toma de medidas",
+                        "en": "Impressions",
+                        "fr": "Prise d'empreinte",
+                    },
                     "default_price": Decimal("200.00"),
                 },
                 {
-                    "labels": {"es": "Colocación", "en": "Placement"},
+                    "labels": {"es": "Colocación", "en": "Placement", "fr": "Pose"},
                     "default_price": Decimal("350.00"),
                 },
             ],
         },
         {
             "internal_code": "REST-CROWN-DISI",
-            "names": {"es": "Corona disilicato de litio", "en": "Lithium disilicate crown"},
+            "names": {
+                "es": "Corona disilicato de litio",
+                "en": "Lithium disilicate crown",
+                "fr": "Couronne disilicate de lithium",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("650.00"),
             "default_duration_minutes": 90,
@@ -575,18 +672,22 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#FDE68A"},
             "sessions": [
                 {
-                    "labels": {"es": "Toma de medidas", "en": "Impressions"},
+                    "labels": {
+                        "es": "Toma de medidas",
+                        "en": "Impressions",
+                        "fr": "Prise d'empreinte",
+                    },
                     "default_price": Decimal("250.00"),
                 },
                 {
-                    "labels": {"es": "Colocación", "en": "Placement"},
+                    "labels": {"es": "Colocación", "en": "Placement", "fr": "Pose"},
                     "default_price": Decimal("400.00"),
                 },
             ],
         },
         {
             "internal_code": "REST-CROWN-METAL",
-            "names": {"es": "Corona metal", "en": "Metal crown"},
+            "names": {"es": "Corona metal", "en": "Metal crown", "fr": "Couronne métallique"},
             "treatment_scope": "tooth",
             "default_price": Decimal("350.00"),
             "default_duration_minutes": 90,
@@ -598,7 +699,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-CROWN-PROV",
-            "names": {"es": "Corona provisional", "en": "Provisional crown"},
+            "names": {
+                "es": "Corona provisional",
+                "en": "Provisional crown",
+                "fr": "Couronne provisoire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("150.00"),
             "default_duration_minutes": 45,
@@ -616,6 +721,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Corona sobre implante metal-cerámica",
                 "en": "Metal-ceramic crown on implant",
+                "fr": "Couronne sur implant métal-céramique",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("600.00"),
@@ -627,11 +733,15 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#F59E0B"},
             "sessions": [
                 {
-                    "labels": {"es": "Toma de medidas", "en": "Impressions"},
+                    "labels": {
+                        "es": "Toma de medidas",
+                        "en": "Impressions",
+                        "fr": "Prise d'empreinte",
+                    },
                     "default_price": Decimal("200.00"),
                 },
                 {
-                    "labels": {"es": "Colocación", "en": "Placement"},
+                    "labels": {"es": "Colocación", "en": "Placement", "fr": "Pose"},
                     "default_price": Decimal("400.00"),
                 },
             ],
@@ -641,6 +751,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Corona sobre implante zirconio",
                 "en": "Zirconia crown on implant",
+                "fr": "Couronne sur implant zircone",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("750.00"),
@@ -652,11 +763,15 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#FBBF24"},
             "sessions": [
                 {
-                    "labels": {"es": "Toma de medidas", "en": "Impressions"},
+                    "labels": {
+                        "es": "Toma de medidas",
+                        "en": "Impressions",
+                        "fr": "Prise d'empreinte",
+                    },
                     "default_price": Decimal("250.00"),
                 },
                 {
-                    "labels": {"es": "Colocación", "en": "Placement"},
+                    "labels": {"es": "Colocación", "en": "Placement", "fr": "Pose"},
                     "default_price": Decimal("500.00"),
                 },
             ],
@@ -666,6 +781,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Corona provisional sobre implante",
                 "en": "Provisional crown on implant",
+                "fr": "Couronne provisoire sur implant",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
@@ -679,7 +795,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         # Puentes (per_role pricing)
         {
             "internal_code": "REST-BRIDGE-MC",
-            "names": {"es": "Puente metal-cerámica", "en": "Metal-ceramic bridge"},
+            "names": {
+                "es": "Puente metal-cerámica",
+                "en": "Metal-ceramic bridge",
+                "fr": "Pont métal-céramique",
+            },
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("400.00"),
             "default_duration_minutes": 120,
@@ -692,7 +812,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-BRIDGE-ZIR",
-            "names": {"es": "Puente zirconio", "en": "Zirconia bridge"},
+            "names": {"es": "Puente zirconio", "en": "Zirconia bridge", "fr": "Pont zircone"},
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("500.00"),
             "default_duration_minutes": 120,
@@ -705,7 +825,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-BRIDGE-MARY",
-            "names": {"es": "Puente Maryland", "en": "Maryland bridge"},
+            "names": {"es": "Puente Maryland", "en": "Maryland bridge", "fr": "Pont du Maryland"},
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("350.00"),
             "default_duration_minutes": 90,
@@ -719,7 +839,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         # Férulas
         {
             "internal_code": "REST-SPLINT-OCC",
-            "names": {"es": "Férula de descarga", "en": "Occlusal splint"},
+            "names": {
+                "es": "Férula de descarga",
+                "en": "Occlusal splint",
+                "fr": "Gouttière d'occlusion",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("220.00"),
             "default_duration_minutes": 60,
@@ -734,6 +858,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Férula periodontal de contención",
                 "en": "Periodontal retention splint",
+                "fr": "Gouttière de contention parodontale",
             },
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("80.00"),
@@ -749,6 +874,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Reconstrucción amplia con composite",
                 "en": "Large composite reconstruction",
+                "fr": "Reconstruction extensive en composite",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("160.00"),
@@ -764,6 +890,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Reparación de obturación",
                 "en": "Filling repair",
+                "fr": "Réparation d'obturation",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("55.00"),
@@ -776,7 +903,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-CROWN-RECEMENT",
-            "names": {"es": "Recementado de corona", "en": "Crown recementation"},
+            "names": {
+                "es": "Recementado de corona",
+                "en": "Crown recementation",
+                "fr": "Recimentation de couronne",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("60.00"),
             "default_duration_minutes": 20,
@@ -791,6 +922,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Corona sobre diente endodonciado",
                 "en": "Crown over endodontically treated tooth",
+                "fr": "Couronne sur dent dévitalisée",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("450.00"),
@@ -803,7 +935,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-HEAL-ABUT",
-            "names": {"es": "Pilar de cicatrización", "en": "Healing abutment"},
+            "names": {
+                "es": "Pilar de cicatrización",
+                "en": "Healing abutment",
+                "fr": "Pilier de cicatrisation",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("150.00"),
             "default_duration_minutes": 30,
@@ -815,7 +951,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "REST-DEF-ABUT",
-            "names": {"es": "Pilar definitivo", "en": "Definitive abutment"},
+            "names": {
+                "es": "Pilar definitivo",
+                "en": "Definitive abutment",
+                "fr": "Pilier définitif",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("250.00"),
             "default_duration_minutes": 30,
@@ -830,7 +970,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "endodoncia": [
         {
             "internal_code": "ENDO-UNI",
-            "names": {"es": "Endodoncia unirradicular", "en": "Single-root endodontics"},
+            "names": {
+                "es": "Endodoncia unirradicular",
+                "en": "Single-root endodontics",
+                "fr": "Endodontie uniradiculaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 60,
@@ -842,7 +986,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-BI",
-            "names": {"es": "Endodoncia birradicular", "en": "Two-root endodontics"},
+            "names": {
+                "es": "Endodoncia birradicular",
+                "en": "Two-root endodontics",
+                "fr": "Endodontie biradiculaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("280.00"),
             "default_duration_minutes": 75,
@@ -854,7 +1002,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-MULTI",
-            "names": {"es": "Endodoncia molar", "en": "Molar endodontics"},
+            "names": {
+                "es": "Endodoncia molar",
+                "en": "Molar endodontics",
+                "fr": "Endodontie molaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("380.00"),
             "default_duration_minutes": 90,
@@ -865,22 +1017,34 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#7C3AED"},
             "sessions": [
                 {
-                    "labels": {"es": "Apertura y conductometría", "en": "Access and length"},
+                    "labels": {
+                        "es": "Apertura y conductometría",
+                        "en": "Access and length",
+                        "fr": "Ouverture et détermination",
+                    },
                     "default_price": Decimal("130.00"),
                 },
                 {
-                    "labels": {"es": "Limpieza y conformación", "en": "Cleaning and shaping"},
+                    "labels": {
+                        "es": "Limpieza y conformación",
+                        "en": "Cleaning and shaping",
+                        "fr": "Nettoyage et évasage",
+                    },
                     "default_price": Decimal("130.00"),
                 },
                 {
-                    "labels": {"es": "Obturación", "en": "Obturation"},
+                    "labels": {"es": "Obturación", "en": "Obturation", "fr": "Obturation"},
                     "default_price": Decimal("120.00"),
                 },
             ],
         },
         {
             "internal_code": "ENDO-RETREAT",
-            "names": {"es": "Re-tratamiento endodóncico", "en": "Endodontic retreatment"},
+            "names": {
+                "es": "Re-tratamiento endodóncico",
+                "en": "Endodontic retreatment",
+                "fr": "Retraitement endodontique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("380.00"),
             "default_duration_minutes": 90,
@@ -892,7 +1056,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-POST-FIBER",
-            "names": {"es": "Perno de fibra", "en": "Fiber post"},
+            "names": {"es": "Perno de fibra", "en": "Fiber post", "fr": "Pivot en fibre"},
             "treatment_scope": "tooth",
             "default_price": Decimal("120.00"),
             "default_duration_minutes": 45,
@@ -904,7 +1068,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-POST-METAL",
-            "names": {"es": "Perno colado", "en": "Cast post"},
+            "names": {"es": "Perno colado", "en": "Cast post", "fr": "Pivot coulé"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 60,
@@ -916,7 +1080,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-URGENT",
-            "names": {"es": "Apertura cameral urgente", "en": "Emergency pulp chamber opening"},
+            "names": {
+                "es": "Apertura cameral urgente",
+                "en": "Emergency pulp chamber opening",
+                "fr": "Ouverture d'urgence de la chambre pulpaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("80.00"),
             "default_duration_minutes": 30,
@@ -931,6 +1099,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Recambio de medicación intraconducto",
                 "en": "Intracanal medication refresh",
+                "fr": "Renouvellement de médicament intraradiculaire",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("60.00"),
@@ -943,7 +1112,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-APICOFORM",
-            "names": {"es": "Apicoformación", "en": "Apexification"},
+            "names": {"es": "Apicoformación", "en": "Apexification", "fr": "Apexification"},
             "treatment_scope": "tooth",
             "default_price": Decimal("280.00"),
             "default_duration_minutes": 75,
@@ -955,7 +1124,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ENDO-PED",
-            "names": {"es": "Endodoncia en pieza temporal", "en": "Endodontics on primary tooth"},
+            "names": {
+                "es": "Endodoncia en pieza temporal",
+                "en": "Endodontics on primary tooth",
+                "fr": "Endodontie sur dent temporaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("140.00"),
             "default_duration_minutes": 45,
@@ -970,7 +1143,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "periodoncia": [
         {
             "internal_code": "PERIO-SCAL",
-            "names": {"es": "Tartrectomía simple", "en": "Simple scaling"},
+            "names": {
+                "es": "Tartrectomía simple",
+                "en": "Simple scaling",
+                "fr": "Détartrage simple",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("60.00"),
             "default_duration_minutes": 30,
@@ -982,6 +1159,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Raspado y alisado radicular (por cuadrante)",
                 "en": "Root scaling and planing (per quadrant)",
+                "fr": "Détartrage et surfaçage radiculaire (par quadrant)",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
@@ -991,7 +1169,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-SURG",
-            "names": {"es": "Cirugía periodontal", "en": "Periodontal surgery"},
+            "names": {
+                "es": "Cirugía periodontal",
+                "en": "Periodontal surgery",
+                "fr": "Chirurgie parodontale",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("450.00"),
             "default_duration_minutes": 90,
@@ -1000,7 +1182,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-GRAFT",
-            "names": {"es": "Injerto gingival", "en": "Gingival graft"},
+            "names": {"es": "Injerto gingival", "en": "Gingival graft", "fr": "Greffe gingivale"},
             "treatment_scope": "tooth",
             "default_price": Decimal("380.00"),
             "default_duration_minutes": 75,
@@ -1009,7 +1191,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-BONE",
-            "names": {"es": "Regeneración ósea guiada", "en": "Guided bone regeneration"},
+            "names": {
+                "es": "Regeneración ósea guiada",
+                "en": "Guided bone regeneration",
+                "fr": "Régénération osseuse guidée",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("550.00"),
             "default_duration_minutes": 90,
@@ -1018,7 +1204,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-MAINT",
-            "names": {"es": "Mantenimiento periodontal", "en": "Periodontal maintenance"},
+            "names": {
+                "es": "Mantenimiento periodontal",
+                "en": "Periodontal maintenance",
+                "fr": "Entretien parodontal",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("90.00"),
             "default_duration_minutes": 45,
@@ -1027,7 +1217,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-CURET-SEXT",
-            "names": {"es": "Curetaje por sextante", "en": "Curettage per sextant"},
+            "names": {
+                "es": "Curetaje por sextante",
+                "en": "Curettage per sextant",
+                "fr": "Curetage par sextant",
+            },
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("90.00"),
             "default_duration_minutes": 45,
@@ -1036,7 +1230,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-STUDY",
-            "names": {"es": "Estudio periodontal (sondaje)", "en": "Periodontal probing study"},
+            "names": {
+                "es": "Estudio periodontal (sondaje)",
+                "en": "Periodontal probing study",
+                "fr": "Étude parodontale (sondage)",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("70.00"),
             "default_duration_minutes": 45,
@@ -1048,6 +1246,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Férula de contención post-RAR",
                 "en": "Post-SRP retention splint",
+                "fr": "Gouttière de contention post-DDR",
             },
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("150.00"),
@@ -1060,7 +1259,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PERIO-GINGIV",
-            "names": {"es": "Gingivectomía", "en": "Gingivectomy"},
+            "names": {"es": "Gingivectomía", "en": "Gingivectomy", "fr": "Gingivectomie"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 45,
@@ -1072,6 +1271,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Cirugía periodontal resectiva",
                 "en": "Resective periodontal surgery",
+                "fr": "Chirurgie parodontale résécative",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("480.00"),
@@ -1084,6 +1284,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Cirugía periodontal regenerativa",
                 "en": "Regenerative periodontal surgery",
+                "fr": "Chirurgie parodontale régénérative",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("580.00"),
@@ -1096,7 +1297,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "cirugia": [
         {
             "internal_code": "SURG-EXT-SIMPLE",
-            "names": {"es": "Extracción simple", "en": "Simple extraction"},
+            "names": {
+                "es": "Extracción simple",
+                "en": "Simple extraction",
+                "fr": "Extraction simple",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("80.00"),
             "default_duration_minutes": 30,
@@ -1108,7 +1313,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-EXT-COMPLEX",
-            "names": {"es": "Extracción compleja", "en": "Complex extraction"},
+            "names": {
+                "es": "Extracción compleja",
+                "en": "Complex extraction",
+                "fr": "Extraction compliquée",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("140.00"),
             "default_duration_minutes": 45,
@@ -1120,7 +1329,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-EXT-3MOLAR",
-            "names": {"es": "Extracción tercer molar", "en": "Wisdom tooth extraction"},
+            "names": {
+                "es": "Extracción tercer molar",
+                "en": "Wisdom tooth extraction",
+                "fr": "Extraction de la dent de sagesse",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("200.00"),
             "default_duration_minutes": 60,
@@ -1135,6 +1348,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Extracción quirúrgica con ostectomía",
                 "en": "Surgical extraction with osteotomy",
+                "fr": "Extraction chirurgicale avec ostéotomie",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("280.00"),
@@ -1147,7 +1361,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-IMP-TI",
-            "names": {"es": "Implante de titanio", "en": "Titanium implant"},
+            "names": {
+                "es": "Implante de titanio",
+                "en": "Titanium implant",
+                "fr": "Implant en titane",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("1100.00"),
             "default_duration_minutes": 90,
@@ -1158,22 +1376,38 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "visualization_config": {"color": "#10B981"},
             "sessions": [
                 {
-                    "labels": {"es": "Cirugía de implante", "en": "Implant surgery"},
+                    "labels": {
+                        "es": "Cirugía de implante",
+                        "en": "Implant surgery",
+                        "fr": "Chirurgie implantaire",
+                    },
                     "default_price": Decimal("700.00"),
                 },
                 {
-                    "labels": {"es": "Pilar de cicatrización", "en": "Healing abutment"},
+                    "labels": {
+                        "es": "Pilar de cicatrización",
+                        "en": "Healing abutment",
+                        "fr": "Pilier de cicatrisation",
+                    },
                     "default_price": Decimal("150.00"),
                 },
                 {
-                    "labels": {"es": "Colocación de corona", "en": "Crown placement"},
+                    "labels": {
+                        "es": "Colocación de corona",
+                        "en": "Crown placement",
+                        "fr": "Pose de couronne",
+                    },
                     "default_price": Decimal("250.00"),
                 },
             ],
         },
         {
             "internal_code": "SURG-IMP-ZIR",
-            "names": {"es": "Implante de zirconio", "en": "Zirconia implant"},
+            "names": {
+                "es": "Implante de zirconio",
+                "en": "Zirconia implant",
+                "fr": "Implant en zircone",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("1500.00"),
             "default_duration_minutes": 90,
@@ -1185,7 +1419,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-SINUS",
-            "names": {"es": "Elevación de seno", "en": "Sinus lift"},
+            "names": {"es": "Elevación de seno", "en": "Sinus lift", "fr": "Élévation sinusienne"},
             "treatment_scope": "tooth",
             "default_price": Decimal("800.00"),
             "default_duration_minutes": 90,
@@ -1194,7 +1428,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-BONE-GRAFT",
-            "names": {"es": "Injerto óseo", "en": "Bone graft"},
+            "names": {"es": "Injerto óseo", "en": "Bone graft", "fr": "Greffe osseuse"},
             "treatment_scope": "tooth",
             "default_price": Decimal("450.00"),
             "default_duration_minutes": 75,
@@ -1203,7 +1437,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-APEC",
-            "names": {"es": "Apicectomía", "en": "Apicoectomy"},
+            "names": {"es": "Apicectomía", "en": "Apicoectomy", "fr": "Apicectomie"},
             "treatment_scope": "tooth",
             "default_price": Decimal("320.00"),
             "default_duration_minutes": 75,
@@ -1215,7 +1449,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-FREN",
-            "names": {"es": "Frenectomía", "en": "Frenectomy"},
+            "names": {"es": "Frenectomía", "en": "Frenectomy", "fr": "Frenectomie"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 30,
@@ -1224,7 +1458,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-BIOPSY",
-            "names": {"es": "Biopsia", "en": "Biopsy"},
+            "names": {"es": "Biopsia", "en": "Biopsy", "fr": "Biopsie"},
             "treatment_scope": "tooth",
             "default_price": Decimal("220.00"),
             "default_duration_minutes": 45,
@@ -1236,6 +1470,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Injerto de tejido conectivo",
                 "en": "Connective tissue graft",
+                "fr": "Greffe de tissu conjonctif",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("420.00"),
@@ -1245,7 +1480,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-CROWN-LENGTH",
-            "names": {"es": "Alargamiento coronario", "en": "Crown lengthening"},
+            "names": {
+                "es": "Alargamiento coronario",
+                "en": "Crown lengthening",
+                "fr": "Allongement coronaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("380.00"),
             "default_duration_minutes": 75,
@@ -1254,7 +1493,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-CYST",
-            "names": {"es": "Exéresis de quiste", "en": "Cyst removal"},
+            "names": {"es": "Exéresis de quiste", "en": "Cyst removal", "fr": "Exérèse de kyste"},
             "treatment_scope": "tooth",
             "default_price": Decimal("550.00"),
             "default_duration_minutes": 90,
@@ -1269,6 +1508,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Extracción de pieza incluida",
                 "en": "Impacted tooth extraction",
+                "fr": "Extraction de dent incluse",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("250.00"),
@@ -1281,7 +1521,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-BONE-REGUL",
-            "names": {"es": "Regularización ósea", "en": "Bone reshaping"},
+            "names": {
+                "es": "Regularización ósea",
+                "en": "Bone reshaping",
+                "fr": "Régularisation osseuse",
+            },
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("220.00"),
             "default_duration_minutes": 60,
@@ -1293,6 +1537,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Plasma rico en plaquetas",
                 "en": "Platelet-rich plasma",
+                "fr": "Plasma riche en plaquettes",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
@@ -1305,6 +1550,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Tratamiento de periimplantitis",
                 "en": "Peri-implantitis treatment",
+                "fr": "Traitement de péri-implantite",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("420.00"),
@@ -1314,7 +1560,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-BONE-VERT",
-            "names": {"es": "Aumento óseo vertical", "en": "Vertical bone augmentation"},
+            "names": {
+                "es": "Aumento óseo vertical",
+                "en": "Vertical bone augmentation",
+                "fr": "Augmentation osseuse verticale",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("750.00"),
             "default_duration_minutes": 90,
@@ -1323,7 +1573,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-BONE-HORIZ",
-            "names": {"es": "Aumento óseo horizontal", "en": "Horizontal bone augmentation"},
+            "names": {
+                "es": "Aumento óseo horizontal",
+                "en": "Horizontal bone augmentation",
+                "fr": "Augmentation osseuse horizontale",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("650.00"),
             "default_duration_minutes": 90,
@@ -1335,6 +1589,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Elevación de seno cerrada (atraumática)",
                 "en": "Closed sinus lift (atraumatic)",
+                "fr": "Élévation sinusienne fermée (atraumatique)",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("500.00"),
@@ -1347,7 +1602,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "ortodoncia": [
         {
             "internal_code": "ORTO-METAL",
-            "names": {"es": "Ortodoncia brackets metálicos", "en": "Metal braces"},
+            "names": {
+                "es": "Ortodoncia brackets metálicos",
+                "en": "Metal braces",
+                "fr": "Bagues métalliques",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("2500.00"),
             "default_duration_minutes": 60,
@@ -1356,7 +1615,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-CERAM",
-            "names": {"es": "Ortodoncia brackets estéticos", "en": "Ceramic braces"},
+            "names": {
+                "es": "Ortodoncia brackets estéticos",
+                "en": "Ceramic braces",
+                "fr": "Bagues esthétiques",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("3500.00"),
             "default_duration_minutes": 60,
@@ -1365,7 +1628,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-LINGUAL",
-            "names": {"es": "Ortodoncia lingual", "en": "Lingual braces"},
+            "names": {"es": "Ortodoncia lingual", "en": "Lingual braces", "fr": "Bagues linguales"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("5500.00"),
             "default_duration_minutes": 60,
@@ -1374,7 +1637,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-INV-LITE",
-            "names": {"es": "Invisalign Lite", "en": "Invisalign Lite"},
+            "names": {"es": "Invisalign Lite", "en": "Invisalign Lite", "fr": "Invisalign Lite"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("2900.00"),
             "default_duration_minutes": 45,
@@ -1383,7 +1646,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-INV-FULL",
-            "names": {"es": "Invisalign Full", "en": "Invisalign Full"},
+            "names": {"es": "Invisalign Full", "en": "Invisalign Full", "fr": "Invisalign Full"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("4500.00"),
             "default_duration_minutes": 45,
@@ -1392,7 +1655,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-BRACK",
-            "names": {"es": "Bracket individual (reposición)", "en": "Bracket (replacement)"},
+            "names": {
+                "es": "Bracket individual (reposición)",
+                "en": "Bracket (replacement)",
+                "fr": "Baguette individuelle (remplacement)",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("45.00"),
             "default_duration_minutes": 20,
@@ -1404,7 +1671,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-REVIEW",
-            "names": {"es": "Revisión de ortodoncia", "en": "Orthodontic review"},
+            "names": {
+                "es": "Revisión de ortodoncia",
+                "en": "Orthodontic review",
+                "fr": "Contrôle d'orthodontie",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("40.00"),
             "default_duration_minutes": 30,
@@ -1413,7 +1684,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-RET-FIX",
-            "names": {"es": "Retenedor fijo", "en": "Fixed retainer"},
+            "names": {"es": "Retenedor fijo", "en": "Fixed retainer", "fr": "Relieur fixe"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 45,
@@ -1425,7 +1696,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-RET-REM",
-            "names": {"es": "Retenedor removible", "en": "Removable retainer"},
+            "names": {
+                "es": "Retenedor removible",
+                "en": "Removable retainer",
+                "fr": "Relieur amovible",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("120.00"),
             "default_duration_minutes": 30,
@@ -1434,7 +1709,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-ATTACH",
-            "names": {"es": "Ataches de Invisalign", "en": "Invisalign attachments"},
+            "names": {
+                "es": "Ataches de Invisalign",
+                "en": "Invisalign attachments",
+                "fr": "Attachements Invisalign",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("60.00"),
             "default_duration_minutes": 30,
@@ -1446,7 +1725,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-BRACK-CEMENT",
-            "names": {"es": "Cementado de bracket", "en": "Bracket bonding"},
+            "names": {
+                "es": "Cementado de bracket",
+                "en": "Bracket bonding",
+                "fr": "Collage de baguette",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("35.00"),
             "default_duration_minutes": 15,
@@ -1458,7 +1741,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-BRACK-DEBOND",
-            "names": {"es": "Descementado de brackets", "en": "Bracket removal"},
+            "names": {
+                "es": "Descementado de brackets",
+                "en": "Bracket removal",
+                "fr": "Désinstallation de bagues",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("120.00"),
             "default_duration_minutes": 45,
@@ -1467,7 +1754,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-SEPARATOR",
-            "names": {"es": "Separadores ortodóncicos", "en": "Orthodontic separators"},
+            "names": {
+                "es": "Separadores ortodóncicos",
+                "en": "Orthodontic separators",
+                "fr": "Séparateurs orthodontiques",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("50.00"),
             "default_duration_minutes": 20,
@@ -1476,7 +1767,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-PALATAL-EXP",
-            "names": {"es": "Expansor palatino", "en": "Palatal expander"},
+            "names": {
+                "es": "Expansor palatino",
+                "en": "Palatal expander",
+                "fr": "Dilatateur palatin",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("450.00"),
             "default_duration_minutes": 60,
@@ -1488,6 +1783,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Microtornillo / anclaje esquelético temporal (TAD)",
                 "en": "Temporary anchorage device (TAD)",
+                "fr": "Dispositif d'ancrage temporaire (TAD)",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("250.00"),
@@ -1500,7 +1796,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "estetica": [
         {
             "internal_code": "EST-BLAN-AMB",
-            "names": {"es": "Blanqueamiento ambulatorio", "en": "At-home whitening"},
+            "names": {
+                "es": "Blanqueamiento ambulatorio",
+                "en": "At-home whitening",
+                "fr": "Blanchiment à domicile",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("250.00"),
             "default_duration_minutes": 30,
@@ -1509,7 +1809,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "EST-BLAN-CLIN",
-            "names": {"es": "Blanqueamiento en clínica", "en": "In-office whitening"},
+            "names": {
+                "es": "Blanqueamiento en clínica",
+                "en": "In-office whitening",
+                "fr": "Blanchiment en cabinet",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("400.00"),
             "default_duration_minutes": 90,
@@ -1518,7 +1822,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "EST-BLAN-COMBO",
-            "names": {"es": "Blanqueamiento combinado", "en": "Combined whitening"},
+            "names": {
+                "es": "Blanqueamiento combinado",
+                "en": "Combined whitening",
+                "fr": "Blanchiment combiné",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("550.00"),
             "default_duration_minutes": 120,
@@ -1527,7 +1835,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "EST-MICROAB",
-            "names": {"es": "Microabrasión", "en": "Microabrasion"},
+            "names": {"es": "Microabrasión", "en": "Microabrasion", "fr": "Microabrasion"},
             "treatment_scope": "tooth",
             "default_price": Decimal("120.00"),
             "default_duration_minutes": 45,
@@ -1536,7 +1844,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "EST-REMIN",
-            "names": {"es": "Remineralización estética", "en": "Aesthetic remineralization"},
+            "names": {
+                "es": "Remineralización estética",
+                "en": "Aesthetic remineralization",
+                "fr": "Reminéralisation esthétique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("90.00"),
             "default_duration_minutes": 30,
@@ -1548,6 +1860,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Reconstrucción estética con composite",
                 "en": "Aesthetic composite reconstruction",
+                "fr": "Reconstruction esthétique en composite",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("220.00"),
@@ -1560,6 +1873,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Eliminación de pigmentación",
                 "en": "Pigmentation removal",
+                "fr": "Élimination des pigmentation",
             },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("90.00"),
@@ -1572,7 +1886,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "protesis": [
         {
             "internal_code": "PROT-FULL-SUP",
-            "names": {"es": "Prótesis completa superior", "en": "Full upper denture"},
+            "names": {
+                "es": "Prótesis completa superior",
+                "en": "Full upper denture",
+                "fr": "Prothèse complète supérieure",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("900.00"),
             "default_duration_minutes": 90,
@@ -1581,7 +1899,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PROT-FULL-INF",
-            "names": {"es": "Prótesis completa inferior", "en": "Full lower denture"},
+            "names": {
+                "es": "Prótesis completa inferior",
+                "en": "Full lower denture",
+                "fr": "Prothèse complète inférieure",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("900.00"),
             "default_duration_minutes": 90,
@@ -1590,7 +1912,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PROT-PART-METAL",
-            "names": {"es": "Prótesis parcial esquelética", "en": "Partial metal denture"},
+            "names": {
+                "es": "Prótesis parcial esquelética",
+                "en": "Partial metal denture",
+                "fr": "Prothèse partielle squelettique",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("750.00"),
             "default_duration_minutes": 90,
@@ -1599,7 +1925,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PROT-PART-ACR",
-            "names": {"es": "Prótesis parcial acrílica", "en": "Partial acrylic denture"},
+            "names": {
+                "es": "Prótesis parcial acrílica",
+                "en": "Partial acrylic denture",
+                "fr": "Prothèse partielle acrylique",
+            },
             "treatment_scope": "global_arch",
             "default_price": Decimal("450.00"),
             "default_duration_minutes": 75,
@@ -1611,6 +1941,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Sobredentadura sobre implantes",
                 "en": "Implant-supported overdenture",
+                "fr": "Surprothèse sur implants",
             },
             "treatment_scope": "global_arch",
             "default_price": Decimal("1800.00"),
@@ -1620,7 +1951,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PROT-REBASE",
-            "names": {"es": "Rebasado de prótesis", "en": "Denture reline"},
+            "names": {
+                "es": "Rebasado de prótesis",
+                "en": "Denture reline",
+                "fr": "Rebasage de prothèse",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("120.00"),
             "default_duration_minutes": 45,
@@ -1629,7 +1964,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PROT-REPAIR",
-            "names": {"es": "Reparación de prótesis", "en": "Denture repair"},
+            "names": {
+                "es": "Reparación de prótesis",
+                "en": "Denture repair",
+                "fr": "Réparation de prothèse",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("80.00"),
             "default_duration_minutes": 30,
@@ -1641,6 +1980,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Prótesis provisional removible",
                 "en": "Provisional removable denture",
+                "fr": "Prothèse provisoire amovible",
             },
             "treatment_scope": "global_arch",
             "default_price": Decimal("350.00"),
@@ -1650,7 +1990,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PROT-OCC-ADJ",
-            "names": {"es": "Ajuste oclusal", "en": "Occlusal adjustment"},
+            "names": {
+                "es": "Ajuste oclusal",
+                "en": "Occlusal adjustment",
+                "fr": "Ajustement occlusal",
+            },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("60.00"),
             "default_duration_minutes": 30,
@@ -1662,7 +2006,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
     "pediatrica": [
         {
             "internal_code": "PED-FLUOR",
-            "names": {"es": "Fluorización pediátrica", "en": "Pediatric fluoride"},
+            "names": {
+                "es": "Fluorización pediátrica",
+                "en": "Pediatric fluoride",
+                "fr": "Fluoruration pédiatrique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("25.00"),
             "default_duration_minutes": 15,
@@ -1671,7 +2019,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PED-SEAL",
-            "names": {"es": "Sellador pediátrico", "en": "Pediatric sealant"},
+            "names": {
+                "es": "Sellador pediátrico",
+                "en": "Pediatric sealant",
+                "fr": "Sillonnage pédiatrique",
+            },
             "treatment_scope": "tooth",
             "requires_surfaces": True,
             "default_price": Decimal("25.00"),
@@ -1684,7 +2036,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PED-PULPOTOMY",
-            "names": {"es": "Pulpotomía", "en": "Pulpotomy"},
+            "names": {"es": "Pulpotomía", "en": "Pulpotomy", "fr": "Pulpotomie"},
             "treatment_scope": "tooth",
             "default_price": Decimal("150.00"),
             "default_duration_minutes": 45,
@@ -1696,7 +2048,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PED-CROWN-SS",
-            "names": {"es": "Corona preformada pediátrica", "en": "Stainless steel crown"},
+            "names": {
+                "es": "Corona preformada pediátrica",
+                "en": "Stainless steel crown",
+                "fr": "Couronne préformée pédiatrique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 45,
@@ -1708,7 +2064,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PED-SPACE",
-            "names": {"es": "Mantenedor de espacio simple", "en": "Simple space maintainer"},
+            "names": {
+                "es": "Mantenedor de espacio simple",
+                "en": "Simple space maintainer",
+                "fr": "Mainteneur d'espace simple",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("150.00"),
             "default_duration_minutes": 45,
@@ -1720,6 +2080,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Mantenedor de espacio compuesto",
                 "en": "Compound space maintainer",
+                "fr": "Mainteneur d'espace composé",
             },
             "treatment_scope": "multi_tooth",
             "default_price": Decimal("220.00"),
@@ -1729,7 +2090,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PED-EXT-TEMP",
-            "names": {"es": "Extracción de pieza temporal", "en": "Primary tooth extraction"},
+            "names": {
+                "es": "Extracción de pieza temporal",
+                "en": "Primary tooth extraction",
+                "fr": "Extraction de dent temporaire",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("55.00"),
             "default_duration_minutes": 30,
@@ -1744,6 +2109,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Obturación en dentición temporal",
                 "en": "Primary tooth filling",
+                "fr": "Obturation sur dent temporaire",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("45.00"),
@@ -1764,7 +2130,11 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PED-PULPECTOMY",
-            "names": {"es": "Pulpectomía pediátrica", "en": "Pediatric pulpectomy"},
+            "names": {
+                "es": "Pulpectomía pediátrica",
+                "en": "Pediatric pulpectomy",
+                "fr": "Pulpectomie pédiatrique",
+            },
             "treatment_scope": "tooth",
             "default_price": Decimal("160.00"),
             "default_duration_minutes": 60,

--- a/backend/app/modules/catalog/service.py
+++ b/backend/app/modules/catalog/service.py
@@ -51,19 +51,19 @@ def validate_session_template(
 # Default VAT types to seed for new clinics
 DEFAULT_VAT_TYPES = [
     {
-        "names": {"es": "Exento", "en": "Exempt"},
+        "names": {"es": "Exento", "en": "Exempt", "fr": "Exonéré"},
         "rate": 0.0,
         "is_default": True,
         "is_system": True,
     },
     {
-        "names": {"es": "Reducido (10%)", "en": "Reduced (10%)"},
+        "names": {"es": "Reducido (10%)", "en": "Reduced (10%)", "fr": "Réduit (10%)"},
         "rate": 10.0,
         "is_default": False,
         "is_system": True,
     },
     {
-        "names": {"es": "General (21%)", "en": "Standard (21%)"},
+        "names": {"es": "General (21%)", "en": "Standard (21%)", "fr": "Général (21%)"},
         "rate": 21.0,
         "is_default": False,
         "is_system": True,

--- a/backend/app/modules/catalog/tools.py
+++ b/backend/app/modules/catalog/tools.py
@@ -35,7 +35,7 @@ class GetCatalogItemArgs(BaseModel):
 def _name(names: dict | None) -> str | None:
     if not names:
         return None
-    return names.get("es") or names.get("en") or next(iter(names.values()), None)
+    return names.get("es") or names.get("en") or names.get("fr") or next(iter(names.values()), None)
 
 
 def _summary(item) -> dict:

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- i18n: add French translations to seed data; add `body_i18n_key` to
+  template responses. Simplified label resolution in service layer:
+  removed `_resolve_catalog_by_type` and `lang` parameter from feed
+  endpoints; labels now resolve via `["es","en","fr"]` fallback from
+  catalog `names` dict, returning empty string when `catalog_item_id`
+  is NULL. Date formatting in NoteCard, PlanNotesTimeline, and
+  PatientClinicalNotesByPlan now uses locale-aware
+  `toLocaleString(locale)` to respect the active language.
+
 - feat(appointment-owner): add ``owner_type='appointment'`` with two
   new ``note_type`` values (``appointment_clinical`` +
   ``appointment_administrative``) so notes can attach to a

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## Unreleased
 
-- i18n: add French translations to seed data; add `body_i18n_key` to
-  template responses. Simplified label resolution in service layer:
-  removed `_resolve_catalog_by_type` and `lang` parameter from feed
-  endpoints; labels now resolve via `["es","en","fr"]` fallback from
-  catalog `names` dict, returning empty string when `catalog_item_id`
-  is NULL. Date formatting in NoteCard, PlanNotesTimeline, and
-  PatientClinicalNotesByPlan now uses locale-aware
-  `toLocaleString(locale)` to respect the active language.
+- i18n: add French locale (`fr.json`); add French translations to seed
+  data; add `body_i18n_key` to template responses so template bodies
+  resolve in the active locale. Labels now resolve via
+  `es → en → fr` catalog-name fallback (still falling back to
+  `treatment.clinical_type` when no catalog item). Date formatting in
+  NoteCard, PlanNotesTimeline, and PatientClinicalNotesByPlan uses
+  locale-aware `toLocaleString(locale)`.
 
 - feat(appointment-owner): add ``owner_type='appointment'`` with two
   new ``note_type`` values (``appointment_clinical`` +

--- a/backend/app/modules/clinical_notes/frontend/components/NoteCard.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/NoteCard.vue
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   'open-linked': [linked: ClinicalNoteLinked]
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { metaFor } = useNoteTypeMeta()
 
 const meta = computed(() => metaFor(props.noteType))
@@ -60,7 +60,7 @@ function formatRelative(iso: string): string {
     if (diffH < 24) return t('clinicalNotes.time.hoursAgo', { n: diffH })
     const diffD = Math.round(diffH / 24)
     if (diffD < 7) return t('clinicalNotes.time.daysAgo', { n: diffD })
-    return new Date(iso).toLocaleDateString()
+    return new Date(iso).toLocaleDateString(locale.value)
   } catch {
     return iso
   }
@@ -68,7 +68,7 @@ function formatRelative(iso: string): string {
 
 function formatAbsolute(iso: string): string {
   try {
-    return new Date(iso).toLocaleString()
+    return new Date(iso).toLocaleString(locale.value)
   } catch {
     return iso
   }

--- a/backend/app/modules/clinical_notes/frontend/components/NoteComposer.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/NoteComposer.vue
@@ -80,7 +80,7 @@ function attachmentIcon(doc: Document): string {
   return 'i-lucide-paperclip'
 }
 
-const { t } = useI18n()
+const { t, te } = useI18n()
 const { metaFor } = useNoteTypeMeta()
 const { listTemplates } = useClinicalNotes()
 
@@ -110,7 +110,7 @@ async function refreshTemplates() {
 }
 
 function applyTemplate(tpl: NoteTemplate) {
-  const resolvedBody = t(tpl.body_i18n_key) || tpl.body
+  const resolvedBody = te(tpl.body_i18n_key) ? t(tpl.body_i18n_key) : tpl.body
   if (body.value.trim()) {
     body.value = `${body.value.trim()}\n\n${resolvedBody}`
   } else {

--- a/backend/app/modules/clinical_notes/frontend/components/NoteComposer.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/NoteComposer.vue
@@ -110,10 +110,11 @@ async function refreshTemplates() {
 }
 
 function applyTemplate(tpl: NoteTemplate) {
+  const resolvedBody = t(tpl.body_i18n_key) || tpl.body
   if (body.value.trim()) {
-    body.value = `${body.value.trim()}\n\n${tpl.body}`
+    body.value = `${body.value.trim()}\n\n${resolvedBody}`
   } else {
-    body.value = tpl.body
+    body.value = resolvedBody
   }
 }
 
@@ -200,7 +201,7 @@ watch(category, refreshTemplates)
           <button
             type="button"
             class="ml-1"
-            :aria-label="t('actions.remove', 'Quitar')"
+            :aria-label="t('actions.remove')"
             @click="removeAttached(doc.id)"
           >
             <UIcon

--- a/backend/app/modules/clinical_notes/frontend/components/PatientClinicalNotesByPlan.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/PatientClinicalNotesByPlan.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
   ctx: { patientId: string }
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { listGroupedForPatient } = useClinicalNotes()
 
 const groups = ref<PlanNotesGroup[]>([])
@@ -35,7 +35,7 @@ watch(() => props.ctx?.patientId, refresh, { immediate: true })
 
 function formatDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleString()
+    return new Date(iso).toLocaleString(locale.value)
   } catch {
     return iso
   }

--- a/backend/app/modules/clinical_notes/frontend/components/PlanNotesTimeline.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/PlanNotesTimeline.vue
@@ -259,7 +259,7 @@ function resolveTreatmentName(item: PlannedTreatmentItem): string | null {
 
 function formatDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleString()
+    return new Date(iso).toLocaleString(locale.value)
   } catch {
     return iso
   }

--- a/backend/app/modules/clinical_notes/frontend/i18n/locales/en.json
+++ b/backend/app/modules/clinical_notes/frontend/i18n/locales/en.json
@@ -54,6 +54,7 @@
     "composer": {
       "placeholder": "Write the note…",
       "templates": "Templates",
+      "attach": "Attach photo or document",
       "bindToTooth": "Attach to tooth {n}"
     },
     "linked": {
@@ -107,6 +108,17 @@
       "general": {
         "followUp": "General follow-up"
       }
+    },
+    "templateBodies": {
+      "endo_single_visit": "Diagnosis: \nAnesthesia: \nCanals located: \nWorking length: \nObturation: \nPost-op: ",
+      "endo_multi_visit": "Session: \nCanals worked: \nIntracanal medication: \nNext appointment: ",
+      "perio_scaling": "Quadrants treated: \nProbing depth: \nBleeding on probing: \nHygiene instructions: ",
+      "implant_placement": "Implant (brand / diameter / length): \nFinal torque (Ncm): \nPrimary stability: \nGraft: \nPost-op: ",
+      "diagnosis_caries": "Finding: caries \nDepth: \nSymptoms: \nVitality test: \nSuggested treatment: ",
+      "diagnosis_periapical": "Periapical lesion \nTooth: \nX-ray: \nTests (percussion, palpation): \nDiagnosis: ",
+      "admin_phone_call": "Patient call: \nReason: \nAction taken: \nFollow-up: ",
+      "admin_reschedule": "Reschedule request: \nCurrent date: \nNew proposal: ",
+      "general_follow_up": "Findings: \nProcedure performed: \nPatient instructions: "
     }
   }
 }

--- a/backend/app/modules/clinical_notes/frontend/i18n/locales/es.json
+++ b/backend/app/modules/clinical_notes/frontend/i18n/locales/es.json
@@ -54,6 +54,7 @@
     "composer": {
       "placeholder": "Escribe la nota…",
       "templates": "Plantillas",
+      "attach": "Adjuntar foto o documento",
       "bindToTooth": "Asociar al diente {n}"
     },
     "linked": {
@@ -107,6 +108,17 @@
       "general": {
         "followUp": "Seguimiento general"
       }
+    },
+    "templateBodies": {
+      "endo_single_visit": "Diagnóstico: \nAnestesia: \nCanales localizados: \nLongitud de trabajo: \nObturación: \nPost-op: ",
+      "endo_multi_visit": "Sesión: \nCanales trabajados: \nMedicación intracanala: \nPróxima cita: ",
+      "perio_scaling": "Cuadrantes tratados: \nProfundidad de sondaje: \nSangrado al sondaje: \nIndicaciones higiene: ",
+      "implant_placement": "Implante (marca / diámetro / longitud): \nTorque final (Ncm): \nEstabilidad primaria: \nInjerto: \nPost-op: ",
+      "diagnosis_caries": "Hallazgo: caries \nProfundidad: \nSíntomas: \nPrueba de vitalidad: \nTratamiento sugerido: ",
+      "diagnosis_periapical": "Lesión periapical \nDiente: \nRadiografía: \nPruebas (percusión, palpación): \nDiagnóstico: ",
+      "admin_phone_call": "Llamada del paciente: \nMotivo: \nAcción tomada: \nSeguimiento: ",
+      "admin_reschedule": "Solicita cambio de cita: \nFecha actual: \nNueva propuesta: ",
+      "general_follow_up": "Hallazgos: \nProcedimiento realizado: \nIndicaciones al paciente: "
     }
   }
 }

--- a/backend/app/modules/clinical_notes/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/clinical_notes/frontend/i18n/locales/fr.json
@@ -1,0 +1,124 @@
+{
+  "clinicalNotes": {
+    "types": {
+      "administrative": "Administratif",
+      "diagnosis": "Diagnostique",
+      "treatment": "Traitement",
+      "treatment_plan": "Plan",
+      "appointment_clinical": "Clinique",
+      "appointment_administrative": "Administratif"
+    },
+    "appointment": {
+      "addByType": "Ajouter une note {label}",
+      "empty": "Aucune note sur ce rendez-vous pour le moment. Utilisez les boutons ci-dessus pour en ajouter une."
+    },
+    "feed": {
+      "filterLabel": "Filtres",
+      "filterAll": "Toutes",
+      "filterClear": "Effacer les filtres",
+      "filterStatus": "Affichage de {n} sur {total} types",
+      "addAdministrative": "Note administrative",
+      "loadMore": "Charger plus",
+      "empty": {
+        "title": "Aucune note pour le moment",
+        "help": "Les notes administratives, de diagnostique et de traitement apparaîtront ici par ordre chronologique."
+      }
+    },
+    "diagnosisSidebar": {
+      "title": "Notes",
+      "addNote": "Ajouter une note",
+      "empty": "Aucune note dans cette catégorie."
+    },
+    "treatmentButton": {
+      "title": "Notes de traitement",
+      "add": "Ajouter une note",
+      "empty": "Aucune note sur ce traitement pour le moment.",
+      "aria": "Notes de traitement ({n})"
+    },
+    "timeline": {
+      "addPlanNote": "Note de plan",
+      "empty": "Aucune note pour le moment.",
+      "emptyForFilter": "Aucune note ne correspond au filtre.",
+      "source": {
+        "plan": "Plan",
+        "treatment": "Traitement",
+        "visit": "Visite"
+      }
+    },
+    "byPlan": {
+      "empty": "Ce patient n'a pas encore de notes cliniques liées à un plan.",
+      "planNotesLabel": "Notes du plan",
+      "unknownTreatment": "Traitement",
+      "noNotesForTreatment": "Aucune note sur ce traitement pour le moment."
+    },
+    "composer": {
+      "placeholder": "Écrivez la note…",
+      "templates": "Modèles",
+      "attach": "Joindre une photo ou un document",
+      "bindToTooth": "Attacher à la dent {n}"
+    },
+    "linked": {
+      "tooth": "Dent {n}",
+      "treatment": "Traitement",
+      "treatmentOnTooth": "{label} (dent {n})",
+      "plan": "Plan",
+      "planNamed": "Plan : {label}"
+    },
+    "actions": {
+      "showMore": "Afficher plus",
+      "showLess": "Afficher moins",
+      "openLinked": "Ouvrir le contexte"
+    },
+    "author": {
+      "unknown": "Auteur inconnu"
+    },
+    "time": {
+      "justNow": "à l'instant",
+      "minutesAgo": "il y a {n} min",
+      "hoursAgo": "il y a {n} h",
+      "daysAgo": "il y a {n} j"
+    },
+    "toasts": {
+      "saved": "Note enregistrée",
+      "deleted": "Note supprimée",
+      "saveFailed": "Impossible d'enregistrer la note"
+    },
+    "confirms": {
+      "delete": "Supprimer cette note ? La récupération nécessite de contacter le support."
+    },
+    "templates": {
+      "endo": {
+        "singleVisit": "Endodontie (visite unique)",
+        "multiVisit": "Endodontie (visites multiples)"
+      },
+      "perio": {
+        "scaling": "Détartrage / RAR"
+      },
+      "implant": {
+        "placement": "Pose d'implant"
+      },
+      "diagnosis": {
+        "caries": "Carie",
+        "periapical": "Lésion périapicale"
+      },
+      "admin": {
+        "phoneCall": "Appel téléphonique du patient",
+        "reschedule": "Demande de report"
+      },
+      "general": {
+        "followUp": "Suivi général"
+      }
+    },
+    "templateBodies": {
+      "endo_single_visit": "Diagnostique : \nAnesthésie : \nCanaux localisés : \nLongueur de travail : \nObturation : \nPost-op : ",
+      "endo_multi_visit": "Séance : \nCanaux traités : \nMédicament intracanalaire : \nProchain rendez-vous : ",
+      "perio_scaling": "Quadrants traités : \nProfondeur de sondage : \nSangrado au sondage : \nConsignes d'hygiène : ",
+      "implant_placement": "Implant (marque / diamètre / longueur) : \nCouple final (Ncm) : \nStabilité primaire : \nGreffe : \nPost-op : ",
+      "diagnosis_caries": "Observation : carie \nProfondeur : \nSymptômes : \nTest de vitalité : \nTraitement suggéré : ",
+      "diagnosis_periapical": "Lésion périapicale \nDent : \nRadiographie : \nPercussion, palpation : \nDiagnostique : ",
+      "admin_phone_call": "Appel du patient : \nMotif : \nAction entreprise : \nSuivi : ",
+      "admin_reschedule": "Demande de report : \nDate actuelle : \nNouvelle proposition : ",
+      "general_follow_up": "Observations : \nProcédure réalisée : \nConsignes au patient : "
+    }
+  }
+}

--- a/backend/app/modules/clinical_notes/frontend/nuxt.config.ts
+++ b/backend/app/modules/clinical_notes/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/clinical_notes/note_templates.py
+++ b/backend/app/modules/clinical_notes/note_templates.py
@@ -17,6 +17,7 @@ from typing import Final, TypedDict
 class NoteTemplate(TypedDict):
     id: str
     i18n_key: str
+    body_i18n_key: str
     body: str
 
 
@@ -25,6 +26,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "endo_single_visit",
             "i18n_key": "clinicalNotes.templates.endo.singleVisit",
+            "body_i18n_key": "clinicalNotes.templateBodies.endo_single_visit",
             "body": (
                 "Diagnóstico: \n"
                 "Anestesia: \n"
@@ -37,6 +39,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "endo_multi_visit",
             "i18n_key": "clinicalNotes.templates.endo.multiVisit",
+            "body_i18n_key": "clinicalNotes.templateBodies.endo_multi_visit",
             "body": (
                 "Sesión: \nConductos trabajados: \nMedicación intraconducto: \nPróxima cita: "
             ),
@@ -46,6 +49,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "perio_scaling",
             "i18n_key": "clinicalNotes.templates.perio.scaling",
+            "body_i18n_key": "clinicalNotes.templateBodies.perio_scaling",
             "body": (
                 "Cuadrantes tratados: \n"
                 "Profundidad de sondaje: \n"
@@ -58,6 +62,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "implant_placement",
             "i18n_key": "clinicalNotes.templates.implant.placement",
+            "body_i18n_key": "clinicalNotes.templateBodies.implant_placement",
             "body": (
                 "Implante (marca / diámetro / longitud): \n"
                 "Torque final (Ncm): \n"
@@ -71,6 +76,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "diagnosis_caries",
             "i18n_key": "clinicalNotes.templates.diagnosis.caries",
+            "body_i18n_key": "clinicalNotes.templateBodies.diagnosis_caries",
             "body": (
                 "Hallazgo: caries \nProfundidad: \nSíntomas: \nPrueba de vitalidad: \n"
                 "Tratamiento sugerido: "
@@ -79,6 +85,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "diagnosis_periapical",
             "i18n_key": "clinicalNotes.templates.diagnosis.periapical",
+            "body_i18n_key": "clinicalNotes.templateBodies.diagnosis_periapical",
             "body": (
                 "Lesión periapical \nDiente: \nRadiografía: \n"
                 "Pruebas (percusión, palpación): \nDiagnóstico: "
@@ -89,11 +96,13 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "admin_phone_call",
             "i18n_key": "clinicalNotes.templates.admin.phoneCall",
+            "body_i18n_key": "clinicalNotes.templateBodies.admin_phone_call",
             "body": "Llamada del paciente: \nMotivo: \nAcción tomada: \nSeguimiento: ",
         },
         {
             "id": "admin_reschedule",
             "i18n_key": "clinicalNotes.templates.admin.reschedule",
+            "body_i18n_key": "clinicalNotes.templateBodies.admin_reschedule",
             "body": "Solicita cambio de cita: \nFecha actual: \nNueva propuesta: ",
         },
     ],
@@ -101,6 +110,7 @@ NOTE_TEMPLATES: Final[dict[str, list[NoteTemplate]]] = {
         {
             "id": "general_follow_up",
             "i18n_key": "clinicalNotes.templates.general.followUp",
+            "body_i18n_key": "clinicalNotes.templateBodies.general_follow_up",
             "body": "Hallazgos: \nProcedimiento realizado: \nIndicaciones al paciente: ",
         },
     ],

--- a/backend/app/modules/clinical_notes/router.py
+++ b/backend/app/modules/clinical_notes/router.py
@@ -383,6 +383,7 @@ async def list_note_templates(
                     id=tpl["id"],
                     category=category,
                     i18n_key=tpl["i18n_key"],
+                    body_i18n_key=tpl["body_i18n_key"],
                     body=tpl["body"],
                 )
             )
@@ -394,6 +395,7 @@ async def list_note_templates(
                         id=tpl["id"],
                         category=cat,
                         i18n_key=tpl["i18n_key"],
+                        body_i18n_key=tpl["body_i18n_key"],
                         body=tpl["body"],
                     )
                 )

--- a/backend/app/modules/clinical_notes/schemas.py
+++ b/backend/app/modules/clinical_notes/schemas.py
@@ -236,6 +236,7 @@ class NoteTemplateResponse(BaseModel):
     id: str
     category: str
     i18n_key: str
+    body_i18n_key: str
     body: str
 
 

--- a/backend/app/modules/clinical_notes/seed.py
+++ b/backend/app/modules/clinical_notes/seed.py
@@ -36,206 +36,152 @@ from .models import (
     ClinicalNote,
 )
 
-# UI strings stay in Spanish per project convention (CLAUDE.md).
+# Translation dicts resolved via t() at seed time — after set_language().
 _ADMIN_BODIES = (
-    t(
-        {
-            "es": "Prefiere citas por la tarde. Avisar 24h antes para confirmar.",
-            "en": "Prefers afternoon appointments. Notify 24h before to confirm.",
-            "fr": "Préfère les rendez-vous l'après-midi. Prévenir 24h avant pour confirmer.",
-        }
-    ),
-    t(
-        {
-            "es": "Llamar siempre al móvil; no responde al fijo.",
-            "en": "Always call mobile; does not answer landline.",
-            "fr": "Appeler toujours le portable ; ne répond pas au fixe.",
-        }
-    ),
-    t(
-        {
-            "es": "Pago habitual con tarjeta. Solicita factura simplificada.",
-            "en": "Usually pays by card. Requests simplified invoice.",
-            "fr": "Paiement habituel par carte. Demande une facture simplifiée.",
-        }
-    ),
-    t(
-        {
-            "es": "Acude acompañado/a de un familiar; documentar consentimiento.",
-            "en": "Attends with a family member; document consent.",
-            "fr": "Vient accompagné(e) d'un membre de la famille ; documenter le consentement.",
-        }
-    ),
-    t(
-        {
-            "es": "Idioma preferido para comunicaciones: español.",
-            "en": "Preferred language for communications: Spanish.",
-            "fr": "Langue préférée pour les communications : espagnol.",
-        }
-    ),
-    t(
-        {
-            "es": "Solicita recordatorio por WhatsApp el día anterior.",
-            "en": "Requests WhatsApp reminder the day before.",
-            "fr": "Demande un rappel par WhatsApp la veille.",
-        }
-    ),
-    t(
-        {
-            "es": "Tiene movilidad reducida; reservar cabinete accesible.",
-            "en": "Has reduced mobility; reserve accessible room.",
-            "fr": "Mobilité réduite ; réserver le cabinet accessible.",
-        }
-    ),
+    {
+        "es": "Prefiere citas por la tarde. Avisar 24h antes para confirmar.",
+        "en": "Prefers afternoon appointments. Notify 24h before to confirm.",
+        "fr": "Préfère les rendez-vous l'après-midi. Prévenir 24h avant pour confirmer.",
+    },
+    {
+        "es": "Llamar siempre al móvil; no responde al fijo.",
+        "en": "Always call mobile; does not answer landline.",
+        "fr": "Appeler toujours le portable ; ne répond pas au fixe.",
+    },
+    {
+        "es": "Pago habitual con tarjeta. Solicita factura simplificada.",
+        "en": "Usually pays by card. Requests simplified invoice.",
+        "fr": "Paiement habituel par carte. Demande une facture simplifiée.",
+    },
+    {
+        "es": "Acude acompañado/a de un familiar; documentar consentimiento.",
+        "en": "Attends with a family member; document consent.",
+        "fr": "Vient accompagné(e) d'un membre de la famille ; documenter le consentement.",
+    },
+    {
+        "es": "Idioma preferido para comunicaciones: español.",
+        "en": "Preferred language for communications: Spanish.",
+        "fr": "Langue préférée pour les communications : espagnol.",
+    },
+    {
+        "es": "Solicita recordatorio por WhatsApp el día anterior.",
+        "en": "Requests WhatsApp reminder the day before.",
+        "fr": "Demande un rappel par WhatsApp la veille.",
+    },
+    {
+        "es": "Tiene movilidad reducida; reservar cabinete accesible.",
+        "en": "Has reduced mobility; reserve accessible room.",
+        "fr": "Mobilité réduite ; réserver le cabinet accessible.",
+    },
 )
 
 _DIAGNOSIS_BODIES = (
-    t(
-        {
-            "es": "Caries oclusal incipiente; valorar empaste en próxima visita.",
-            "en": "Incipient occlusal caries; evaluate filling at next visit.",
-            "fr": "Carie occlusale naissante ; évaluer l'obturation à la prochaine visite.",
-        }
-    ),
-    t(
-        {
-            "es": "Movilidad grado I y sospecha de absceso periapical. Solicitar radiografía periapical.",
-            "en": "Grade I mobility and suspected periapical abscess. Request periapical X-ray.",
-            "fr": "Mobilité grade I et suspicion d'abcès périapical. Demander une radiographie périapicale.",
-        }
-    ),
-    t(
-        {
-            "es": "Sensibilidad al frío en el cuadrante; descartar recesión gingival.",
-            "en": "Cold sensitivity in quadrant; rule out gingival recession.",
-            "fr": "Sensibilité au froid dans le quadrant ; éliminer la récession gingivale.",
-        }
-    ),
-    t(
-        {
-            "es": "Bruxismo evidente con desgaste oclusal generalizado. Considerar férula de descarga.",
-            "en": "Evident bruxism with generalized occlusal wear. Consider occlusal splint.",
-            "fr": "Bruxisme évident avec usure occlusale généralisée. Envisager une gouttière d'occlusion.",
-        }
-    ),
-    t(
-        {
-            "es": "Encía inflamada con sangrado al sondaje. Refuerzo de higiene oral.",
-            "en": "Inflamed gums with bleeding on probing. Oral hygiene reinforcement.",
-            "fr": "Gencives enflammées avec saignement au sondage. Renforcement de l'hygiène buccale.",
-        }
-    ),
-    t(
-        {
-            "es": "Restauración antigua filtrada; recomendar sustitución.",
-            "en": "Leaky old restoration; recommend replacement.",
-            "fr": "Obturation ancienne fuyante ; recommander le remplacement.",
-        }
-    ),
-    t(
-        {
-            "es": "Tercer molar incluido sin sintomatología actual; mantener en observación.",
-            "en": "Impacted third molar, currently asymptomatic; keep under observation.",
-            "fr": "Troisième molaire inclus, actuellement asymptomatique ; maintenir sous observation.",
-        }
-    ),
+    {
+        "es": "Caries oclusal incipiente; valorar empaste en próxima visita.",
+        "en": "Incipient occlusal caries; evaluate filling at next visit.",
+        "fr": "Carie occlusale naissante ; évaluer l'obturation à la prochaine visite.",
+    },
+    {
+        "es": "Movilidad grado I y sospecha de absceso periapical. Solicitar radiografía periapical.",
+        "en": "Grade I mobility and suspected periapical abscess. Request periapical X-ray.",
+        "fr": "Mobilité grade I et suspicion d'abcès périapical. Demander une radiographie périapicale.",
+    },
+    {
+        "es": "Sensibilidad al frío en el cuadrante; descartar recesión gingival.",
+        "en": "Cold sensitivity in quadrant; rule out gingival recession.",
+        "fr": "Sensibilité au froid dans le quadrant ; éliminer la récession gingivale.",
+    },
+    {
+        "es": "Bruxismo evidente con desgaste oclusal generalizado. Considerar férula de descarga.",
+        "en": "Evident bruxism with generalized occlusal wear. Consider occlusal splint.",
+        "fr": "Bruxisme évident avec usure occlusale généralisée. Envisager une gouttière d'occlusion.",
+    },
+    {
+        "es": "Encía inflamada con sangrado al sondaje. Refuerzo de higiene oral.",
+        "en": "Inflamed gums with bleeding on probing. Oral hygiene reinforcement.",
+        "fr": "Gencives enflammées avec saignement au sondage. Renforcement de l'hygiène buccale.",
+    },
+    {
+        "es": "Restauración antigua filtrada; recomendar sustitución.",
+        "en": "Leaky old restoration; recommend replacement.",
+        "fr": "Obturation ancienne fuyante ; recommander le remplacement.",
+    },
+    {
+        "es": "Tercer molar incluido sin sintomatología actual; mantener en observación.",
+        "en": "Impacted third molar, currently asymptomatic; keep under observation.",
+        "fr": "Troisième molaire inclus, actuellement asymptomatique ; maintenir sous observation.",
+    },
 )
 
 _TREATMENT_BODIES = (
-    t(
-        {
-            "es": "Se aplica anestesia local (articaína 4% con epinefrina 1:100.000) sin incidencias.",
-            "en": "Local anesthesia applied (articaine 4% with epinephrine 1:100,000) without incident.",
-            "fr": "Anesthésie locale appliquée (articaine 4% avec épinéphrine 1:100 000) sans incident.",
-        }
-    ),
-    t(
-        {
-            "es": "Apertura cameral e irrigación con hipoclorito sódico al 5,25%. Localizados 3 conductos.",
-            "en": "Chamber access and irrigation with 5.25% sodium hypochlorite. 3 canals located.",
-            "fr": "Ouverture pulpaire et irrigation à l'hypochlorite de sodium 5,25 %. 3 canaux localisés.",
-        }
-    ),
-    t(
-        {
-            "es": "Adaptación marginal correcta tras pulido. Paciente refiere ausencia de molestias.",
-            "en": "Correct marginal adaptation after polishing. Patient reports no discomfort.",
-            "fr": "Adaptation marginale correcte après polissage. Patient déclare absence de gêne.",
-        }
-    ),
-    t(
-        {
-            "es": "Se coloca dique de goma para aislamiento absoluto. Buena cooperación del paciente.",
-            "en": "Rubber dam placed for absolute isolation. Good patient cooperation.",
-            "fr": "Digue en place pour l'isolement absolu. Bonne coopération du patient.",
-        }
-    ),
-    t(
-        {
-            "es": "Se recomienda cita de control en dos semanas para revisar oclusión.",
-            "en": "Follow-up appointment recommended in two weeks to check occlusion.",
-            "fr": "Rendez-vous de contrôle recommandé dans deux semaines pour vérifier l'occlusion.",
-        }
-    ),
-    t(
-        {
-            "es": "Procedimiento sin complicaciones. Indicaciones postoperatorias entregadas.",
-            "en": "Procedure without complications. Post-operative instructions given.",
-            "fr": "Procédure sans complications. Consignes post-opératoires remises.",
-        }
-    ),
-    t(
-        {
-            "es": "Cementado definitivo con cemento de ionómero de vidrio. Ajuste oclusal verificado.",
-            "en": "Permanent cementation with glass ionomer cement. Occlusal adjustment verified.",
-            "fr": "Cimentation définitive au ciment verre ionomère. Réglage occlusal vérifié.",
-        }
-    ),
+    {
+        "es": "Se aplica anestesia local (articaína 4% con epinefrina 1:100.000) sin incidencias.",
+        "en": "Local anesthesia applied (articaine 4% with epinephrine 1:100,000) without incident.",
+        "fr": "Anesthésie locale appliquée (articaine 4% avec épinéphrine 1:100 000) sans incident.",
+    },
+    {
+        "es": "Apertura cameral e irrigación con hipoclorito sódico al 5,25%. Localizados 3 conductos.",
+        "en": "Chamber access and irrigation with 5.25% sodium hypochlorite. 3 canals located.",
+        "fr": "Ouverture pulpaire et irrigation à l'hypochlorite de sodium 5,25 %. 3 canaux localisés.",
+    },
+    {
+        "es": "Adaptación marginal correcta tras pulido. Paciente refiere ausencia de molestias.",
+        "en": "Correct marginal adaptation after polishing. Patient reports no discomfort.",
+        "fr": "Adaptation marginale correcte après polissage. Patient déclare absence de gêne.",
+    },
+    {
+        "es": "Se coloca dique de goma para aislamiento absoluto. Buena cooperación del paciente.",
+        "en": "Rubber dam placed for absolute isolation. Good patient cooperation.",
+        "fr": "Digue en place pour l'isolement absolu. Bonne coopération du patient.",
+    },
+    {
+        "es": "Se recomienda cita de control en dos semanas para revisar oclusión.",
+        "en": "Follow-up appointment recommended in two weeks to check occlusion.",
+        "fr": "Rendez-vous de contrôle recommandé dans deux semaines pour vérifier l'occlusion.",
+    },
+    {
+        "es": "Procedimiento sin complicaciones. Indicaciones postoperatorias entregadas.",
+        "en": "Procedure without complications. Post-operative instructions given.",
+        "fr": "Procédure sans complications. Consignes post-opératoires remises.",
+    },
+    {
+        "es": "Cementado definitivo con cemento de ionómero de vidrio. Ajuste oclusal verificado.",
+        "en": "Permanent cementation with glass ionomer cement. Occlusal adjustment verified.",
+        "fr": "Cimentation définitive au ciment verre ionomère. Réglage occlusal vérifié.",
+    },
 )
 
 _PLAN_BODIES = (
-    t(
-        {
-            "es": "Plan acordado con el paciente. Priorizar tratamientos urgentes en cuadrante superior derecho.",
-            "en": "Plan agreed with patient. Prioritize urgent treatments in the upper right quadrant.",
-            "fr": "Plan convenu avec le patient. Prioriser les traitements urgents dans le quadrant supérieur droit.",
-        }
-    ),
-    t(
-        {
-            "es": "Paciente solicita financiación; gestionar opción a 6 meses sin intereses.",
-            "en": "Patient requests financing; arrange 6-month interest-free option.",
-            "fr": "Patient demande un financement ; organiser l'option 6 mois sans intérêts.",
-        }
-    ),
-    t(
-        {
-            "es": "Se acuerda iniciar fase higiénica antes de los tratamientos restauradores.",
-            "en": "Hygiene phase agreed before restorative treatments.",
-            "fr": "Phase d'hygiène convenue avant les traitements restaurateurs.",
-        }
-    ),
-    t(
-        {
-            "es": "Pendiente de presentación al cónyuge; confirmará aceptación tras consulta familiar.",
-            "en": "Pending presentation to spouse; will confirm acceptance after family consultation.",
-            "fr": "En attente de présentation au conjoint ; confirmera l'acceptation après consultation familiale.",
-        }
-    ),
-    t(
-        {
-            "es": "Se aplica descuento del 10% por tratamiento integral.",
-            "en": "10% discount applied for comprehensive treatment.",
-            "fr": "Remise de 10 % appliquée pour le traitement global.",
-        }
-    ),
-    t(
-        {
-            "es": "Paciente prefiere posponer la fase estética hasta después del verano.",
-            "en": "Patient prefers to postpone the aesthetic phase until after summer.",
-            "fr": "Patient préfère reporter la phase esthétique après l'été.",
-        }
-    ),
+    {
+        "es": "Plan acordado con el paciente. Priorizar tratamientos urgentes en cuadrante superior derecho.",
+        "en": "Plan agreed with patient. Prioritize urgent treatments in the upper right quadrant.",
+        "fr": "Plan convenu avec le patient. Prioriser les traitements urgents dans le quadrant supérieur droit.",
+    },
+    {
+        "es": "Paciente solicita financiación; gestionar opción a 6 meses sin intereses.",
+        "en": "Patient requests financing; arrange 6-month interest-free option.",
+        "fr": "Patient demande un financement ; organiser l'option 6 mois sans intérêts.",
+    },
+    {
+        "es": "Se acuerda iniciar fase higiénica antes de los tratamientos restauradores.",
+        "en": "Hygiene phase agreed before restorative treatments.",
+        "fr": "Phase d'hygiène convenue avant les traitements restaurateurs.",
+    },
+    {
+        "es": "Pendiente de presentación al cónyuge; confirmará aceptación tras consulta familiar.",
+        "en": "Pending presentation to spouse; will confirm acceptance after family consultation.",
+        "fr": "En attente de présentation au conjoint ; confirmera l'acceptation après consultation familiale.",
+    },
+    {
+        "es": "Se aplica descuento del 10% por tratamiento integral.",
+        "en": "10% discount applied for comprehensive treatment.",
+        "fr": "Remise de 10 % appliquée pour le traitement global.",
+    },
+    {
+        "es": "Paciente prefiere posponer la fase estética hasta después del verano.",
+        "en": "Patient prefers to postpone the aesthetic phase until after summer.",
+        "fr": "Patient préfère reporter la phase esthétique après l'été.",
+    },
 )
 
 
@@ -285,7 +231,7 @@ async def seed_clinical_notes_demo(
                 owner_type=NOTE_OWNER_PATIENT,
                 owner_id=patient.id,
                 tooth_number=None,
-                body=_ADMIN_BODIES[cursor % len(_ADMIN_BODIES)],
+                body=t(_ADMIN_BODIES[cursor % len(_ADMIN_BODIES)]),
                 author_id=author(cursor),
                 created_at=admin_at,
                 updated_at=admin_at,
@@ -302,7 +248,7 @@ async def seed_clinical_notes_demo(
                 owner_type=NOTE_OWNER_PATIENT,
                 owner_id=patient.id,
                 tooth_number=tooth_by_patient.get(patient.id),
-                body=_DIAGNOSIS_BODIES[cursor % len(_DIAGNOSIS_BODIES)],
+                body=t(_DIAGNOSIS_BODIES[cursor % len(_DIAGNOSIS_BODIES)]),
                 author_id=author(cursor),
                 created_at=diag_at,
                 updated_at=diag_at,
@@ -328,7 +274,7 @@ async def seed_clinical_notes_demo(
                 owner_type=NOTE_OWNER_PLAN,
                 owner_id=plan.id,
                 tooth_number=None,
-                body=_PLAN_BODIES[cursor % len(_PLAN_BODIES)],
+                body=t(_PLAN_BODIES[cursor % len(_PLAN_BODIES)]),
                 author_id=author(cursor),
                 created_at=plan_at,
                 updated_at=plan_at,
@@ -355,7 +301,7 @@ async def seed_clinical_notes_demo(
                 owner_type=NOTE_OWNER_TREATMENT,
                 owner_id=tx.id,
                 tooth_number=None,
-                body=_TREATMENT_BODIES[cursor % len(_TREATMENT_BODIES)],
+                body=t(_TREATMENT_BODIES[cursor % len(_TREATMENT_BODIES)]),
                 author_id=author(cursor),
                 created_at=tx_at,
                 updated_at=tx_at,

--- a/backend/app/modules/clinical_notes/seed.py
+++ b/backend/app/modules/clinical_notes/seed.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.modules.odontogram.models import Treatment, TreatmentTooth
 from app.modules.patients.models import Patient
 from app.modules.treatment_plan.models import TreatmentPlan
+from app.seeds.demo_data import t
 
 from .models import (
     NOTE_OWNER_PATIENT,
@@ -37,42 +38,204 @@ from .models import (
 
 # UI strings stay in Spanish per project convention (CLAUDE.md).
 _ADMIN_BODIES = (
-    "Prefiere citas por la tarde. Avisar 24h antes para confirmar.",
-    "Llamar siempre al móvil; no responde al fijo.",
-    "Pago habitual con tarjeta. Solicita factura simplificada.",
-    "Acude acompañado/a de un familiar; documentar consentimiento.",
-    "Idioma preferido para comunicaciones: español.",
-    "Solicita recordatorio por WhatsApp el día anterior.",
-    "Tiene movilidad reducida; reservar cabinete accesible.",
+    t(
+        {
+            "es": "Prefiere citas por la tarde. Avisar 24h antes para confirmar.",
+            "en": "Prefers afternoon appointments. Notify 24h before to confirm.",
+            "fr": "Préfère les rendez-vous l'après-midi. Prévenir 24h avant pour confirmer.",
+        }
+    ),
+    t(
+        {
+            "es": "Llamar siempre al móvil; no responde al fijo.",
+            "en": "Always call mobile; does not answer landline.",
+            "fr": "Appeler toujours le portable ; ne répond pas au fixe.",
+        }
+    ),
+    t(
+        {
+            "es": "Pago habitual con tarjeta. Solicita factura simplificada.",
+            "en": "Usually pays by card. Requests simplified invoice.",
+            "fr": "Paiement habituel par carte. Demande une facture simplifiée.",
+        }
+    ),
+    t(
+        {
+            "es": "Acude acompañado/a de un familiar; documentar consentimiento.",
+            "en": "Attends with a family member; document consent.",
+            "fr": "Vient accompagné(e) d'un membre de la famille ; documenter le consentement.",
+        }
+    ),
+    t(
+        {
+            "es": "Idioma preferido para comunicaciones: español.",
+            "en": "Preferred language for communications: Spanish.",
+            "fr": "Langue préférée pour les communications : espagnol.",
+        }
+    ),
+    t(
+        {
+            "es": "Solicita recordatorio por WhatsApp el día anterior.",
+            "en": "Requests WhatsApp reminder the day before.",
+            "fr": "Demande un rappel par WhatsApp la veille.",
+        }
+    ),
+    t(
+        {
+            "es": "Tiene movilidad reducida; reservar cabinete accesible.",
+            "en": "Has reduced mobility; reserve accessible room.",
+            "fr": "Mobilité réduite ; réserver le cabinet accessible.",
+        }
+    ),
 )
 
 _DIAGNOSIS_BODIES = (
-    "Caries oclusal incipiente; valorar empaste en próxima visita.",
-    "Movilidad grado I y sospecha de absceso periapical. Solicitar radiografía periapical.",
-    "Sensibilidad al frío en el cuadrante; descartar recesión gingival.",
-    "Bruxismo evidente con desgaste oclusal generalizado. Considerar férula de descarga.",
-    "Encía inflamada con sangrado al sondaje. Refuerzo de higiene oral.",
-    "Restauración antigua filtrada; recomendar sustitución.",
-    "Tercer molar incluido sin sintomatología actual; mantener en observación.",
+    t(
+        {
+            "es": "Caries oclusal incipiente; valorar empaste en próxima visita.",
+            "en": "Incipient occlusal caries; evaluate filling at next visit.",
+            "fr": "Carie occlusale naissante ; évaluer l'obturation à la prochaine visite.",
+        }
+    ),
+    t(
+        {
+            "es": "Movilidad grado I y sospecha de absceso periapical. Solicitar radiografía periapical.",
+            "en": "Grade I mobility and suspected periapical abscess. Request periapical X-ray.",
+            "fr": "Mobilité grade I et suspicion d'abcès périapical. Demander une radiographie périapicale.",
+        }
+    ),
+    t(
+        {
+            "es": "Sensibilidad al frío en el cuadrante; descartar recesión gingival.",
+            "en": "Cold sensitivity in quadrant; rule out gingival recession.",
+            "fr": "Sensibilité au froid dans le quadrant ; éliminer la récession gingivale.",
+        }
+    ),
+    t(
+        {
+            "es": "Bruxismo evidente con desgaste oclusal generalizado. Considerar férula de descarga.",
+            "en": "Evident bruxism with generalized occlusal wear. Consider occlusal splint.",
+            "fr": "Bruxisme évident avec usure occlusale généralisée. Envisager une gouttière d'occlusion.",
+        }
+    ),
+    t(
+        {
+            "es": "Encía inflamada con sangrado al sondaje. Refuerzo de higiene oral.",
+            "en": "Inflamed gums with bleeding on probing. Oral hygiene reinforcement.",
+            "fr": "Gencives enflammées avec saignement au sondage. Renforcement de l'hygiène buccale.",
+        }
+    ),
+    t(
+        {
+            "es": "Restauración antigua filtrada; recomendar sustitución.",
+            "en": "Leaky old restoration; recommend replacement.",
+            "fr": "Obturation ancienne fuyante ; recommander le remplacement.",
+        }
+    ),
+    t(
+        {
+            "es": "Tercer molar incluido sin sintomatología actual; mantener en observación.",
+            "en": "Impacted third molar, currently asymptomatic; keep under observation.",
+            "fr": "Troisième molaire inclus, actuellement asymptomatique ; maintenir sous observation.",
+        }
+    ),
 )
 
 _TREATMENT_BODIES = (
-    "Se aplica anestesia local (articaína 4% con epinefrina 1:100.000) sin incidencias.",
-    "Apertura cameral e irrigación con hipoclorito sódico al 5,25%. Localizados 3 conductos.",
-    "Adaptación marginal correcta tras pulido. Paciente refiere ausencia de molestias.",
-    "Se coloca dique de goma para aislamiento absoluto. Buena cooperación del paciente.",
-    "Se recomienda cita de control en dos semanas para revisar oclusión.",
-    "Procedimiento sin complicaciones. Indicaciones postoperatorias entregadas.",
-    "Cementado definitivo con cemento de ionómero de vidrio. Ajuste oclusal verificado.",
+    t(
+        {
+            "es": "Se aplica anestesia local (articaína 4% con epinefrina 1:100.000) sin incidencias.",
+            "en": "Local anesthesia applied (articaine 4% with epinephrine 1:100,000) without incident.",
+            "fr": "Anesthésie locale appliquée (articaine 4% avec épinéphrine 1:100 000) sans incident.",
+        }
+    ),
+    t(
+        {
+            "es": "Apertura cameral e irrigación con hipoclorito sódico al 5,25%. Localizados 3 conductos.",
+            "en": "Chamber access and irrigation with 5.25% sodium hypochlorite. 3 canals located.",
+            "fr": "Ouverture pulpaire et irrigation à l'hypochlorite de sodium 5,25 %. 3 canaux localisés.",
+        }
+    ),
+    t(
+        {
+            "es": "Adaptación marginal correcta tras pulido. Paciente refiere ausencia de molestias.",
+            "en": "Correct marginal adaptation after polishing. Patient reports no discomfort.",
+            "fr": "Adaptation marginale correcte après polissage. Patient déclare absence de gêne.",
+        }
+    ),
+    t(
+        {
+            "es": "Se coloca dique de goma para aislamiento absoluto. Buena cooperación del paciente.",
+            "en": "Rubber dam placed for absolute isolation. Good patient cooperation.",
+            "fr": "Digue en place pour l'isolement absolu. Bonne coopération du patient.",
+        }
+    ),
+    t(
+        {
+            "es": "Se recomienda cita de control en dos semanas para revisar oclusión.",
+            "en": "Follow-up appointment recommended in two weeks to check occlusion.",
+            "fr": "Rendez-vous de contrôle recommandé dans deux semaines pour vérifier l'occlusion.",
+        }
+    ),
+    t(
+        {
+            "es": "Procedimiento sin complicaciones. Indicaciones postoperatorias entregadas.",
+            "en": "Procedure without complications. Post-operative instructions given.",
+            "fr": "Procédure sans complications. Consignes post-opératoires remises.",
+        }
+    ),
+    t(
+        {
+            "es": "Cementado definitivo con cemento de ionómero de vidrio. Ajuste oclusal verificado.",
+            "en": "Permanent cementation with glass ionomer cement. Occlusal adjustment verified.",
+            "fr": "Cimentation définitive au ciment verre ionomère. Réglage occlusal vérifié.",
+        }
+    ),
 )
 
 _PLAN_BODIES = (
-    "Plan acordado con el paciente. Priorizar tratamientos urgentes en cuadrante superior derecho.",
-    "Paciente solicita financiación; gestionar opción a 6 meses sin intereses.",
-    "Se acuerda iniciar fase higiénica antes de los tratamientos restauradores.",
-    "Pendiente de presentación al cónyuge; confirmará aceptación tras consulta familiar.",
-    "Se aplica descuento del 10% por tratamiento integral.",
-    "Paciente prefiere posponer la fase estética hasta después del verano.",
+    t(
+        {
+            "es": "Plan acordado con el paciente. Priorizar tratamientos urgentes en cuadrante superior derecho.",
+            "en": "Plan agreed with patient. Prioritize urgent treatments in the upper right quadrant.",
+            "fr": "Plan convenu avec le patient. Prioriser les traitements urgents dans le quadrant supérieur droit.",
+        }
+    ),
+    t(
+        {
+            "es": "Paciente solicita financiación; gestionar opción a 6 meses sin intereses.",
+            "en": "Patient requests financing; arrange 6-month interest-free option.",
+            "fr": "Patient demande un financement ; organiser l'option 6 mois sans intérêts.",
+        }
+    ),
+    t(
+        {
+            "es": "Se acuerda iniciar fase higiénica antes de los tratamientos restauradores.",
+            "en": "Hygiene phase agreed before restorative treatments.",
+            "fr": "Phase d'hygiène convenue avant les traitements restaurateurs.",
+        }
+    ),
+    t(
+        {
+            "es": "Pendiente de presentación al cónyuge; confirmará aceptación tras consulta familiar.",
+            "en": "Pending presentation to spouse; will confirm acceptance after family consultation.",
+            "fr": "En attente de présentation au conjoint ; confirmera l'acceptation après consultation familiale.",
+        }
+    ),
+    t(
+        {
+            "es": "Se aplica descuento del 10% por tratamiento integral.",
+            "en": "10% discount applied for comprehensive treatment.",
+            "fr": "Remise de 10 % appliquée pour le traitement global.",
+        }
+    ),
+    t(
+        {
+            "es": "Paciente prefiere posponer la fase estética hasta después del verano.",
+            "en": "Patient prefers to postpone the aesthetic phase until after summer.",
+            "fr": "Patient préfère reporter la phase esthétique après l'été.",
+        }
+    ),
 )
 
 
@@ -181,7 +344,7 @@ async def seed_clinical_notes_demo(
             Treatment.status == "performed",
         )
     )
-    for i, t in enumerate(performed_res.scalars().all()):
+    for i, tx in enumerate(performed_res.scalars().all()):
         if i % 2 == 1:
             continue
         tx_at = now - timedelta(days=10 + (i % 18))
@@ -190,7 +353,7 @@ async def seed_clinical_notes_demo(
                 clinic_id=clinic_id,
                 note_type=NOTE_TYPE_TREATMENT,
                 owner_type=NOTE_OWNER_TREATMENT,
-                owner_id=t.id,
+                owner_id=tx.id,
                 tooth_number=None,
                 body=_TREATMENT_BODIES[cursor % len(_TREATMENT_BODIES)],
                 author_id=author(cursor),

--- a/backend/app/modules/clinical_notes/service.py
+++ b/backend/app/modules/clinical_notes/service.py
@@ -596,7 +596,9 @@ def _build_linked(
         treatment = treatments_by_id.get(note.owner_id)
         teeth = [t.tooth_number for t in (treatment.teeth or [])] if treatment else []
         catalog = treatment.catalog_item if treatment else None
-        label = _resolve_label(catalog.names if catalog else None) or ""
+        label = _resolve_label(catalog.names if catalog else None) or (
+            treatment.clinical_type if treatment else None
+        )
         return {
             "kind": "treatment",
             "id": note.owner_id,
@@ -787,7 +789,7 @@ async def list_grouped_for_patient(
                     _resolve_label(
                         treatment.catalog_item.names if treatment.catalog_item else None,
                     )
-                    or ""
+                    or treatment.clinical_type
                 )
                 teeth = [t.tooth_number for t in (treatment.teeth or [])]
             treatment_groups.append(

--- a/backend/app/modules/clinical_notes/service.py
+++ b/backend/app/modules/clinical_notes/service.py
@@ -571,6 +571,14 @@ def _author_brief(author) -> dict:
     }
 
 
+def _resolve_label(
+    names: dict[str, str] | None,
+) -> str | None:
+    """Resolve a display label from catalog names: es → en → fr."""
+    names = names or {}
+    return next((names[k] for k in ("es", "en", "fr") if names.get(k)), None)
+
+
 def _build_linked(
     note: ClinicalNote,
     plan_by_id: dict[UUID, TreatmentPlan],
@@ -588,10 +596,7 @@ def _build_linked(
         treatment = treatments_by_id.get(note.owner_id)
         teeth = [t.tooth_number for t in (treatment.teeth or [])] if treatment else []
         catalog = treatment.catalog_item if treatment else None
-        names = (catalog.names if catalog else None) or {}
-        label = (
-            names.get("es") or names.get("en") or (treatment.clinical_type if treatment else None)
-        )
+        label = _resolve_label(catalog.names if catalog else None) or ""
         return {
             "kind": "treatment",
             "id": note.owner_id,
@@ -729,7 +734,9 @@ async def list_merged_for_plan(db: AsyncSession, clinic_id: UUID, plan_id: UUID)
 
 
 async def list_grouped_for_patient(
-    db: AsyncSession, clinic_id: UUID, patient_id: UUID
+    db: AsyncSession,
+    clinic_id: UUID,
+    patient_id: UUID,
 ) -> list[dict]:
     """Per-plan grouping with plan-level + per-treatment buckets, newest plan first."""
     plans_result = await db.execute(
@@ -776,11 +783,12 @@ async def list_grouped_for_patient(
             label = None
             teeth: list[int] = []
             if treatment:
-                catalog = treatment.catalog_item
-                if catalog and catalog.names:
-                    label = catalog.names.get("es") or catalog.names.get("en")
-                if not label:
-                    label = treatment.clinical_type
+                label = (
+                    _resolve_label(
+                        treatment.catalog_item.names if treatment.catalog_item else None,
+                    )
+                    or ""
+                )
                 teeth = [t.tooth_number for t in (treatment.teeth or [])]
             treatment_groups.append(
                 {

--- a/backend/app/modules/copilot/CHANGELOG.md
+++ b/backend/app/modules/copilot/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - feat(pending): "Pendientes" feed (IA redesign Fase 2, ADR 0015). New
   read-only `GET /pending` aggregates overdue recalls + budgets awaiting
   response through the tool registry with the caller's role (RBAC parity;

--- a/backend/app/modules/copilot/frontend/components/CopilotSettingsPanel.vue
+++ b/backend/app/modules/copilot/frontend/components/CopilotSettingsPanel.vue
@@ -28,6 +28,13 @@ interface CopilotMetrics {
 }
 
 const { t } = useI18n()
+
+function toolDisplayName(name: string): string {
+  const i18nKey = name.replace(/\./g, '_')
+  const key = `copilot.settings.metrics.toolNames.${i18nKey}`
+  const translated = t(key)
+  return translated !== key ? translated : name
+}
 const toast = useToast()
 const api = useApi()
 const { users, fetchUsers } = useUsers()
@@ -234,7 +241,7 @@ async function save() {
                 :key="tool.tool_name"
                 class="flex justify-between"
               >
-                <span class="font-mono text-xs">{{ tool.tool_name }}</span>
+                <span class="font-mono text-xs">{{ toolDisplayName(tool.tool_name) }}</span>
                 <span class="text-muted">
                   {{ tool.calls }}
                   <template v-if="tool.errors">

--- a/backend/app/modules/copilot/frontend/i18n/locales/en.json
+++ b/backend/app/modules/copilot/frontend/i18n/locales/en.json
@@ -105,7 +105,14 @@
         "avgLatency": "Avg. latency",
         "conversations": "Conversations",
         "tokenBudget": "Monthly token budget",
-        "topTools": "Most-used tools"
+        "topTools": "Most-used tools",
+        "toolNames": {
+          "recalls_list_due_recalls": "Overdue recalls",
+          "budget_list_budgets": "Pending estimates",
+          "patients_list_patients": "Patient search",
+          "appointments_list_appointments": "Appointments",
+          "invoices_list_invoices": "Invoices"
+        }
       }
     },
     "tool": {

--- a/backend/app/modules/copilot/frontend/i18n/locales/es.json
+++ b/backend/app/modules/copilot/frontend/i18n/locales/es.json
@@ -105,7 +105,14 @@
         "avgLatency": "Latencia media",
         "conversations": "Conversaciones",
         "tokenBudget": "Presupuesto mensual de tokens",
-        "topTools": "Herramientas más usadas"
+        "topTools": "Herramientas más usadas",
+        "toolNames": {
+          "recalls_list_due_recalls": "Recordatorios pendientes",
+          "budget_list_budgets": "Presupuestos pendientes",
+          "patients_list_patients": "Búsqueda de pacientes",
+          "appointments_list_appointments": "Citas",
+          "invoices_list_invoices": "Facturas"
+        }
       }
     },
     "tool": {

--- a/backend/app/modules/copilot/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/copilot/frontend/i18n/locales/fr.json
@@ -1,0 +1,185 @@
+{
+  "nav": {
+    "copilot": "IA"
+  },
+  "copilot": {
+    "title": "IA",
+    "open": "Ouvrir l'IA",
+    "empty": "Demandez-moi des informations sur les patients, l'agenda, ou pour prendre un rendez-vous.",
+    "placeholder": "Écrivez votre message…",
+    "send": "Envoyer",
+    "copy": "Copier",
+    "new": "Nouvelle conversation",
+    "thinking": "Réflexion…",
+    "you": "Vous",
+    "assistant": "IA",
+    "trust": "Vos données sont protégées",
+    "phase": {
+      "working": "En cours…",
+      "writing": "Écriture…"
+    },
+    "tabs": {
+      "pending": "À faire",
+      "chat": "Discussion"
+    },
+    "pending": {
+      "empty": "Rien en attente. Vous êtes à jour.",
+      "unknownPatient": "Patient inconnu",
+      "group": {
+        "recall": "Rappels à suivre",
+        "budget": "Devis en attente de réponse"
+      }
+    },
+    "nudge": {
+      "act": "Y jeter un œil",
+      "dismiss": "Ignorer",
+      "appointmentCancelled": {
+        "text": "Le rendez-vous de {time} a été annulé — un créneau vient de s'ouvrir.",
+        "prompt": "Le rendez-vous de {time} a été annulé. Trouvez des patients en rappel qui pourraient remplir ce créneau."
+      }
+    },
+    "suggest": {
+      "heading": "Comment puis-je aider ?",
+      "cat": {
+        "workflows": "Flux de travail",
+        "patients": "Patients",
+        "agenda": "Agenda",
+        "recalls": "Rappels",
+        "money": "Encaissements et devis",
+        "reports": "Rapports"
+      },
+      "dailyBriefing": "Briefing du jour",
+      "prepareVisit": "Préparer une visite",
+      "fillGap": "Remplir un créneau",
+      "searchPatient": "Trouver un patient",
+      "patientSummary": "Résumer un patient",
+      "freeSlots": "Créneaux libres aujourd'hui",
+      "bookAppointment": "Prendre un rendez-vous",
+      "dueRecalls": "Rappels à échéance",
+      "pendingBudgets": "Devis non répondus",
+      "recordPayment": "Enregistrer un paiement",
+      "monthCollections": "Encaissements du mois",
+      "agendaSummary": "Vue d'ensemble de l'agenda",
+      "prompt": {
+        "dailyBriefing": "Donnez-moi le briefing du jour : rendez-vous d'aujourd'hui, rappels en retard et devis non répondus",
+        "prepareVisit": "Préparez-moi la prochaine visite d'un patient",
+        "fillGap": "Un créneau s'est libéré dans l'agenda, qui pouvons-nous appeler ?",
+        "searchPatient": "Trouver un patient",
+        "patientSummary": "Donnez-moi le résumé d'un patient",
+        "freeSlots": "Quels créneaux sont libres aujourd'hui ?",
+        "bookAppointment": "Je veux prendre un rendez-vous",
+        "dueRecalls": "Quels rappels sont à échéance ce mois-ci ?",
+        "pendingBudgets": "Quels devis sont envoyés et sans réponse ?",
+        "recordPayment": "Je veux enregistrer un paiement patient",
+        "monthCollections": "Résumé des encaissements du mois",
+        "agendaSummary": "Donnez-moi un aperçu de l'agenda d'aujourd'hui"
+      }
+    },
+    "settings": {
+      "title": "Copilot",
+      "description": "Assistant IA : briefing matinal et moteur",
+      "saved": "Paramètres enregistrés",
+      "digest": {
+        "title": "E-mail de briefing matinal",
+        "description": "Chaque matin : rendez-vous du jour, rappels en retard et devis non répondus.",
+        "enabled": "Envoyer le briefing quotidien",
+        "hour": "Heure d'envoi",
+        "hourHelp": "Interprété dans le fuseau horaire de la clinique.",
+        "recipients": "Destinataires",
+        "recipientsHelp": "Chaque destinataire reçoit son propre briefing, limité à ce que son rôle peut voir.",
+        "recipientsPlaceholder": "Sélectionner le personnel…"
+      },
+      "engine": {
+        "title": "Moteur",
+        "provider": "Fournisseur",
+        "model": "Modèle",
+        "redaction": "Rédaction PHI",
+        "redactionOn": "Activé",
+        "redactionOff": "Désactivé"
+      },
+      "metrics": {
+        "title": "Utilisation",
+        "description": "Les {days} derniers jours.",
+        "toolCalls": "Appels d'outils",
+        "errorRate": "Taux d'erreur",
+        "avgLatency": "Latence moyenne",
+        "conversations": "Conversations",
+        "tokenBudget": "Budget de tokens mensuel",
+        "topTools": "Outils les plus utilisés",
+        "toolNames": {
+          "recalls_list_due_recalls": "Rappels en retard",
+          "budget_list_budgets": "Devis en attente",
+          "patients_list_patients": "Recherche de patients",
+          "appointments_list_appointments": "Rendez-vous",
+          "invoices_list_invoices": "Factures"
+        }
+      }
+    },
+    "tool": {
+      "running": "Exécution de {name}…",
+      "done": "{name} terminé",
+      "failed": "{name} échoué"
+    },
+    "card": {
+      "viewPatient": "Voir le dossier",
+      "noResults": "Aucun résultat",
+      "notFound": "Introuvable",
+      "more": "+{n} de plus",
+      "freeSlots": "Créneaux libres",
+      "appointments": "Rendez-vous",
+      "patients": "Patients"
+    },
+    "patientStatus": {
+      "active": "actif",
+      "archived": "archivé"
+    },
+    "apptStatus": {
+      "scheduled": "Planifié",
+      "confirmed": "Confirmé",
+      "checked_in": "Enregistré",
+      "in_treatment": "En cours de traitement",
+      "completed": "Terminé",
+      "cancelled": "Annulé",
+      "no_show": "Pas présenté"
+    },
+    "confirm": {
+      "title": "Confirmer l'action",
+      "body": "L'IA souhaite exécuter {name}.",
+      "approve": "Confirmer",
+      "reject": "Annuler",
+      "approved": "Confirmé",
+      "rejected": "Annulé",
+      "destructiveNote": "Cette action est irréversible.",
+      "action": {
+        "book_appointment": "L'IA souhaite prendre un rendez-vous.",
+        "cancel_appointment": "L'IA souhaite annuler un rendez-vous.",
+        "create_patient": "L'IA souhaite créer un patient."
+      },
+      "field": {
+        "patient_id": "Patient",
+        "professional_id": "Professionnel",
+        "appointment_id": "Rendez-vous",
+        "cabinet_id": "Cabine",
+        "cabinet": "Cabine",
+        "start_time": "Date",
+        "end_time": "Fin",
+        "datetime": "Date",
+        "service": "Prestation",
+        "reason": "Motif",
+        "duration_minutes": "Durée (min)",
+        "first_name": "Prénom",
+        "last_name": "Nom",
+        "phone": "Téléphone",
+        "email": "E-mail",
+        "date_of_birth": "Date de naissance",
+        "query": "Recherche"
+      }
+    },
+    "budgetExceeded": "La limite mensuelle d'utilisation de l'IA a été atteinte.",
+    "error": "Une erreur s'est produite.",
+    "page": {
+      "title": "IA",
+      "subtitle": "Votre assistant de clinique, limité à vos permissions."
+    }
+  }
+}

--- a/backend/app/modules/copilot/frontend/nuxt.config.ts
+++ b/backend/app/modules/copilot/frontend/nuxt.config.ts
@@ -8,7 +8,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/media/frontend/components/media/DocumentUpload.vue
+++ b/backend/app/modules/media/frontend/components/media/DocumentUpload.vue
@@ -181,7 +181,7 @@ async function submit() {
           {{ t('documents.dropzone.hint', 'Arrastra un documento o haz clic') }}
         </p>
         <p class="mt-1 text-xs text-muted">
-          PDF · JPG · PNG — hasta 10 MB
+          PDF · JPG · PNG — {{ t('common.maxFileSize', 'hasta 10 MB') }}
         </p>
       </div>
       <input

--- a/backend/app/modules/media/frontend/components/media/PhotoLightbox.vue
+++ b/backend/app/modules/media/frontend/components/media/PhotoLightbox.vue
@@ -196,7 +196,7 @@ function toggleCompare() {
             <button
               type="button"
               class="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/40"
-              :aria-label="t('actions.close', 'Cerrar')"
+              :aria-label="t('common.close')"
               @click="close"
             >
               <UIcon
@@ -213,7 +213,7 @@ function toggleCompare() {
             v-if="index > 0 && !comparing"
             type="button"
             class="absolute left-2 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/60 sm:block"
-            aria-label="Previous"
+            :aria-label="t('common.previous')"
             @click="prev"
           >
             <UIcon
@@ -287,7 +287,7 @@ function toggleCompare() {
             v-if="index < documents.length - 1 && !comparing"
             type="button"
             class="absolute right-2 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/60 sm:block"
-            aria-label="Next"
+            :aria-label="t('common.next')"
             @click="next"
           >
             <UIcon

--- a/backend/app/modules/media/frontend/components/media/PhotoUpload.vue
+++ b/backend/app/modules/media/frontend/components/media/PhotoUpload.vue
@@ -203,7 +203,7 @@ async function submit() {
           {{ t('photoGallery.dropHere', 'Arrastra una foto o haz clic') }}
         </p>
         <p class="text-xs text-muted mt-1">
-          JPG · PNG · HEIC · WebP — hasta 10 MB
+          JPG · PNG · HEIC · WebP — {{ t('common.maxFileSize', 'hasta 10 MB') }}
         </p>
       </div>
       <input

--- a/backend/app/modules/migration_import/CHANGELOG.md
+++ b/backend/app/modules/migration_import/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - fix(entity_mappings): widen ``source_canonical_uuid`` from
   ``VARCHAR(36)`` to ``VARCHAR(64)`` (alembic ``mig_0004``). The
   ``appointment_note`` sidecar registers a derived canonical of shape

--- a/backend/app/modules/migration_import/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/migration_import/frontend/i18n/locales/fr.json
@@ -1,0 +1,90 @@
+{
+  "migrationImport": {
+    "settingsCard": {
+      "title": "Migration de données (dental-bridge)",
+      "description": "Importez un fichier DPMF produit par dental-bridge (patients, rendez-vous, budgets, paiements, documents)."
+    },
+    "page": {
+      "title": "Migration de données",
+      "subtitle": "Importez les données extraites par dental-bridge dans cette clinique."
+    },
+    "upload": {
+      "dropFile": "Déposez le fichier .dpm ici, ou cliquez pour en choisir un",
+      "passphrase": "Phrase secrète (fichiers chiffrés uniquement)",
+      "passphraseHelp": "Uniquement requis pour .dpm.enc / .dpm.zst.enc",
+      "submit": "Télécharger et valider",
+      "uploading": "Téléchargement…",
+      "error": "Échec du téléchargement"
+    },
+    "validate": {
+      "running": "Vérification du fichier…",
+      "ok": "Le fichier est valide",
+      "failed": "La validation a échoué"
+    },
+    "preview": {
+      "title": "Aperçu",
+      "entities": "Entités",
+      "samples": "Échantillons",
+      "warnings": "Avertissements",
+      "files": "Fichiers joints",
+      "filesTotal": "Total",
+      "filesWithSha": "Avec sha256",
+      "filesWithoutSha": "Sans sha256",
+      "verifactuCheckbox": "Importer les données légales Verifactu",
+      "verifactuHelp": "Préserve les hachages légaux (Verifactu) sur les factures. Uniquement disponible lorsque le module Verifactu est installé et que le fichier contient ces données.",
+      "confirm": "Confirmer et importer",
+      "warning": "Cette action est irréversible. Vérifiez les données avant de confirmer."
+    },
+    "filters": {
+      "title": "Filtrage des professionnels",
+      "description": "Le personnel filtré est importé comme inactif (conservé pour les références historiques mais masqué de l'agenda). Vous pouvez les réactiver plus tard dans Paramètres → Utilisateurs.",
+      "totalLabel": "Total",
+      "deactivatedLabel": "Inactif dans la source",
+      "orphansLabel": "Colonnes agenda uniquement",
+      "stale24mLabel": "Aucune activité depuis 24 mois",
+      "minActivityLabel": "Activité minimale (mois)",
+      "minActivityHelp": "Désactiver doucement les professionnels sans trace clinique plus récente que ce nombre de mois. Réglez sur 0 pour désactiver.",
+      "excludeOrphans": "Exclure les colonnes agenda uniquement sans enregistrement de collaborateur réel",
+      "excludeInactive": "Exclure les professionnels marqués comme inactifs dans la source",
+      "excludeNonClinical": "Importer uniquement les dentistes et hygiénistes (ignorer les auxiliaires et le personnel administratif)"
+    },
+    "execute": {
+      "running": "Importation…",
+      "progress": "{processed} sur {total} entités",
+      "ok": "Importation terminée",
+      "failed": "Échec de l'importation"
+    },
+    "proposals": {
+      "title": "Vérifier les associations de catalogue",
+      "subtitle": "Associez chaque traitement Gesdén au catalogue DentalPin avant l'importation.",
+      "build": "Calculer les propositions",
+      "building": "Calcul en cours…",
+      "summary": "{total} propositions : {link} liées, {fuzzy} approximatives, {create} à créer",
+      "bulkAccept": "Accepter toutes les correspondances avec une confiance ≥ 0.9",
+      "accepted": "{n} propositions acceptées.",
+      "columnSource": "Traitement Gesdén",
+      "columnProposed": "Proposition",
+      "columnAction": "Action",
+      "columnStatus": "Statut",
+      "actionLink": "Lier au catalogue",
+      "actionFuzzy": "Correspondance approximative",
+      "actionCreate": "Créer nouveau",
+      "operatorPending": "En attente",
+      "operatorAccepted": "Accepté",
+      "operatorRelinked": "Relié",
+      "operatorCreated": "Créer nouveau",
+      "operatorIgnored": "Ignoré",
+      "acceptRow": "Accepter",
+      "ignoreRow": "Ignorer"
+    },
+    "status": {
+      "uploaded": "Téléversé",
+      "validating": "Validation en cours",
+      "validated": "Validé",
+      "previewing": "Aperçu",
+      "executing": "Importation en cours",
+      "completed": "Terminé",
+      "failed": "Échoué"
+    }
+  }
+}

--- a/backend/app/modules/migration_import/frontend/nuxt.config.ts
+++ b/backend/app/modules/migration_import/frontend/nuxt.config.ts
@@ -9,7 +9,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - feat(conversation): inbound replies + bidirectional WhatsApp (Phase 2A,
   ADR 0017). ``communication_messages`` gains ``direction`` (outbound/inbound)
   and ``body_text``; it is now the full per-patient thread (Alembic

--- a/backend/app/modules/notifications/frontend/components/settings/ClinicLanguagePage.vue
+++ b/backend/app/modules/notifications/frontend/components/settings/ClinicLanguagePage.vue
@@ -2,10 +2,10 @@
 const { t } = useI18n()
 const { settings, loading, saving, fetch, update } = useCommunicationsSettings()
 
-const language = ref<'es' | 'en'>('es')
+const language = ref<'es' | 'en' | 'fr'>('es')
 
 watch(settings, (s) => {
-  if (s) language.value = (s.language === 'en' ? 'en' : 'es')
+  if (s) language.value = (s.language === 'en' || s.language === 'fr' ? s.language : 'es')
 })
 
 onMounted(fetch)
@@ -13,6 +13,7 @@ onMounted(fetch)
 const options = [
   { value: 'es', label: 'Español' },
   { value: 'en', label: 'English' },
+  { value: 'fr', label: 'Français' },
 ]
 
 async function save() {

--- a/backend/app/modules/notifications/frontend/i18n/locales/notifications-fr.json
+++ b/backend/app/modules/notifications/frontend/i18n/locales/notifications-fr.json
@@ -1,0 +1,11 @@
+{
+  "notifications": {
+    "conversation": {
+      "title": "Conversation WhatsApp",
+      "empty": "Aucun message pour le moment.",
+      "placeholder": "Écrivez une réponse…",
+      "replyError": "Impossible d'envoyer la réponse",
+      "windowClosed": "La fenêtre de 24h est fermée. Utilisez un modèle pour rouvrir la conversation."
+    }
+  }
+}

--- a/backend/app/modules/notifications/frontend/nuxt.config.ts
+++ b/backend/app/modules/notifications/frontend/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'notifications-en.json' },
-      { code: 'es', file: 'notifications-es.json' }
+      { code: 'es', file: 'notifications-es.json' },
+      { code: 'fr', file: 'notifications-fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/patient_timeline/seed.py
+++ b/backend/app/modules/patient_timeline/seed.py
@@ -29,6 +29,7 @@ from app.modules.billing.models import Invoice
 from app.modules.budget.models import Budget
 from app.modules.odontogram.models import Treatment
 from app.modules.treatment_plan.models import PlannedTreatmentItem, TreatmentPlan
+from app.seeds.demo_data import t
 
 from .models import PatientTimeline
 
@@ -49,14 +50,41 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
         if not appt.patient_id:
             continue
 
-        title_es = {
-            "scheduled": "Cita programada",
-            "confirmed": "Cita programada",
-            "completed": "Cita completada",
-            "cancelled": "Cita cancelada",
-            "no_show": "Paciente no asistió",
-        }.get(appt.status, "Cita")
-        treatment_label = appt.treatment_type or "Consulta"
+        title_map = {
+            "scheduled": t(
+                {
+                    "es": "Cita programada",
+                    "en": "Scheduled appointment",
+                    "fr": "Rendez-vous planifié",
+                }
+            ),
+            "confirmed": t(
+                {
+                    "es": "Cita programada",
+                    "en": "Scheduled appointment",
+                    "fr": "Rendez-vous planifié",
+                }
+            ),
+            "completed": t(
+                {
+                    "es": "Cita completada",
+                    "en": "Completed appointment",
+                    "fr": "Rendez-vous terminé",
+                }
+            ),
+            "cancelled": t(
+                {"es": "Cita cancelada", "en": "Cancelled appointment", "fr": "Rendez-vous annulé"}
+            ),
+            "no_show": t(
+                {"es": "Paciente no asistió", "en": "Patient no-show", "fr": "Patient absent"}
+            ),
+        }
+        title_es = title_map.get(
+            appt.status, t({"es": "Cita", "en": "Appointment", "fr": "Rendez-vous"})
+        )
+        treatment_label = appt.treatment_type or t(
+            {"es": "Consulta", "en": "Consultation", "fr": "Consultation"}
+        )
         occurred = appt.end_time if appt.status == "completed" else appt.start_time
 
         event_type_map = {
@@ -97,7 +125,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                 event_category="treatment",
                 source_table="treatment_plans",
                 source_id=plan.id,
-                title=f"Plan de tratamiento creado: {plan.title or plan.plan_number}",
+                title=f"{t({'es': 'Plan de tratamiento creado', 'en': 'Treatment plan created', 'fr': 'Plan de traitement créé'})}: {plan.title or plan.plan_number}",
                 event_data={"plan_number": plan.plan_number},
                 occurred_at=plan.created_at or datetime.now(UTC),
                 created_by=plan.created_by,
@@ -122,7 +150,12 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
             if item.treatment and item.treatment.catalog_item
             else {}
         ) or {}
-        item_name = names.get("es") or names.get("en") or "tratamiento"
+        item_name = (
+            names.get("es")
+            or names.get("en")
+            or names.get("fr")
+            or t({"es": "tratamiento", "en": "treatment", "fr": "traitement"})
+        )
         patient_id = item.treatment.patient_id if item.treatment else None
         if not patient_id:
             continue
@@ -134,7 +167,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                 event_category="treatment",
                 source_table="planned_treatment_items",
                 source_id=item.id,
-                title=f"Tratamiento del plan completado: {item_name}",
+                title=f"{t({'es': 'Tratamiento del plan completado', 'en': 'Plan treatment completed', 'fr': 'Traitement du plan terminé'})}: {item_name}",
                 event_data={"plan_id": str(item.treatment_plan_id)},
                 occurred_at=item.completed_at or item.created_at or datetime.now(UTC),
                 created_by=item.completed_by,
@@ -150,7 +183,13 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
     )
     for treatment in performed.scalars().all():
         names = (treatment.catalog_item.names if treatment.catalog_item else {}) or {}
-        name = names.get("es") or names.get("en") or treatment.clinical_type or "tratamiento"
+        name = (
+            names.get("es")
+            or names.get("en")
+            or names.get("fr")
+            or treatment.clinical_type
+            or t({"es": "tratamiento", "en": "treatment", "fr": "traitement"})
+        )
         teeth = [t.tooth_number for t in treatment.teeth]
         teeth_label = ", ".join(str(t) for t in teeth) if teeth else None
         db.add(
@@ -161,8 +200,10 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                 event_category="treatment",
                 source_table="treatments",
                 source_id=treatment.id,
-                title=f"Tratamiento realizado: {name}",
-                description=f"Dientes: {teeth_label}" if teeth_label else None,
+                title=f"{t({'es': 'Tratamiento realizado', 'en': 'Treatment performed', 'fr': 'Traitement réalisé'})}: {name}",
+                description=f"{t({'es': 'Dientes', 'en': 'Teeth', 'fr': 'Dents'})}: {teeth_label}"
+                if teeth_label
+                else None,
                 event_data={
                     "clinical_type": treatment.clinical_type,
                     "tooth_numbers": teeth,
@@ -185,7 +226,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                     event_category="financial",
                     source_table="budgets",
                     source_id=budget.id,
-                    title=f"Presupuesto enviado: {budget.budget_number}",
+                    title=f"{t({'es': 'Presupuesto enviado', 'en': 'Budget sent', 'fr': 'Devis envoyé'})}: {budget.budget_number}",
                     event_data={
                         "budget_number": budget.budget_number,
                         "total": str(budget.total),
@@ -203,7 +244,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                     event_category="financial",
                     source_table="budgets",
                     source_id=budget.id,
-                    title=f"Presupuesto aceptado: {budget.budget_number}",
+                    title=f"{t({'es': 'Presupuesto aceptado', 'en': 'Budget accepted', 'fr': 'Devis accepté'})}: {budget.budget_number}",
                     event_data={
                         "budget_number": budget.budget_number,
                         "total": str(budget.total),
@@ -225,7 +266,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                     event_category="financial",
                     source_table="invoices",
                     source_id=invoice.id,
-                    title=f"Factura emitida: {invoice.invoice_number or '—'}",
+                    title=f"{t({'es': 'Factura emitida', 'en': 'Invoice issued', 'fr': 'Facture émise'})}: {invoice.invoice_number or '—'}",
                     event_data={
                         "invoice_number": invoice.invoice_number,
                         "total": str(invoice.total),
@@ -249,7 +290,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
                     event_category="financial",
                     source_table="invoices",
                     source_id=invoice.id,
-                    title=f"Factura pagada: {invoice.invoice_number or '—'}",
+                    title=f"{t({'es': 'Factura pagada', 'en': 'Invoice paid', 'fr': 'Facture payée'})}: {invoice.invoice_number or '—'}",
                     event_data={
                         "invoice_number": invoice.invoice_number,
                         "total": str(invoice.total),

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- i18n: add French locale (`fr.json`); Moroccan patient name seed data.
+- i18n: replace hardcoded strings in patient components with `$t()`
+  calls; add French patient names/contacts to demo seed data.
 
 - fix(events): include `clinic_id` in the `patient.archived` and
   `patient.updated` payloads (audit event-bus #11, #95). Every event

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`); Moroccan patient name seed data.
+
 - fix(events): include `clinic_id` in the `patient.archived` and
   `patient.updated` payloads (audit event-bus #11, #95). Every event
   must carry the tenant per the multi-tenancy convention; the omission

--- a/backend/app/modules/patients/frontend/components/patient/PatientBottomActionBar.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientBottomActionBar.vue
@@ -23,7 +23,7 @@ const { t } = useI18n()
   <nav
     class="patient-bottom-bar lg:hidden fixed inset-x-0 bottom-0 z-40 bg-surface/95 backdrop-blur border-t border-default px-2 py-1.5"
     :style="{ paddingBottom: 'calc(0.375rem + env(safe-area-inset-bottom))' }"
-    aria-label="Patient quick actions"
+    :aria-label="t('patients.quickActions.ariaLabel')"
   >
     <div class="flex items-stretch gap-1">
       <button

--- a/backend/app/modules/patients/frontend/components/patient/PatientStickyHeader.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientStickyHeader.vue
@@ -100,7 +100,7 @@ const actionItems = computed(() => [
 <template>
   <header
     class="patient-sticky-header sticky top-0 z-30 -mx-4 sm:mx-0 bg-surface/90 backdrop-blur border-b border-default px-4 sm:px-3 py-2.5"
-    aria-label="Cabecera del paciente"
+    :aria-label="t('patients.header.ariaLabel')"
   >
     <div class="flex items-center gap-3 sm:gap-4">
       <UButton

--- a/backend/app/modules/patients/frontend/components/patient/info/ContactInfoCard.vue
+++ b/backend/app/modules/patients/frontend/components/patient/info/ContactInfoCard.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
   editGuardian: []
 }>()
 
-const { t } = useI18n()
+const { t, te } = useI18n()
 
 const phoneHref = computed(() => (props.patient.phone ? `tel:${props.patient.phone}` : undefined))
 const emailHref = computed(() => (props.patient.email ? `mailto:${props.patient.email}` : undefined))
@@ -37,16 +37,14 @@ const emergencyRelationshipLabel = computed(() => {
   const rel = props.patient.emergency_contact?.relationship
   if (!rel) return null
   const key = `patients.emergencyContact.relationships.${rel}`
-  const translated = t(key)
-  return translated === key ? rel : translated
+  return te(key) ? t(key) : rel
 })
 
 const guardianRelationshipLabel = computed(() => {
   const rel = props.patient.legal_guardian?.relationship
   if (!rel) return null
   const key = `patients.legalGuardian.relationships.${rel}`
-  const translated = t(key)
-  return translated === key ? rel : translated
+  return te(key) ? t(key) : rel
 })
 </script>
 

--- a/backend/app/modules/patients/frontend/components/patient/info/MedicalSnapshotCard.vue
+++ b/backend/app/modules/patients/frontend/components/patient/info/MedicalSnapshotCard.vue
@@ -89,7 +89,7 @@ function allergyTooltip(a: AllergyEntry): string {
     <!-- Allergies block — three states -->
     <section
       class="mb-4"
-      aria-label="Alergias"
+      :aria-label="t('patients.medicalSnapshot.allergiesLabel')"
     >
       <!-- A. No medical data at all -->
       <div

--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - fix(security): lock the payment row `FOR UPDATE` before the refund
   cap check (audit S3/C1, #97). Two concurrent refunds could both read
   `already_refunded` before either inserted, letting Σrefund exceed

--- a/backend/app/modules/payments/frontend/components/PatientPaymentsPanel.vue
+++ b/backend/app/modules/payments/frontend/components/PatientPaymentsPanel.vue
@@ -180,7 +180,7 @@ function entryMeta(entry: PatientLedgerEntry): string[] {
   if (entry.entry_type !== 'earned') return []
   const parts: string[] = []
   if (entry.treatment_status) parts.push(treatmentStatusLabel(entry.treatment_status))
-  if (entry.professional_name) parts.push(`Dr. ${entry.professional_name}`)
+  if (entry.professional_name) parts.push(t('payments.patientPanel.timeline.drPrefix', { name: entry.professional_name }))
   return parts
 }
 

--- a/backend/app/modules/payments/frontend/components/PaymentCreateModal.vue
+++ b/backend/app/modules/payments/frontend/components/PaymentCreateModal.vue
@@ -55,7 +55,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { create } = usePayments()
-const { format: formatCurrency } = useCurrency()
+const { format: formatCurrency, symbol: currencySymbol } = useCurrency()
 
 const isBudgetContext = computed(() => Boolean(props.defaultBudgetId))
 const isPatientLocked = computed(() => Boolean(props.defaultPatientId))
@@ -292,7 +292,7 @@ function handleKeydown(e: KeyboardEvent) {
               inputmode="decimal"
               class="w-full text-3xl font-semibold py-3 px-4 pr-14 rounded-token-md border border-default bg-surface focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] tnum"
             >
-            <span class="absolute right-4 top-1/2 -translate-y-1/2 text-xl text-muted pointer-events-none">€</span>
+            <span class="absolute right-4 top-1/2 -translate-y-1/2 text-xl text-muted pointer-events-none">{{ currencySymbol() }}</span>
           </div>
           <div
             v-if="suggestedAmount !== undefined && suggestedAmount > 0"

--- a/backend/app/modules/payments/frontend/components/summary/BalanceCard.vue
+++ b/backend/app/modules/payments/frontend/components/summary/BalanceCard.vue
@@ -44,8 +44,8 @@ const href = computed(
 )
 
 const ctaLabel = computed(() => {
-  if (debt.value > 0) return t('patientDetail.collect', 'Cobrar')
-  return t('patientDetail.viewLedger', 'Abrir cobros')
+  if (debt.value > 0) return t('patientDetail.collect')
+  return t('patientDetail.viewLedger')
 })
 
 const isEmpty = computed(() =>
@@ -55,7 +55,7 @@ const isEmpty = computed(() =>
 
 <template>
   <SummaryCard
-    :title="t('patientDetail.balance', 'Saldo')"
+    :title="t('patientDetail.balance')"
     icon="i-lucide-wallet"
     :severity="severity"
     :loading="status === 'pending'"
@@ -63,7 +63,7 @@ const isEmpty = computed(() =>
     :to="href"
   >
     <template #empty>
-      {{ t('patientDetail.noPayments', 'Sin movimientos') }}
+      {{ t('patientDetail.noPayments') }}
     </template>
 
     <dl class="space-y-1 text-ui">
@@ -72,7 +72,7 @@ const isEmpty = computed(() =>
         class="flex items-baseline justify-between gap-2"
       >
         <dt class="text-caption text-muted">
-          {{ t('payments.balance.debt', 'Debe') }}
+          {{ t('payments.balance.debt') }}
         </dt>
         <dd class="text-h2 text-[var(--color-danger-accent)] tnum">
           {{ formatCurrency(debt) }}
@@ -83,7 +83,7 @@ const isEmpty = computed(() =>
         class="flex items-baseline justify-between gap-2"
       >
         <dt class="text-caption text-muted">
-          {{ t('payments.balance.credit', 'A cuenta') }}
+          {{ t('payments.balance.credit') }}
         </dt>
         <dd class="text-default tnum">
           {{ formatCurrency(credit) }}
@@ -91,7 +91,7 @@ const isEmpty = computed(() =>
       </div>
       <div class="flex items-baseline justify-between gap-2">
         <dt class="text-caption text-muted">
-          {{ t('payments.balance.paid', 'Total cobrado') }}
+          {{ t('payments.balance.paid') }}
         </dt>
         <dd class="text-default tnum">
           {{ formatCurrency(totalPaid) }}

--- a/backend/app/modules/payments/frontend/i18n/locales/en.json
+++ b/backend/app/modules/payments/frontend/i18n/locales/en.json
@@ -200,6 +200,7 @@
         "emptyCta": "Record first payment",
         "loadError": "Could not load patient ledger.",
         "retry": "Retry",
+        "drPrefix": "Dr. {name}",
         "types": {
           "payment": "Payment",
           "refund": "Refund",

--- a/backend/app/modules/payments/frontend/i18n/locales/es.json
+++ b/backend/app/modules/payments/frontend/i18n/locales/es.json
@@ -200,6 +200,7 @@
         "emptyCta": "Registrar primer pago",
         "loadError": "No se pudo cargar el estado de cuenta.",
         "retry": "Reintentar",
+        "drPrefix": "Dr. {name}",
         "types": {
           "payment": "Pago",
           "refund": "Devolución",

--- a/backend/app/modules/payments/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/payments/frontend/i18n/locales/fr.json
@@ -1,0 +1,287 @@
+{
+  "payments": {
+    "nav": {
+      "payments": "Paiements",
+      "reports": "Rapports de paiements"
+    },
+    "balance": {
+      "debt": "Doit",
+      "credit": "En compte",
+      "paid": "Total payé"
+    },
+    "list": {
+      "title": "Paiements",
+      "subtitle": "Paiements patients, avances sur devis et crédit en compte.",
+      "empty": "Aucun paiement enregistré.",
+      "new": "Nouveau paiement",
+      "searchPlaceholder": "Patient ou référence",
+      "filterDateFrom": "Du",
+      "filterDateTo": "Au",
+      "filterMethod": "Mode de paiement",
+      "filterPatient": "Patient",
+      "filter": {
+        "method": "Mode de paiement",
+        "hasRefunds": "Avec remboursements",
+        "hasUnallocated": "Non alloué",
+        "patient": "Patient",
+        "withDebt": "Avec dette",
+        "paymentStatus": "Statut"
+      },
+      "sort": {
+        "paymentDate": "Date",
+        "amount": "Montant"
+      },
+      "budgetStatus": {
+        "paid": "Payé",
+        "partial": "Partiel",
+        "unpaid": "Impayé"
+      },
+      "row": {
+        "debtTooltip": "Solde débiteur du patient",
+        "creditTooltip": "Solde créditeur du patient",
+        "allocationsLabel": "Allocation",
+        "refundedLabel": "Remboursé",
+        "noPatient": "Aucun patient"
+      },
+      "columnDate": "Date",
+      "columnPatient": "Patient",
+      "columnAmount": "Montant",
+      "columnMethod": "Mode",
+      "columnAllocations": "Allocation",
+      "columnNet": "Net",
+      "columnActions": "Actions"
+    },
+    "detail": {
+      "title": "Paiement {reference}",
+      "amount": "Montant",
+      "method": "Mode de paiement",
+      "date": "Date",
+      "recordedBy": "Enregistré par",
+      "allocations": "Allocations",
+      "refunds": "Remboursements",
+      "refund": "Remboursement",
+      "refundedTotal": "Remboursé",
+      "netAmount": "Net",
+      "reference": "Référence",
+      "notes": "Notes"
+    },
+    "new": {
+      "title": "Enregistrer un paiement",
+      "patient": "Patient",
+      "patientPlaceholder": "Rechercher un patient...",
+      "unknownPatient": "Patient inconnu",
+      "amount": "Montant",
+      "suggestedHint": "En attente de facturation : {amount}",
+      "useSuggested": "utiliser ce montant",
+      "method": "Mode de paiement",
+      "moreMethods": "Plus d'options",
+      "date": "Date",
+      "today": "Aujourd'hui",
+      "advanced": "Options avancées",
+      "reference": "Référence",
+      "referencePlaceholder": "N° autorisation CB, référence de virement...",
+      "notes": "Notes",
+      "allocations": "Allocation",
+      "allocationsHint": "Répartir ce paiement sur des devis ou le laisser en crédit patient.",
+      "addAllocation": "Ajouter une allocation",
+      "allocationToBudget": "Au devis",
+      "allocationOnAccount": "En compte",
+      "sumLabel": "Somme :",
+      "sumMismatch": "ne correspond pas au montant",
+      "submit": "Enregistrer",
+      "submitWithAmount": "Facturer {amount}",
+      "cancel": "Annuler",
+      "errPatient": "Sélectionnez un patient",
+      "errAmount": "Saisissez un montant supérieur à 0",
+      "errSum": "La somme des allocations doit être égale au montant",
+      "errUnknown": "Impossible d'enregistrer le paiement. Réessayez."
+    },
+    "methods": {
+      "cash": "Espèces",
+      "card": "Carte",
+      "bank_transfer": "Virement",
+      "direct_debit": "Prélèvement",
+      "insurance": "Assurance",
+      "other": "Autre"
+    },
+    "refund": {
+      "title": "Rembourser le paiement",
+      "amount": "Montant",
+      "method": "Mode de remboursement",
+      "reason": "Motif",
+      "note": "Détails",
+      "submit": "Rembourser",
+      "reasonCodes": {
+        "duplicate": "Paiement en double",
+        "overpaid": "Surpaiement",
+        "treatment_cancelled": "Traitement annulé",
+        "dispute": "Litige",
+        "other": "Autre"
+      }
+    },
+    "ledger": {
+      "title": "Grand livre du patient",
+      "totalPaid": "Total payé",
+      "totalEarned": "Traitement réalisé",
+      "patientCredit": "Solde créditeur du patient",
+      "clinicReceivable": "Créances de la clinique",
+      "onAccount": "En compte",
+      "empty": "Aucun mouvement."
+    },
+    "budgetCard": {
+      "title": "Paiements du devis",
+      "budgetTotal": "Devisé",
+      "collected": "Encaissé",
+      "pending": "En attente",
+      "collect": "Encaisser",
+      "empty": "Aucun paiement imputé à ce devis pour le moment.",
+      "collectedLabel": "Encaissé",
+      "pendingLabel": "En attente",
+      "outOfTotal": "sur {total} au total",
+      "settled": "Devis entièrement encaissé",
+      "history": "Historique des paiements",
+      "payment": "Paiement",
+      "emptyDetailed": "Aucun paiement enregistré pour le moment. Utilisez « Encaisser » pour enregistrer le premier."
+    },
+    "budgetCollect": {
+      "title": "Encaisser le devis",
+      "amountLabel": "Montant",
+      "methodLabel": "Mode de paiement",
+      "dateLabel": "Date du paiement",
+      "today": "Aujourd'hui",
+      "quickFull": "Total",
+      "optionalDetails": "Ajouter une référence ou des notes (optionnel)",
+      "referenceLabel": "Référence",
+      "referencePlaceholder": "ex. N° de transaction TPV",
+      "notesLabel": "Notes internes",
+      "submit": "Encaisser",
+      "cancel": "Annuler",
+      "success": "Paiement enregistré",
+      "errorGeneric": "Impossible d'enregistrer le paiement",
+      "noteAppliedToBudget": "appliqué au devis.",
+      "notePendingAfter": "Restant",
+      "noteFullySettled": "Le devis sera entièrement réglé.",
+      "noteToBudget": "appliqué au devis et",
+      "noteExcessToOnAccount": "en crédit patient.",
+      "noteBudgetSettled": "Le devis est déjà entièrement payé.",
+      "noteToOnAccount": "en crédit patient."
+    },
+    "pendingCharges": {
+      "title": "En attente de facturation",
+      "count": "{n} séances",
+      "more": "+ {n} de plus",
+      "collect": "Encaisser {amount}",
+      "unnamedSession": "Séance sans titre"
+    },
+    "patientPanel": {
+      "title": "Grand livre du patient",
+      "kpis": {
+        "totalPaid": "Total payé",
+        "debt": "Créances de la clinique",
+        "onAccount": "En compte"
+      },
+      "sidebar": {
+        "title": "Résumé",
+        "credit": "Crédit patient",
+        "lastPayment": "Dernier paiement",
+        "noLastPayment": "Aucun paiement pour le moment",
+        "totalEarned": "Traitement réalisé"
+      },
+      "banner": {
+        "debtTitle": "Doit {amount} à la clinique",
+        "debtDescription": "Le total payé est inférieur au traitement réalisé.",
+        "creditTitle": "A {amount} en crédit",
+        "creditDescription": "A payé plus que le traitement réalisé."
+      },
+      "cobrar": "Enregistrer un paiement",
+      "timeline": {
+        "title": "Mouvements",
+        "empty": "Aucun mouvement enregistré",
+        "emptyCta": "Enregistrer le premier paiement",
+        "loadError": "Impossible de charger le grand livre du patient.",
+        "retry": "Réessayer",
+        "drPrefix": "Dr {name}",
+        "types": {
+          "payment": "Paiement",
+          "refund": "Remboursement",
+          "earned": "Traitement réalisé"
+        },
+        "treatmentStatus": {
+          "planned": "Planifié",
+          "performed": "Ralisé",
+          "completed": "Terminé",
+          "cancelled": "Annulé",
+          "in_progress": "En cours"
+        },
+        "rowMenu": {
+          "detail": "Voir le détail",
+          "refund": "Rembourser"
+        }
+      },
+      "refundModal": {
+        "title": "Rembourser le paiement",
+        "amount": "Montant du remboursement",
+        "method": "Mode de remboursement",
+        "reason": "Motif",
+        "note": "Détails (optionnel)",
+        "submit": "Confirmer le remboursement",
+        "cancel": "Annuler",
+        "errorGeneric": "Impossible d'enregistrer le remboursement"
+      }
+    },
+    "reports": {
+      "title": "Rapports de paiements",
+      "subtitle": "Encaissements, remboursements, soldes patients et tendances pour la période.",
+      "cardDescription": "Encaissements, remboursements, soldes patients, vieillissement et tendances.",
+      "period": "Période",
+      "refresh": "Actualiser",
+      "collected": "Encaissé",
+      "refunded": "Remboursé",
+      "net": "Net",
+      "patientCredit": "Total crédit patient",
+      "patientCreditHint": "Soldes en compte ou avances.",
+      "clinicReceivable": "Créances de la clinique",
+      "refundRatio": "Taux de remboursement",
+      "byMethod": "Par mode de paiement",
+      "byProfessional": "Par professionnel",
+      "byProfessionalHint": "Traitement réalisé, non encaissé.",
+      "aging": "Vieillissement des créances",
+      "agingHint": "Patients avec solde débiteur groupés par ancienneté de la dette.",
+      "refunds": "Remboursements par motif",
+      "refundsHint": "Distribution des remboursements par motif enregistré.",
+      "bucket": "{range} jours",
+      "unknownProfessional": "Non assigné",
+      "countShort": "{n} transactions",
+      "countPatients": "{n} patients",
+      "granularity": {
+        "day": "Jour",
+        "week": "Semaine",
+        "month": "Mois"
+      },
+      "hero": {
+        "netCollected": "Net encaissé",
+        "netCollectedHint": "Encaissements moins remboursements sur la période.",
+        "receivable": "Créances en attente",
+        "receivableHint": "Traitement réalisé non encore encaissé, par ancienneté.",
+        "vsPrevious": "vs. période précédente",
+        "transactionsCount": "{n} transactions sur la période"
+      },
+      "trend": {
+        "title": "Tendance des encaissements",
+        "subtitle": "Net par tranche. La ligne pointillée représente les remboursements."
+      },
+      "empty": {
+        "noDataTitle": "Aucune donnée pour cette période",
+        "noDataDescription": "Ajustez la période ou enregistrez un paiement pour commencer à voir le rapport.",
+        "noTrend": "Pas assez de points pour tracer la tendance.",
+        "noMethods": "Aucun encaissement par mode de paiement sur la période.",
+        "noProfessionals": "Aucun traitement réalisé sur la période.",
+        "noReceivable": "Aucun patient avec dette en attente."
+      },
+      "drilldown": {
+        "viewPayments": "Voir les paiements de la période",
+        "viewPatients": "Voir les patients endettés"
+      }
+    }
+  }
+}

--- a/backend/app/modules/payments/frontend/nuxt.config.ts
+++ b/backend/app/modules/payments/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/payments/frontend/pages/reports/payments/index.vue
+++ b/backend/app/modules/payments/frontend/pages/reports/payments/index.vue
@@ -392,7 +392,7 @@ const allReportsEmpty = computed(() => {
               :aria-label="t('payments.reports.drilldown.viewPatients')"
               @click="goToPatientsWithDebt()"
             >
-              <div class="text-caption text-muted">{{ b.label }}d</div>
+              <div class="text-caption text-muted">{{ t('payments.reports.bucket', { range: b.label }) }}</div>
               <div class="text-ui font-medium text-default tnum mt-0.5">
                 {{ formatMoney(b.total) }}
               </div>

--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - fix(frontend): call `api.del` instead of the non-existent `api.delete`
   when discarding a draft (audit frontend #1, #95). `useApi` exposes
   `del`, so `discardDraft` threw a TypeError before any request fired —

--- a/backend/app/modules/periodontogram/frontend/components/PerioArchBlock.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioArchBlock.vue
@@ -37,6 +37,8 @@ const emit = defineEmits<{
   editSite: [toothNumber: number, siteCode: SiteCode, patch: Record<string, unknown>]
 }>()
 
+const { t } = useI18n()
+
 // ---------------------------------------------------------------------------
 // Ordering
 // ---------------------------------------------------------------------------
@@ -62,11 +64,11 @@ const orderedTeeth = computed(() => {
 const TOOTH_COL_PX = 60
 const profileOverlayWidth = computed(() => `${orderedTeeth.value.length * TOOTH_COL_PX}px`)
 
-const heading = computed(() => (props.arch === 'upper' ? 'Superior' : 'Inferior'))
+const heading = computed(() => t(props.arch === 'upper' ? 'periodontogram.arch.upper' : 'periodontogram.arch.lower'))
 const innerFace = computed<'palatal' | 'lingual'>(() =>
   props.arch === 'upper' ? 'palatal' : 'lingual'
 )
-const innerFaceLabel = computed(() => (props.arch === 'upper' ? 'Palatino' : 'Lingual'))
+const innerFaceLabel = computed(() => t(props.arch === 'upper' ? 'periodontogram.arch.palatal' : 'periodontogram.arch.lingual'))
 const innerSites = PALATAL_SITES
 
 // ---------------------------------------------------------------------------
@@ -192,7 +194,7 @@ function selectOnFocus(e: FocusEvent) {
     <header class="flex items-center justify-between px-3 py-2">
       <h4 class="text-xs font-semibold uppercase tracking-wide text-muted">{{ heading }}</h4>
       <span class="text-[10px] text-subtle">
-        Vestibular (MV V DV) ↔ {{ innerFaceLabel }} (ML L DL)
+        {{ t('periodontogram.arch.vestibular') }} (MV V DV) ↔ {{ innerFaceLabel }} (ML L DL)
       </span>
     </header>
 
@@ -221,13 +223,13 @@ function selectOnFocus(e: FocusEvent) {
       <tbody v-if="arch === 'upper'" class="divide-y divide-gray-100 dark:divide-gray-800">
         <!-- Implante (toggle ● / ·) -->
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Implante</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.implant') }}</th>
           <td v-for="t in orderedTeeth" :key="`imp-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :class="{ 'text-emerald-600 dark:text-emerald-400': t.is_implant }"
               :disabled="readonly"
-              :title="t.is_implant ? 'Implante (clic para quitar)' : 'Clic para marcar como implante'"
+              :title="t.is_implant ? t('periodontogram.arch.implantToggleOn') : t('periodontogram.arch.implantToggleOff')"
               @click="onImplantToggle(t)"
             >
               {{ t.is_implant ? '●' : '·' }}
@@ -235,14 +237,14 @@ function selectOnFocus(e: FocusEvent) {
           </td>
         </tr>
 
-        <!-- Movilidad (cycle 0..3 + null) -->
+        <!-- Mobility (cycle 0..3 + null) -->
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Movilidad</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.mobility') }}</th>
           <td v-for="t in orderedTeeth" :key="`mob-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Clic para cambiar movilidad (0–3)"
+              :title="t('periodontogram.arch.mobilityTitle')"
               @click="onToothCycle(t, 'mobility')"
             >
               {{ mobilityGlyph(t.mobility) }}
@@ -250,14 +252,14 @@ function selectOnFocus(e: FocusEvent) {
           </td>
         </tr>
 
-        <!-- Pronóstico cycle -->
+        <!-- Prognosis cycle -->
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Pronóstico</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.prognosis') }}</th>
           <td v-for="t in orderedTeeth" :key="`pron-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Bueno / Medio / Dudoso / Sin esperanza"
+              :title="t('periodontogram.arch.prognosisTitle')"
               @click="onToothCycle(t, 'prognosis')"
             >
               {{ prognosisGlyph(t.prognosis) }}
@@ -267,12 +269,12 @@ function selectOnFocus(e: FocusEvent) {
 
         <!-- Furca V / L cycles -->
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Furca V</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaV') }}</th>
           <td v-for="t in orderedTeeth" :key="`furv-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Furca vestibular (0/I/II/III)"
+              :title="t('periodontogram.arch.furcaVTitle')"
               @click="onToothCycle(t, 'furcation_buccal')"
             >
               {{ furcaGlyph(t.furcation_buccal) }}
@@ -280,12 +282,12 @@ function selectOnFocus(e: FocusEvent) {
           </td>
         </tr>
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Furca L/P</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaLP') }}</th>
           <td v-for="t in orderedTeeth" :key="`furl-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Furca lingual/palatina (0/I/II/III)"
+              :title="t('periodontogram.arch.furcaLPTitle')"
               @click="onToothCycle(t, 'furcation_lingual')"
             >
               {{ furcaGlyph(t.furcation_lingual) }}
@@ -293,9 +295,9 @@ function selectOnFocus(e: FocusEvent) {
           </td>
         </tr>
 
-        <!-- Anchura encía (numeric input) -->
+        <!-- Gingival width (numeric input) -->
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Anchura encía</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.gingivalWidth') }}</th>
           <td v-for="t in orderedTeeth" :key="`kg-${t.tooth_number}`" class="px-1">
             <input
               type="number"
@@ -312,10 +314,10 @@ function selectOnFocus(e: FocusEvent) {
 
         <!-- Vestibular site metrics — amber tint, sits above the V tooth row -->
         <tr v-for="row in [
-          { kind: 'site-pd', label: 'Sondaje' },
-          { kind: 'site-gm', label: 'Margen' },
-          { kind: 'site-plaque', label: 'Placa' },
-          { kind: 'site-bop', label: 'Sangrado' }
+          { kind: 'site-pd', label: t('periodontogram.arch.probing') },
+          { kind: 'site-gm', label: t('periodontogram.arch.margin') },
+          { kind: 'site-plaque', label: t('periodontogram.arch.plaque') },
+          { kind: 'site-bop', label: t('periodontogram.arch.bleeding') }
         ]" :key="`v-${row.kind}`" class="perio-row-vestibular">
           <th scope="row" class="px-1 text-right font-medium text-amber-700 dark:text-amber-400">
             {{ row.label }} <span class="text-[9px] text-amber-500 dark:text-amber-300/80">V</span>
@@ -331,7 +333,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.probing_depth_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} sondaje (0–15 mm)`"
+                  :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
                 />
@@ -343,7 +345,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} margen gingival (-5 a 10 mm)`"
+                  :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
                 />
@@ -353,7 +355,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--plaque"
                   :class="{ 'is-on': siteValue(t, code)?.plaque }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} placa (clic para alternar)`"
+                  :title="t('periodontogram.arch.plaqueTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
                 />
                 <button
@@ -362,7 +364,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--bop"
                   :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} sangrado (clic para alternar)`"
+                  :title="t('periodontogram.arch.bleedingTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
                 />
               </template>
@@ -380,7 +382,7 @@ function selectOnFocus(e: FocusEvent) {
             scope="row"
             class="px-1 text-right text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 perio-row-anchor"
           >
-            Vestibular
+            {{ t('periodontogram.arch.vestibular') }}
             <div class="perio-profile-anchor perio-profile-anchor--top" :style="{ width: profileOverlayWidth }">
               <PerioProfileStrip
                 :teeth="orderedTeeth"
@@ -422,10 +424,10 @@ function selectOnFocus(e: FocusEvent) {
 
         <!-- Palatal site metrics — sky tint -->
         <tr v-for="row in [
-          { kind: 'site-bop', label: 'Sangrado' },
-          { kind: 'site-plaque', label: 'Placa' },
-          { kind: 'site-gm', label: 'Margen' },
-          { kind: 'site-pd', label: 'Sondaje' }
+          { kind: 'site-bop', label: t('periodontogram.arch.bleeding') },
+          { kind: 'site-plaque', label: t('periodontogram.arch.plaque') },
+          { kind: 'site-gm', label: t('periodontogram.arch.margin') },
+          { kind: 'site-pd', label: t('periodontogram.arch.probing') }
         ]" :key="`p-${row.kind}`" class="perio-row-palatal">
           <th scope="row" class="px-1 text-right font-medium text-sky-700 dark:text-sky-400">
             {{ row.label }} <span class="text-[9px] text-sky-500 dark:text-sky-300/80">{{ innerFaceLabel.charAt(0) }}</span>
@@ -441,7 +443,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.probing_depth_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} sondaje (0–15 mm)`"
+                  :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
                 />
@@ -453,7 +455,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} margen gingival (-5 a 10 mm)`"
+                  :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
                 />
@@ -463,7 +465,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--plaque"
                   :class="{ 'is-on': siteValue(t, code)?.plaque }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} placa (clic para alternar)`"
+                  :title="t('periodontogram.arch.plaqueTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
                 />
                 <button
@@ -472,7 +474,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--bop"
                   :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} sangrado (clic para alternar)`"
+                  :title="t('periodontogram.arch.bleedingTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
                 />
               </template>
@@ -485,10 +487,10 @@ function selectOnFocus(e: FocusEvent) {
       <tbody v-else class="divide-y divide-gray-100 dark:divide-gray-800">
         <!-- Lingual site metrics on top -->
         <tr v-for="row in [
-          { kind: 'site-pd', label: 'Sondaje' },
-          { kind: 'site-gm', label: 'Margen' },
-          { kind: 'site-plaque', label: 'Placa' },
-          { kind: 'site-bop', label: 'Sangrado' }
+          { kind: 'site-pd', label: t('periodontogram.arch.probing') },
+          { kind: 'site-gm', label: t('periodontogram.arch.margin') },
+          { kind: 'site-plaque', label: t('periodontogram.arch.plaque') },
+          { kind: 'site-bop', label: t('periodontogram.arch.bleeding') }
         ]" :key="`l-${row.kind}`" class="perio-row-palatal">
           <th scope="row" class="px-1 text-right font-medium text-sky-700 dark:text-sky-400">
             {{ row.label }} <span class="text-[9px] text-sky-500 dark:text-sky-300/80">L</span>
@@ -504,7 +506,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.probing_depth_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} sondaje (0–15 mm)`"
+                  :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
                 />
@@ -516,7 +518,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} margen gingival (-5 a 10 mm)`"
+                  :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
                 />
@@ -526,7 +528,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--plaque"
                   :class="{ 'is-on': siteValue(t, code)?.plaque }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} placa (clic para alternar)`"
+                  :title="t('periodontogram.arch.plaqueTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
                 />
                 <button
@@ -535,7 +537,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--bop"
                   :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} sangrado (clic para alternar)`"
+                  :title="t('periodontogram.arch.bleedingTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
                 />
               </template>
@@ -573,7 +575,7 @@ function selectOnFocus(e: FocusEvent) {
             scope="row"
             class="px-1 text-right text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 perio-row-anchor"
           >
-            Vestibular
+            {{ t('periodontogram.arch.vestibular') }}
             <div class="perio-profile-anchor perio-profile-anchor--bottom" :style="{ width: profileOverlayWidth }">
               <PerioProfileStrip
                 :teeth="orderedTeeth"
@@ -594,10 +596,10 @@ function selectOnFocus(e: FocusEvent) {
 
         <!-- Vestibular site metrics directly below the V tooth row -->
         <tr v-for="row in [
-          { kind: 'site-bop', label: 'Sangrado' },
-          { kind: 'site-plaque', label: 'Placa' },
-          { kind: 'site-gm', label: 'Margen' },
-          { kind: 'site-pd', label: 'Sondaje' }
+          { kind: 'site-bop', label: t('periodontogram.arch.bleeding') },
+          { kind: 'site-plaque', label: t('periodontogram.arch.plaque') },
+          { kind: 'site-gm', label: t('periodontogram.arch.margin') },
+          { kind: 'site-pd', label: t('periodontogram.arch.probing') }
         ]" :key="`v-${row.kind}`" class="perio-row-vestibular">
           <th scope="row" class="px-1 text-right font-medium text-amber-700 dark:text-amber-400">
             {{ row.label }} <span class="text-[9px] text-amber-500 dark:text-amber-300/80">V</span>
@@ -613,7 +615,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.probing_depth_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} sondaje (0–15 mm)`"
+                  :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
                 />
@@ -625,7 +627,7 @@ function selectOnFocus(e: FocusEvent) {
                   :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
                   :disabled="readonly || !t.is_present"
                   class="perio-cell-input perio-cell-input--site"
-                  :title="`${code} margen gingival (-5 a 10 mm)`"
+                  :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
                   @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
                 />
@@ -635,7 +637,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--plaque"
                   :class="{ 'is-on': siteValue(t, code)?.plaque }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} placa (clic para alternar)`"
+                  :title="t('periodontogram.arch.plaqueTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
                 />
                 <button
@@ -644,7 +646,7 @@ function selectOnFocus(e: FocusEvent) {
                   class="perio-cell-toggle perio-cell-toggle--bop"
                   :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
                   :disabled="readonly || !t.is_present"
-                  :title="`${code} sangrado (clic para alternar)`"
+                  :title="t('periodontogram.arch.bleedingTitle', { code })"
                   @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
                 />
               </template>
@@ -654,7 +656,7 @@ function selectOnFocus(e: FocusEvent) {
 
         <!-- Per-tooth metrics (reversed — closest to vestibular row) -->
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Anchura encía</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.gingivalWidth') }}</th>
           <td v-for="t in orderedTeeth" :key="`kg-${t.tooth_number}`" class="px-1">
             <input
               type="number"
@@ -669,57 +671,57 @@ function selectOnFocus(e: FocusEvent) {
           </td>
         </tr>
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Furca L/P</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaLP') }}</th>
           <td v-for="t in orderedTeeth" :key="`furl-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Furca lingual/palatina (0/I/II/III)"
+              :title="t('periodontogram.arch.furcaLPTitle')"
               @click="onToothCycle(t, 'furcation_lingual')"
             >{{ furcaGlyph(t.furcation_lingual) }}</button>
           </td>
         </tr>
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Furca V</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaV') }}</th>
           <td v-for="t in orderedTeeth" :key="`furv-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Furca vestibular (0/I/II/III)"
+              :title="t('periodontogram.arch.furcaVTitle')"
               @click="onToothCycle(t, 'furcation_buccal')"
             >{{ furcaGlyph(t.furcation_buccal) }}</button>
           </td>
         </tr>
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Pronóstico</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.prognosis') }}</th>
           <td v-for="t in orderedTeeth" :key="`pron-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Bueno / Medio / Dudoso / Sin esperanza"
+              :title="t('periodontogram.arch.prognosisTitle')"
               @click="onToothCycle(t, 'prognosis')"
             >{{ prognosisGlyph(t.prognosis) }}</button>
           </td>
         </tr>
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Movilidad</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.mobility') }}</th>
           <td v-for="t in orderedTeeth" :key="`mob-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :disabled="readonly || !t.is_present"
-              title="Clic para cambiar movilidad (0–3)"
+              :title="t('periodontogram.arch.mobilityTitle')"
               @click="onToothCycle(t, 'mobility')"
             >{{ mobilityGlyph(t.mobility) }}</button>
           </td>
         </tr>
         <tr>
-          <th scope="row" class="px-1 text-right font-medium text-muted">Implante</th>
+          <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.implant') }}</th>
           <td v-for="t in orderedTeeth" :key="`imp-${t.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
               :class="{ 'text-emerald-600 dark:text-emerald-400': t.is_implant }"
               :disabled="readonly"
-              :title="t.is_implant ? 'Implante (clic para quitar)' : 'Clic para marcar como implante'"
+              :title="t.is_implant ? t('periodontogram.arch.implantToggleOn') : t('periodontogram.arch.implantToggleOff')"
               @click="onImplantToggle(t)"
             >{{ t.is_implant ? '●' : '·' }}</button>
           </td>

--- a/backend/app/modules/periodontogram/frontend/components/PerioArchBlock.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioArchBlock.vue
@@ -203,18 +203,18 @@ function selectOnFocus(e: FocusEvent) {
     >
       <colgroup>
         <col style="width: 96px" />
-        <col v-for="t in orderedTeeth" :key="`col-${t.tooth_number}`" style="width: 60px" />
+        <col v-for="tooth in orderedTeeth" :key="`col-${tooth.tooth_number}`" style="width: 60px" />
       </colgroup>
 
       <thead v-if="arch === 'upper'">
         <tr>
           <th class="px-1 text-right font-medium text-muted"></th>
           <th
-            v-for="t in orderedTeeth"
-            :key="`fdi-${t.tooth_number}`"
+            v-for="tooth in orderedTeeth"
+            :key="`fdi-${tooth.tooth_number}`"
             class="px-1 py-1 font-medium text-default"
           >
-            {{ t.tooth_number }}
+            {{ tooth.tooth_number }}
           </th>
         </tr>
       </thead>
@@ -224,15 +224,15 @@ function selectOnFocus(e: FocusEvent) {
         <!-- Implante (toggle ● / ·) -->
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.implant') }}</th>
-          <td v-for="t in orderedTeeth" :key="`imp-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`imp-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :class="{ 'text-emerald-600 dark:text-emerald-400': t.is_implant }"
+              :class="{ 'text-emerald-600 dark:text-emerald-400': tooth.is_implant }"
               :disabled="readonly"
-              :title="t.is_implant ? t('periodontogram.arch.implantToggleOn') : t('periodontogram.arch.implantToggleOff')"
-              @click="onImplantToggle(t)"
+              :title="tooth.is_implant ? t('periodontogram.arch.implantToggleOn') : t('periodontogram.arch.implantToggleOff')"
+              @click="onImplantToggle(tooth)"
             >
-              {{ t.is_implant ? '●' : '·' }}
+              {{ tooth.is_implant ? '●' : '·' }}
             </button>
           </td>
         </tr>
@@ -240,14 +240,14 @@ function selectOnFocus(e: FocusEvent) {
         <!-- Mobility (cycle 0..3 + null) -->
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.mobility') }}</th>
-          <td v-for="t in orderedTeeth" :key="`mob-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`mob-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.mobilityTitle')"
-              @click="onToothCycle(t, 'mobility')"
+              @click="onToothCycle(tooth, 'mobility')"
             >
-              {{ mobilityGlyph(t.mobility) }}
+              {{ mobilityGlyph(tooth.mobility) }}
             </button>
           </td>
         </tr>
@@ -255,14 +255,14 @@ function selectOnFocus(e: FocusEvent) {
         <!-- Prognosis cycle -->
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.prognosis') }}</th>
-          <td v-for="t in orderedTeeth" :key="`pron-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`pron-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.prognosisTitle')"
-              @click="onToothCycle(t, 'prognosis')"
+              @click="onToothCycle(tooth, 'prognosis')"
             >
-              {{ prognosisGlyph(t.prognosis) }}
+              {{ prognosisGlyph(tooth.prognosis) }}
             </button>
           </td>
         </tr>
@@ -270,27 +270,27 @@ function selectOnFocus(e: FocusEvent) {
         <!-- Furca V / L cycles -->
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaV') }}</th>
-          <td v-for="t in orderedTeeth" :key="`furv-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`furv-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.furcaVTitle')"
-              @click="onToothCycle(t, 'furcation_buccal')"
+              @click="onToothCycle(tooth, 'furcation_buccal')"
             >
-              {{ furcaGlyph(t.furcation_buccal) }}
+              {{ furcaGlyph(tooth.furcation_buccal) }}
             </button>
           </td>
         </tr>
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaLP') }}</th>
-          <td v-for="t in orderedTeeth" :key="`furl-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`furl-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.furcaLPTitle')"
-              @click="onToothCycle(t, 'furcation_lingual')"
+              @click="onToothCycle(tooth, 'furcation_lingual')"
             >
-              {{ furcaGlyph(t.furcation_lingual) }}
+              {{ furcaGlyph(tooth.furcation_lingual) }}
             </button>
           </td>
         </tr>
@@ -298,16 +298,16 @@ function selectOnFocus(e: FocusEvent) {
         <!-- Gingival width (numeric input) -->
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.gingivalWidth') }}</th>
-          <td v-for="t in orderedTeeth" :key="`kg-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`kg-${tooth.tooth_number}`" class="px-1">
             <input
               type="number"
               min="0"
               max="20"
-              :value="t.keratinized_gingiva_mm ?? ''"
-              :disabled="readonly || !t.is_present"
+              :value="tooth.keratinized_gingiva_mm ?? ''"
+              :disabled="readonly || !tooth.is_present"
               class="perio-cell-input"
               @focus="selectOnFocus"
-              @change="(e) => onToothNumberInput(t.tooth_number, 'keratinized_gingiva_mm', e)"
+              @change="(e) => onToothNumberInput(tooth.tooth_number, 'keratinized_gingiva_mm', e)"
             />
           </td>
         </tr>
@@ -322,50 +322,50 @@ function selectOnFocus(e: FocusEvent) {
           <th scope="row" class="px-1 text-right font-medium text-amber-700 dark:text-amber-400">
             {{ row.label }} <span class="text-[9px] text-amber-500 dark:text-amber-300/80">V</span>
           </th>
-          <td v-for="t in orderedTeeth" :key="`v-${row.kind}-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`v-${row.kind}-${tooth.tooth_number}`" class="px-1">
             <div class="flex items-center justify-center gap-0.5 tabular-nums">
-              <template v-for="code in VESTIBULAR_SITES" :key="`v-${row.kind}-${t.tooth_number}-${code}`">
+              <template v-for="code in VESTIBULAR_SITES" :key="`v-${row.kind}-${tooth.tooth_number}-${code}`">
                 <input
                   v-if="row.kind === 'site-pd'"
                   type="number"
                   min="0"
                   max="15"
-                  :value="siteValue(t, code)?.probing_depth_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.probing_depth_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'probing_depth_mm', e)"
                 />
                 <input
                   v-else-if="row.kind === 'site-gm'"
                   type="number"
                   min="-5"
                   max="10"
-                  :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.gingival_margin_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'gingival_margin_mm', e)"
                 />
                 <button
                   v-else-if="row.kind === 'site-plaque'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--plaque"
-                  :class="{ 'is-on': siteValue(t, code)?.plaque }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.plaque }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.plaqueTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'plaque', siteValue(tooth, code)?.plaque)"
                 />
                 <button
                   v-else-if="row.kind === 'site-bop'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--bop"
-                  :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.bleeding_on_probing }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.bleedingTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'bleeding_on_probing', siteValue(tooth, code)?.bleeding_on_probing)"
                 />
               </template>
             </div>
@@ -391,8 +391,8 @@ function selectOnFocus(e: FocusEvent) {
               />
             </div>
           </th>
-          <td v-for="t in orderedTeeth" :key="`v-tooth-${t.tooth_number}`" class="px-0 align-top">
-            <PerioToothLateral :tooth="t" face="vestibular" :readonly="readonly" />
+          <td v-for="tooth in orderedTeeth" :key="`v-tooth-${tooth.tooth_number}`" class="px-0 align-top">
+            <PerioToothLateral :tooth="tooth" face="vestibular" :readonly="readonly" />
           </td>
         </tr>
 
@@ -412,9 +412,9 @@ function selectOnFocus(e: FocusEvent) {
               />
             </div>
           </th>
-          <td v-for="t in orderedTeeth" :key="`p-tooth-${t.tooth_number}`" class="px-0 align-top">
+          <td v-for="tooth in orderedTeeth" :key="`p-tooth-${tooth.tooth_number}`" class="px-0 align-top">
             <PerioToothLateral
-              :tooth="t"
+              :tooth="tooth"
               :face="innerFace"
               :readonly="readonly"
               markers-position="above"
@@ -432,50 +432,50 @@ function selectOnFocus(e: FocusEvent) {
           <th scope="row" class="px-1 text-right font-medium text-sky-700 dark:text-sky-400">
             {{ row.label }} <span class="text-[9px] text-sky-500 dark:text-sky-300/80">{{ innerFaceLabel.charAt(0) }}</span>
           </th>
-          <td v-for="t in orderedTeeth" :key="`p-${row.kind}-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`p-${row.kind}-${tooth.tooth_number}`" class="px-1">
             <div class="flex items-center justify-center gap-0.5 tabular-nums">
-              <template v-for="code in innerSites" :key="`p-${row.kind}-${t.tooth_number}-${code}`">
+              <template v-for="code in innerSites" :key="`p-${row.kind}-${tooth.tooth_number}-${code}`">
                 <input
                   v-if="row.kind === 'site-pd'"
                   type="number"
                   min="0"
                   max="15"
-                  :value="siteValue(t, code)?.probing_depth_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.probing_depth_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'probing_depth_mm', e)"
                 />
                 <input
                   v-else-if="row.kind === 'site-gm'"
                   type="number"
                   min="-5"
                   max="10"
-                  :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.gingival_margin_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'gingival_margin_mm', e)"
                 />
                 <button
                   v-else-if="row.kind === 'site-plaque'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--plaque"
-                  :class="{ 'is-on': siteValue(t, code)?.plaque }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.plaque }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.plaqueTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'plaque', siteValue(tooth, code)?.plaque)"
                 />
                 <button
                   v-else-if="row.kind === 'site-bop'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--bop"
-                  :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.bleeding_on_probing }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.bleedingTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'bleeding_on_probing', siteValue(tooth, code)?.bleeding_on_probing)"
                 />
               </template>
             </div>
@@ -495,50 +495,50 @@ function selectOnFocus(e: FocusEvent) {
           <th scope="row" class="px-1 text-right font-medium text-sky-700 dark:text-sky-400">
             {{ row.label }} <span class="text-[9px] text-sky-500 dark:text-sky-300/80">L</span>
           </th>
-          <td v-for="t in orderedTeeth" :key="`l-${row.kind}-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`l-${row.kind}-${tooth.tooth_number}`" class="px-1">
             <div class="flex items-center justify-center gap-0.5 tabular-nums">
-              <template v-for="code in innerSites" :key="`l-${row.kind}-${t.tooth_number}-${code}`">
+              <template v-for="code in innerSites" :key="`l-${row.kind}-${tooth.tooth_number}-${code}`">
                 <input
                   v-if="row.kind === 'site-pd'"
                   type="number"
                   min="0"
                   max="15"
-                  :value="siteValue(t, code)?.probing_depth_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.probing_depth_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'probing_depth_mm', e)"
                 />
                 <input
                   v-else-if="row.kind === 'site-gm'"
                   type="number"
                   min="-5"
                   max="10"
-                  :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.gingival_margin_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'gingival_margin_mm', e)"
                 />
                 <button
                   v-else-if="row.kind === 'site-plaque'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--plaque"
-                  :class="{ 'is-on': siteValue(t, code)?.plaque }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.plaque }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.plaqueTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'plaque', siteValue(tooth, code)?.plaque)"
                 />
                 <button
                   v-else-if="row.kind === 'site-bop'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--bop"
-                  :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.bleeding_on_probing }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.bleedingTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'bleeding_on_probing', siteValue(tooth, code)?.bleeding_on_probing)"
                 />
               </template>
             </div>
@@ -562,8 +562,8 @@ function selectOnFocus(e: FocusEvent) {
               />
             </div>
           </th>
-          <td v-for="t in orderedTeeth" :key="`l-tooth-${t.tooth_number}`" class="px-0 align-bottom">
-            <PerioToothLateral :tooth="t" :face="innerFace" :readonly="readonly" />
+          <td v-for="tooth in orderedTeeth" :key="`l-tooth-${tooth.tooth_number}`" class="px-0 align-bottom">
+            <PerioToothLateral :tooth="tooth" :face="innerFace" :readonly="readonly" />
           </td>
         </tr>
 
@@ -584,9 +584,9 @@ function selectOnFocus(e: FocusEvent) {
               />
             </div>
           </th>
-          <td v-for="t in orderedTeeth" :key="`v-tooth-${t.tooth_number}`" class="px-0 align-top">
+          <td v-for="tooth in orderedTeeth" :key="`v-tooth-${tooth.tooth_number}`" class="px-0 align-top">
             <PerioToothLateral
-              :tooth="t"
+              :tooth="tooth"
               face="vestibular"
               :readonly="readonly"
               markers-position="above"
@@ -604,50 +604,50 @@ function selectOnFocus(e: FocusEvent) {
           <th scope="row" class="px-1 text-right font-medium text-amber-700 dark:text-amber-400">
             {{ row.label }} <span class="text-[9px] text-amber-500 dark:text-amber-300/80">V</span>
           </th>
-          <td v-for="t in orderedTeeth" :key="`v-${row.kind}-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`v-${row.kind}-${tooth.tooth_number}`" class="px-1">
             <div class="flex items-center justify-center gap-0.5 tabular-nums">
-              <template v-for="code in VESTIBULAR_SITES" :key="`v-${row.kind}-${t.tooth_number}-${code}`">
+              <template v-for="code in VESTIBULAR_SITES" :key="`v-${row.kind}-${tooth.tooth_number}-${code}`">
                 <input
                   v-if="row.kind === 'site-pd'"
                   type="number"
                   min="0"
                   max="15"
-                  :value="siteValue(t, code)?.probing_depth_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.probing_depth_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.probingTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'probing_depth_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'probing_depth_mm', e)"
                 />
                 <input
                   v-else-if="row.kind === 'site-gm'"
                   type="number"
                   min="-5"
                   max="10"
-                  :value="siteValue(t, code)?.gingival_margin_mm ?? ''"
-                  :disabled="readonly || !t.is_present"
+                  :value="siteValue(tooth, code)?.gingival_margin_mm ?? ''"
+                  :disabled="readonly || !tooth.is_present"
                   class="perio-cell-input perio-cell-input--site"
                   :title="t('periodontogram.arch.marginTitle', { code })"
                   @focus="selectOnFocus"
-                  @change="(e) => onSiteNumberInput(t.tooth_number, code, 'gingival_margin_mm', e)"
+                  @change="(e) => onSiteNumberInput(tooth.tooth_number, code, 'gingival_margin_mm', e)"
                 />
                 <button
                   v-else-if="row.kind === 'site-plaque'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--plaque"
-                  :class="{ 'is-on': siteValue(t, code)?.plaque }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.plaque }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.plaqueTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'plaque', siteValue(t, code)?.plaque)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'plaque', siteValue(tooth, code)?.plaque)"
                 />
                 <button
                   v-else-if="row.kind === 'site-bop'"
                   type="button"
                   class="perio-cell-toggle perio-cell-toggle--bop"
-                  :class="{ 'is-on': siteValue(t, code)?.bleeding_on_probing }"
-                  :disabled="readonly || !t.is_present"
+                  :class="{ 'is-on': siteValue(tooth, code)?.bleeding_on_probing }"
+                  :disabled="readonly || !tooth.is_present"
                   :title="t('periodontogram.arch.bleedingTitle', { code })"
-                  @click="onSiteToggle(t.tooth_number, code, 'bleeding_on_probing', siteValue(t, code)?.bleeding_on_probing)"
+                  @click="onSiteToggle(tooth.tooth_number, code, 'bleeding_on_probing', siteValue(tooth, code)?.bleeding_on_probing)"
                 />
               </template>
             </div>
@@ -657,73 +657,73 @@ function selectOnFocus(e: FocusEvent) {
         <!-- Per-tooth metrics (reversed — closest to vestibular row) -->
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.gingivalWidth') }}</th>
-          <td v-for="t in orderedTeeth" :key="`kg-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`kg-${tooth.tooth_number}`" class="px-1">
             <input
               type="number"
               min="0"
               max="20"
-              :value="t.keratinized_gingiva_mm ?? ''"
-              :disabled="readonly || !t.is_present"
+              :value="tooth.keratinized_gingiva_mm ?? ''"
+              :disabled="readonly || !tooth.is_present"
               class="perio-cell-input"
               @focus="selectOnFocus"
-              @change="(e) => onToothNumberInput(t.tooth_number, 'keratinized_gingiva_mm', e)"
+              @change="(e) => onToothNumberInput(tooth.tooth_number, 'keratinized_gingiva_mm', e)"
             />
           </td>
         </tr>
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaLP') }}</th>
-          <td v-for="t in orderedTeeth" :key="`furl-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`furl-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.furcaLPTitle')"
-              @click="onToothCycle(t, 'furcation_lingual')"
-            >{{ furcaGlyph(t.furcation_lingual) }}</button>
+              @click="onToothCycle(tooth, 'furcation_lingual')"
+            >{{ furcaGlyph(tooth.furcation_lingual) }}</button>
           </td>
         </tr>
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.furcaV') }}</th>
-          <td v-for="t in orderedTeeth" :key="`furv-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`furv-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.furcaVTitle')"
-              @click="onToothCycle(t, 'furcation_buccal')"
-            >{{ furcaGlyph(t.furcation_buccal) }}</button>
+              @click="onToothCycle(tooth, 'furcation_buccal')"
+            >{{ furcaGlyph(tooth.furcation_buccal) }}</button>
           </td>
         </tr>
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.prognosis') }}</th>
-          <td v-for="t in orderedTeeth" :key="`pron-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`pron-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.prognosisTitle')"
-              @click="onToothCycle(t, 'prognosis')"
-            >{{ prognosisGlyph(t.prognosis) }}</button>
+              @click="onToothCycle(tooth, 'prognosis')"
+            >{{ prognosisGlyph(tooth.prognosis) }}</button>
           </td>
         </tr>
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.mobility') }}</th>
-          <td v-for="t in orderedTeeth" :key="`mob-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`mob-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :disabled="readonly || !t.is_present"
+              :disabled="readonly || !tooth.is_present"
               :title="t('periodontogram.arch.mobilityTitle')"
-              @click="onToothCycle(t, 'mobility')"
-            >{{ mobilityGlyph(t.mobility) }}</button>
+              @click="onToothCycle(tooth, 'mobility')"
+            >{{ mobilityGlyph(tooth.mobility) }}</button>
           </td>
         </tr>
         <tr>
           <th scope="row" class="px-1 text-right font-medium text-muted">{{ t('periodontogram.arch.implant') }}</th>
-          <td v-for="t in orderedTeeth" :key="`imp-${t.tooth_number}`" class="px-1">
+          <td v-for="tooth in orderedTeeth" :key="`imp-${tooth.tooth_number}`" class="px-1">
             <button
               class="perio-cell-cycle"
-              :class="{ 'text-emerald-600 dark:text-emerald-400': t.is_implant }"
+              :class="{ 'text-emerald-600 dark:text-emerald-400': tooth.is_implant }"
               :disabled="readonly"
-              :title="t.is_implant ? t('periodontogram.arch.implantToggleOn') : t('periodontogram.arch.implantToggleOff')"
-              @click="onImplantToggle(t)"
-            >{{ t.is_implant ? '●' : '·' }}</button>
+              :title="tooth.is_implant ? t('periodontogram.arch.implantToggleOn') : t('periodontogram.arch.implantToggleOff')"
+              @click="onImplantToggle(tooth)"
+            >{{ tooth.is_implant ? '●' : '·' }}</button>
           </td>
         </tr>
       </tbody>
@@ -732,11 +732,11 @@ function selectOnFocus(e: FocusEvent) {
         <tr>
           <th class="px-1 text-right font-medium text-muted"></th>
           <th
-            v-for="t in orderedTeeth"
-            :key="`fdi-${t.tooth_number}`"
+            v-for="tooth in orderedTeeth"
+            :key="`fdi-${tooth.tooth_number}`"
             class="px-1 py-1 font-medium text-default"
           >
-            {{ t.tooth_number }}
+            {{ tooth.tooth_number }}
           </th>
         </tr>
       </tfoot>

--- a/backend/app/modules/periodontogram/frontend/components/PerioHistoryBanner.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioHistoryBanner.vue
@@ -13,7 +13,7 @@ const emit = defineEmits<{
   returnToCurrent: []
 }>()
 
-const { locale } = useI18n()
+const { t, locale } = useI18n()
 
 function formatDate(iso: string): string {
   try {
@@ -34,10 +34,10 @@ function formatDate(iso: string): string {
   >
     <div class="flex items-center gap-2">
       <UIcon name="i-lucide-history" />
-      <span>Viendo sesión del <strong>{{ formatDate(date) }}</strong> (solo lectura).</span>
+      <span>{{ t('periodontogram.history.viewingSession', { date: formatDate(date) }) }}</span>
     </div>
     <UButton variant="outline" size="xs" @click="emit('returnToCurrent')">
-      Volver al actual
+      {{ t('periodontogram.history.returnToCurrent') }}
     </UButton>
   </div>
 </template>

--- a/backend/app/modules/periodontogram/frontend/components/PerioIndicesBanner.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioIndicesBanner.vue
@@ -122,9 +122,9 @@ function confirmDiscard() {
             class="text-xs"
             aria-hidden="true"
           />
-          <span v-if="saveState === 'saving'">Guardando…</span>
-          <span v-else-if="saveState === 'dirty'">Cambios pendientes</span>
-          <span v-else>Cambios guardados</span>
+          <span v-if="saveState === 'saving'">{{ t('periodontogram.saveState.saving') }}</span>
+          <span v-else-if="saveState === 'dirty'">{{ t('periodontogram.saveState.dirty') }}</span>
+          <span v-else>{{ t('periodontogram.saveState.saved') }}</span>
         </span>
       </div>
 
@@ -138,7 +138,7 @@ function confirmDiscard() {
           size="sm"
           @click="showDiscard = true"
         >
-          Descartar borrador
+          {{ t('periodontogram.session.discardDraft') }}
         </UButton>
         <UButton
           icon="i-lucide-check"
@@ -146,7 +146,7 @@ function confirmDiscard() {
           color="primary"
           @click="showClose = true"
         >
-          Cerrar sesión
+          {{ t('periodontogram.session.closeSession') }}
         </UButton>
       </div>
     </div>
@@ -193,20 +193,19 @@ function confirmDiscard() {
     <!-- Close-session confirmation modal -->
     <UModal
       :open="showClose"
-      title="Cerrar sesión periodontal"
+      :title="t('periodontogram.session.closeTitle')"
       @update:open="(v) => { showClose = v }"
     >
       <template #body>
         <div class="space-y-3 p-4">
           <p class="text-sm text-muted">
-            Una vez cerrada, la sesión queda inmutable y aparece en el historial.
-            Para correcciones tendrás que abrir una nueva sesión.
+            {{ t('periodontogram.session.closeDescription') }}
           </p>
-          <UFormField label="Nota (opcional)">
+          <UFormField :label="t('periodontogram.indicesBanner.noteLabel')">
             <UTextarea
               v-model="notes"
               :rows="3"
-              placeholder="Observaciones de la exploración…"
+              :placeholder="t('periodontogram.indicesBanner.observationsPlaceholder')"
             />
           </UFormField>
         </div>
@@ -214,10 +213,10 @@ function confirmDiscard() {
       <template #footer>
         <div class="flex justify-end gap-2 p-2">
           <UButton variant="outline" color="neutral" @click="showClose = false">
-            Cancelar
+            {{ t('periodontogram.session.cancel') }}
           </UButton>
           <UButton color="primary" icon="i-lucide-check" @click="confirmClose">
-            Cerrar sesión
+            {{ t('periodontogram.session.closeButton') }}
           </UButton>
         </div>
       </template>
@@ -226,24 +225,23 @@ function confirmDiscard() {
     <!-- Discard-draft confirmation modal -->
     <UModal
       :open="showDiscard"
-      title="Descartar borrador"
+      :title="t('periodontogram.session.discardTitle')"
       @update:open="(v) => { showDiscard = v }"
     >
       <template #body>
         <div class="p-4">
           <p class="text-sm text-muted">
-            Se eliminarán todos los datos introducidos en esta sesión.
-            Esta acción no se puede deshacer.
+            {{ t('periodontogram.session.discardDescription') }}
           </p>
         </div>
       </template>
       <template #footer>
         <div class="flex justify-end gap-2 p-2">
           <UButton variant="outline" color="neutral" @click="showDiscard = false">
-            Cancelar
+            {{ t('periodontogram.session.cancel') }}
           </UButton>
           <UButton color="error" icon="i-lucide-trash-2" @click="confirmDiscard">
-            Descartar
+            {{ t('periodontogram.session.discardButton') }}
           </UButton>
         </div>
       </template>

--- a/backend/app/modules/periodontogram/frontend/components/PerioSiteMarker.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioSiteMarker.vue
@@ -21,13 +21,15 @@ const colourClass = computed(() => probingDepthClasses(props.site?.probing_depth
 // Tap targets bump to 44px on touch devices via the @media block in
 // the style section below. Visual size stays compact on desktop.
 const sizeClass = computed(() => (props.size === 'sm' ? 'h-4 w-4 text-[10px]' : 'h-5 w-5 text-xs'))
+
+const { t } = useI18n()
 </script>
 
 <template>
   <span
     class="perio-site-marker inline-flex items-center justify-center rounded-full font-mono font-medium ring-1 ring-inset"
     :class="[colourClass, sizeClass]"
-    :aria-label="`Sitio ${site?.site_code ?? ''}, sondaje ${site?.probing_depth_mm ?? 'sin valor'}`"
+    :aria-label="t('periodontogram.arch.siteMarkerAria', { code: site?.site_code ?? '', depth: site?.probing_depth_mm ?? t('common.noValue') })"
   >
     <span v-if="site?.probing_depth_mm != null">{{ site.probing_depth_mm }}</span>
     <span v-else>·</span>

--- a/backend/app/modules/periodontogram/frontend/components/PeriodontogramChart.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PeriodontogramChart.vue
@@ -36,6 +36,7 @@ const emit = defineEmits<{
 }>()
 
 const toast = useToast()
+const { t } = useI18n()
 
 const {
   saving,
@@ -51,8 +52,8 @@ const {
 watch(lastError, (err) => {
   if (err) {
     toast.add({
-      title: 'No se pudo guardar el cambio',
-      description: 'Comprueba tu conexión e intenta de nuevo.',
+      title: t('periodontogram.errors.saveFailed'),
+      description: t('periodontogram.errors.checkConnection'),
       color: 'error',
       icon: 'i-lucide-alert-triangle'
     })
@@ -177,7 +178,7 @@ const liveIndices = computed<PerioIndices | null>(() => {
     <div
       class="overflow-x-auto pb-2"
       role="region"
-      aria-label="Periodontograma — arcadas superior e inferior"
+      :aria-label="t('periodontogram.chart.ariaLabel')"
     >
       <div class="min-w-[1100px] space-y-4">
         <PerioArchBlock

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/en.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/en.json
@@ -20,7 +20,9 @@
       "discardTitle": "Discard draft",
       "discardDescription": "All data entered in this session will be deleted. This action cannot be undone.",
       "discardButton": "Discard",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "closeSession": "Close session",
+      "discardDraft": "Discard draft"
     },
     "indices": {
       "bop": "Bleeding",
@@ -77,9 +79,6 @@
       "loadFailed": "Could not load the periodontogram.",
       "saveFailed": "Could not save the change.",
       "checkConnection": "Check your connection and try again."
-    },
-    "chart": {
-      "ariaLabel": "Periodontogram — upper and lower arches"
     }
   }
 }

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/en.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/en.json
@@ -13,7 +13,14 @@
       "closedBadge": "Closed session",
       "recordedAt": "Recorded on {date}",
       "openDraft": "Open new session",
-      "continueDraft": "Continue draft"
+      "continueDraft": "Continue draft",
+      "closeTitle": "Close periodontal session",
+      "closeDescription": "Once closed, the session is immutable and appears in history. To make corrections you will need to open a new session.",
+      "closeButton": "Close session",
+      "discardTitle": "Discard draft",
+      "discardDescription": "All data entered in this session will be deleted. This action cannot be undone.",
+      "discardButton": "Discard",
+      "cancel": "Cancel"
     },
     "indices": {
       "bop": "Bleeding",
@@ -21,9 +28,58 @@
       "calMean": "Mean CAL",
       "deepPockets": "Pockets ≥5mm"
     },
+    "saveState": {
+      "saving": "Saving…",
+      "dirty": "Unsaved changes",
+      "saved": "Changes saved"
+    },
+    "history": {
+      "viewingSession": "Viewing session from {date} (read-only).",
+      "returnToCurrent": "Return to current"
+    },
+    "arch": {
+      "upper": "Upper",
+      "lower": "Lower",
+      "palatal": "Palatal",
+      "lingual": "Lingual",
+      "vestibular": "Vestibular",
+      "probing": "Probing",
+      "margin": "Margin",
+      "bleeding": "Bleeding",
+      "plaque": "Plaque",
+      "probingTitle": "{code} probing (0–15 mm)",
+      "marginTitle": "{code} gingival margin (-5 to 10 mm)",
+      "plaqueTitle": "{code} plaque (click to toggle)",
+      "bleedingTitle": "{code} bleeding (click to toggle)",
+      "implant": "Implant",
+      "implantToggleOn": "Implant (click to remove)",
+      "implantToggleOff": "Click to mark as implant",
+      "mobility": "Mobility",
+      "mobilityTitle": "Click to change mobility (0–3)",
+      "prognosis": "Prognosis",
+      "prognosisTitle": "Good / Fair / Doubtful / Hopeless",
+      "furcaV": "Furca V",
+      "furcaVTitle": "Vestibular furcation (0/I/II/III)",
+      "furcaLP": "Furca L/P",
+      "furcaLPTitle": "Lingual/palatal furcation (0/I/II/III)",
+      "gingivalWidth": "Gingival width",
+      "siteMarkerAria": "Site {code}, probing {depth}"
+    },
+    "chart": {
+      "ariaLabel": "Periodontogram — upper and lower arches"
+    },
+    "indicesBanner": {
+      "observationsPlaceholder": "Examination notes…",
+      "noteLabel": "Note (optional)"
+    },
     "loading": "Loading periodontogram…",
     "errors": {
-      "loadFailed": "Could not load the periodontogram."
+      "loadFailed": "Could not load the periodontogram.",
+      "saveFailed": "Could not save the change.",
+      "checkConnection": "Check your connection and try again."
+    },
+    "chart": {
+      "ariaLabel": "Periodontogram — upper and lower arches"
     }
   }
 }

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/es.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/es.json
@@ -21,6 +21,33 @@
       "calMean": "CAL medio",
       "deepPockets": "Bolsas ≥5mm"
     },
+    "arch": {
+      "upper": "Superior",
+      "lower": "Inferior",
+      "palatal": "Palatino",
+      "lingual": "Lingual",
+      "vestibular": "Vestibular",
+      "probing": "Sondaje",
+      "margin": "Margen",
+      "bleeding": "Sangrado",
+      "plaque": "Placa",
+      "probingTitle": "{code} sondaje (0–15 mm)",
+      "marginTitle": "{code} margen gingival (-5 a 10 mm)",
+      "plaqueTitle": "{code} placa (clic para alternar)",
+      "bleedingTitle": "{code} sangrado (clic para alternar)",
+      "implant": "Implante",
+      "implantToggleOn": "Implante (clic para quitar)",
+      "implantToggleOff": "Clic para marcar como implante",
+      "mobility": "Movilidad",
+      "mobilityTitle": "Clic para cambiar movilidad (0–3)",
+      "prognosis": "Pronóstico",
+      "prognosisTitle": "Bueno / Medio / Dudoso / Sin esperanza",
+      "furcaV": "Furca V",
+      "furcaVTitle": "Furca vestibular (0/I/II/III)",
+      "furcaLP": "Furca L/P",
+      "furcaLPTitle": "Furca lingual/palatina (0/I/II/III)",
+      "gingivalWidth": "Anchura encía"
+    },
     "loading": "Cargando periodontograma…",
     "errors": {
       "loadFailed": "No se pudo cargar el periodontograma."

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/es.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/es.json
@@ -13,7 +13,16 @@
       "closedBadge": "Sesión cerrada",
       "recordedAt": "Registrada el {date}",
       "openDraft": "Abrir nueva sesión",
-      "continueDraft": "Continuar borrador"
+      "continueDraft": "Continuar borrador",
+      "cancel": "Cancelar",
+      "closeSession": "Cerrar sesión",
+      "closeButton": "Cerrar sesión",
+      "closeTitle": "Cerrar sesión periodontal",
+      "closeDescription": "Una vez cerrada, la sesión queda inmutable y aparece en el historial. Para correcciones tendrás que abrir una nueva sesión.",
+      "discardDraft": "Descartar borrador",
+      "discardButton": "Descartar",
+      "discardTitle": "Descartar borrador",
+      "discardDescription": "Se eliminarán todos los datos introducidos en esta sesión. Esta acción no se puede deshacer."
     },
     "indices": {
       "bop": "Sangrado",
@@ -46,11 +55,30 @@
       "furcaVTitle": "Furca vestibular (0/I/II/III)",
       "furcaLP": "Furca L/P",
       "furcaLPTitle": "Furca lingual/palatina (0/I/II/III)",
-      "gingivalWidth": "Anchura encía"
+      "gingivalWidth": "Anchura encía",
+      "siteMarkerAria": "Sitio {code}, sondaje {depth}"
     },
     "loading": "Cargando periodontograma…",
     "errors": {
-      "loadFailed": "No se pudo cargar el periodontograma."
+      "loadFailed": "No se pudo cargar el periodontograma.",
+      "saveFailed": "No se pudo guardar el cambio",
+      "checkConnection": "Comprueba tu conexión e intenta de nuevo."
+    },
+    "chart": {
+      "ariaLabel": "Periodontograma — arcadas superior e inferior"
+    },
+    "history": {
+      "viewingSession": "Viendo sesión del {date} (solo lectura).",
+      "returnToCurrent": "Volver al actual"
+    },
+    "indicesBanner": {
+      "noteLabel": "Nota (opcional)",
+      "observationsPlaceholder": "Observaciones de la exploración…"
+    },
+    "saveState": {
+      "saving": "Guardando…",
+      "dirty": "Cambios pendientes",
+      "saved": "Cambios guardados"
     }
   }
 }

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/fr.json
@@ -20,7 +20,9 @@
       "discardTitle": "Abandonner le brouillon",
       "discardDescription": "Toutes les données saisies dans cette session seront supprimées. Cette action est irréversible.",
       "discardButton": "Abandonner",
-      "cancel": "Annuler"
+      "cancel": "Annuler",
+      "closeSession": "Clôturer la session",
+      "discardDraft": "Abandonner le brouillon"
     },
     "indices": {
       "bop": "Saignement",
@@ -77,9 +79,6 @@
       "loadFailed": "Impossible de charger le parodontogramme.",
       "saveFailed": "Impossible d'enregistrer la modification.",
       "checkConnection": "Vérifiez votre connexion et réessayez."
-    },
-    "chart": {
-      "ariaLabel": "Parodontogramme — arcades supérieure et inférieure"
     }
   }
 }

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/fr.json
@@ -1,0 +1,85 @@
+{
+  "periodontogram": {
+    "tab": {
+      "label": "Parodontogramme"
+    },
+    "empty": {
+      "title": "Aucun examen parodontal pour le moment",
+      "description": "Ouvrez une nouvelle session pour enregistrer les profondeurs de sondage, les saignements, la plaque et les autres métriques SEPA.",
+      "cta": "Commencer l'examen"
+    },
+    "session": {
+      "draftBadge": "Brouillon en cours",
+      "closedBadge": "Session clôturée",
+      "recordedAt": "Enregistré le {date}",
+      "openDraft": "Ouvrir une nouvelle session",
+      "continueDraft": "Continuer le brouillon",
+      "closeTitle": "Clôturer la session parodontale",
+      "closeDescription": "Une fois clôturée, la session est immutable et apparaît dans l'historique. Pour apporter des corrections, vous devrez ouvrir une nouvelle session.",
+      "closeButton": "Clôturer la session",
+      "discardTitle": "Abandonner le brouillon",
+      "discardDescription": "Toutes les données saisies dans cette session seront supprimées. Cette action est irréversible.",
+      "discardButton": "Abandonner",
+      "cancel": "Annuler"
+    },
+    "indices": {
+      "bop": "Saignement",
+      "pi": "Plaque",
+      "calMean": "CAL moyen",
+      "deepPockets": "Poches ≥5mm"
+    },
+    "saveState": {
+      "saving": "Enregistrement…",
+      "dirty": "Modifications non enregistrées",
+      "saved": "Modifications enregistrées"
+    },
+    "history": {
+      "viewingSession": "Visualisation de la session du {date} (lecture seule).",
+      "returnToCurrent": "Retour à la session actuelle"
+    },
+    "arch": {
+      "upper": "Supérieure",
+      "lower": "Inférieure",
+      "palatal": "Palatin",
+      "lingual": "Lingual",
+      "vestibular": "Vestibulaire",
+      "probing": "Sondage",
+      "margin": "Marge",
+      "bleeding": "Saignement",
+      "plaque": "Plaque",
+      "probingTitle": "{code} sondage (0–15 mm)",
+      "marginTitle": "{code} marge gingivale (-5 à 10 mm)",
+      "plaqueTitle": "{code} plaque (cliquer pour basculer)",
+      "bleedingTitle": "{code} saignement (cliquer pour basculer)",
+      "implant": "Implant",
+      "implantToggleOn": "Implant (cliquer pour retirer)",
+      "implantToggleOff": "Cliquer pour marquer comme implant",
+      "mobility": "Mobilité",
+      "mobilityTitle": "Cliquer pour modifier la mobilité (0–3)",
+      "prognosis": "Pronostic",
+      "prognosisTitle": "Bon / Moyen / Douteux / Sans espoir",
+      "furcaV": "Furca V",
+      "furcaVTitle": "Furca vestibulaire (0/I/II/III)",
+      "furcaLP": "Furca L/P",
+      "furcaLPTitle": "Furca linguale/palatine (0/I/II/III)",
+      "gingivalWidth": "Largeur gingivale",
+      "siteMarkerAria": "Site {code}, sondage {depth}"
+    },
+    "chart": {
+      "ariaLabel": "Parodontogramme — arcades supérieure et inférieure"
+    },
+    "indicesBanner": {
+      "observationsPlaceholder": "Notes d'examen…",
+      "noteLabel": "Note (optionnel)"
+    },
+    "loading": "Chargement du parodontogramme…",
+    "errors": {
+      "loadFailed": "Impossible de charger le parodontogramme.",
+      "saveFailed": "Impossible d'enregistrer la modification.",
+      "checkConnection": "Vérifiez votre connexion et réessayez."
+    },
+    "chart": {
+      "ariaLabel": "Parodontogramme — arcades supérieure et inférieure"
+    }
+  }
+}

--- a/backend/app/modules/periodontogram/frontend/nuxt.config.ts
+++ b/backend/app/modules/periodontogram/frontend/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French translations to seed data; fix `t()` dict pattern.
+
 - fix(security): reject `create` when `patient_id` belongs to another
   clinic (audit multi-tenancy #1, #95). Previously the recall was
   inserted with the caller's `clinic_id` but no check that the patient

--- a/backend/app/modules/recalls/frontend/components/MonthPickerDropdown.vue
+++ b/backend/app/modules/recalls/frontend/components/MonthPickerDropdown.vue
@@ -9,7 +9,7 @@ interface Props {
 const props = defineProps<Props>()
 const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
 
-const { locale } = useI18n()
+const { t, locale } = useI18n()
 
 const open = ref(false)
 
@@ -77,7 +77,7 @@ function goToday() {
             size="xs"
             variant="ghost"
             color="neutral"
-            :aria-label="'Previous year'"
+            :aria-label="t('common.previousYear')"
             @click="shiftYear(-1)"
           />
           <span class="font-medium tnum">{{ viewYear }}</span>
@@ -86,7 +86,7 @@ function goToday() {
             size="xs"
             variant="ghost"
             color="neutral"
-            :aria-label="'Next year'"
+            :aria-label="t('common.nextYear')"
             @click="shiftYear(1)"
           />
         </div>

--- a/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
@@ -5,6 +5,14 @@ import type { RecallSettings } from '../composables/useRecalls'
 const { t } = useI18n()
 const toast = useToast()
 const recallsApi = useRecalls()
+const { getCategoryLabel } = useTreatmentCatalog()
+const { categories: catalogCategories, getCategoryName, fetchCategories } = useCatalog()
+
+function resolveCategoryName(key: string): string {
+  const cat = catalogCategories.value.find(c => c.key === key)
+  if (cat) return getCategoryName(cat)
+  return t(getCategoryLabel(key))
+}
 
 const settings = ref<RecallSettings | null>(null)
 const isLoading = ref(false)
@@ -22,7 +30,10 @@ async function load() {
   }
 }
 
-onMounted(load)
+onMounted(() => {
+  load()
+  fetchCategories()
+})
 
 async function save() {
   if (!settings.value || isSaving.value) return
@@ -131,7 +142,7 @@ function removeCategory(key: string) {
             :key="row.key"
             class="flex items-center justify-between gap-3 py-2"
           >
-            <span class="font-mono text-sm">{{ row.key }}</span>
+            <span class="font-mono text-sm">{{ resolveCategoryName(row.key) }}</span>
             <span class="text-subtle">→</span>
             <span class="flex-1">{{ t(`recalls.reasons.${row.reason}`) }}</span>
             <UButton
@@ -146,7 +157,7 @@ function removeCategory(key: string) {
         <div class="flex gap-2 mt-3">
           <UInput
             v-model="newCategoryKey"
-            placeholder="catalog category key"
+            :placeholder="t('recalls.settings.categoryKeyPlaceholder')"
             class="flex-1"
           />
           <USelectMenu

--- a/backend/app/modules/recalls/frontend/i18n/locales/en.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/en.json
@@ -111,6 +111,7 @@
       "description": "Default intervals + treatment-category mapping",
       "intervals": "Default intervals (months)",
       "categoryMap": "Treatment → reason",
+      "categoryKeyPlaceholder": "catalog category key",
       "autoSuggest": "Suggest a recall when a treatment is completed",
       "autoLink": "Link a scheduled appointment to a pending recall",
       "saved": "Settings saved"

--- a/backend/app/modules/recalls/frontend/i18n/locales/es.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/es.json
@@ -111,6 +111,7 @@
       "description": "Intervalos por motivo y mapeo de tratamientos",
       "intervals": "Intervalos por defecto (meses)",
       "categoryMap": "Tratamiento → motivo",
+      "categoryKeyPlaceholder": "clave de categoría del catálogo",
       "autoSuggest": "Sugerir recordatorio al completar un tratamiento",
       "autoLink": "Vincular cita al recordatorio existente al agendar",
       "saved": "Configuración guardada"

--- a/backend/app/modules/recalls/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/fr.json
@@ -1,0 +1,129 @@
+{
+  "recalls": {
+    "title": "Rappels",
+    "callList": "Liste d'appels",
+    "noRecallsThisMonth": "Aucun rappel en attente ce mois-ci",
+    "filters": {
+      "month": "Mois",
+      "reason": "Motif",
+      "professional": "Professionnel",
+      "status": "Statut",
+      "priority": "Priorité",
+      "overdue": "Afficher les en retard",
+      "any": "Tous",
+      "thisMonth": "Ce mois-ci"
+    },
+    "counters": {
+      "due_this_week": "Échéance cette semaine",
+      "due_this_month": "Échéance ce mois-ci",
+      "overdue": "En retard",
+      "scheduled_this_month": "Planifiés ce mois-ci",
+      "completed_this_month": "Terminés ce mois-ci",
+      "conversion_rate": "Taux de conversion"
+    },
+    "setRecall": "Planifier un rappel",
+    "setRecallShort": "Rappel",
+    "history": "Historique des rappels",
+    "viewAll": "Voir tout",
+    "pillNext": "Prochain rappel : {month} · {reason}",
+    "pillNone": "Aucun rappel actif",
+    "reasons": {
+      "hygiene": "Hygiène",
+      "checkup": "Contrôle",
+      "ortho_review": "Revue d'orthodontie",
+      "implant_review": "Revue d'implant",
+      "post_op": "Post-opératoire",
+      "treatment_followup": "Suivi de traitement",
+      "other": "Autre"
+    },
+    "priority": {
+      "low": "Basse",
+      "normal": "Normale",
+      "high": "Haute"
+    },
+    "status": {
+      "pending": "En attente",
+      "contacted_no_answer": "Pas de réponse",
+      "contacted_scheduled": "Planifié",
+      "contacted_declined": "Refusé",
+      "done": "Terminé",
+      "cancelled": "Annulé",
+      "needs_review": "À revoir"
+    },
+    "actions": {
+      "call": "Appeler",
+      "logAttempt": "Enregistrer la tentative",
+      "noAnswer": "Pas de réponse",
+      "book": "Prendre rendez-vous",
+      "snooze": "Reporter",
+      "cancel": "Annuler",
+      "markDone": "Marquer terminé",
+      "exportCsv": "Exporter CSV",
+      "save": "Enregistrer"
+    },
+    "closeoutPrompt": {
+      "title": "Planifier un rappel ?",
+      "subtitle": "Le patient vient de terminer — quand devons-nous le rappeler ?",
+      "skip": "Pas maintenant"
+    },
+    "modal": {
+      "title": "Planifier un rappel",
+      "subtitle": "Marquer le patient pour un rappel futur",
+      "patient": "Patient",
+      "reason": "Motif",
+      "when": "Quand",
+      "month": "Mois cible",
+      "targetMonth": "Mois cible",
+      "preciseDate": "Choisir un jour précis",
+      "priority": "Priorité",
+      "assigned": "Professionnel assigné",
+      "note": "Note interne",
+      "notePlaceholder": "Détail optionnel (ex. « Vérifier la couronne sur 47 »)",
+      "optional": "optionnel",
+      "duplicateGuard": "Un rappel en attente existe déjà pour ce patient et ce motif. Il sera mis à jour."
+    },
+    "doNotContact": {
+      "cannotSchedule": "Ce patient est marqué « Ne pas contacter ». Les rappels ne peuvent pas être planifiés. Mettez à jour la préférence démographique pour réactiver le contact."
+    },
+    "activeRecallHint": "Rappel actif · appuyez pour gérer",
+    "logAttempt": {
+      "channel": "Canal",
+      "outcome": "Résultat",
+      "note": "Note",
+      "submit": "Enregistrer la tentative"
+    },
+    "channel": {
+      "phone": "Téléphone",
+      "whatsapp": "WhatsApp",
+      "sms": "SMS",
+      "email": "E-mail"
+    },
+    "outcome": {
+      "no_answer": "Pas de réponse",
+      "voicemail": "Messagerie vocale",
+      "scheduled": "Rendez-vous planifié",
+      "declined": "Refusé",
+      "wrong_number": "Mauvais numéro"
+    },
+    "snoozePrompt": "Reporter de combien de mois ?",
+    "settings": {
+      "title": "Rappels",
+      "description": "Intervalles par défaut + correspondance catégorie de traitement",
+      "intervals": "Intervalles par défaut (mois)",
+      "categoryMap": "Traitement → motif",
+      "categoryKeyPlaceholder": "clé de catégorie du catalogue",
+      "autoSuggest": "Suggérer un rappel lorsqu'un traitement est terminé",
+      "autoLink": "Lier un rendez-vous planifié à un rappel en attente",
+      "saved": "Paramètres enregistrés"
+    },
+    "dashboard": {
+      "title": "Rappels"
+    },
+    "suggestion": {
+      "title": "Rappel suggéré",
+      "body": "Après ce traitement, nous suggérons un rappel dans {month} ({reason}).",
+      "create": "Créer le rappel",
+      "dismiss": "Ignorer"
+    }
+  }
+}

--- a/backend/app/modules/recalls/frontend/nuxt.config.ts
+++ b/backend/app/modules/recalls/frontend/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/recalls/seed.py
+++ b/backend/app/modules/recalls/seed.py
@@ -53,13 +53,11 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "pending",
         "attempts": 0,
-        "note": t(
-            {
-                "es": "Recordatorio de higiene anual.",
-                "en": "Annual hygiene reminder.",
-                "fr": "Rappel d'hygiène annuel.",
-            }
-        ),
+        "note": {
+            "es": "Recordatorio de higiene anual.",
+            "en": "Annual hygiene reminder.",
+            "fr": "Rappel d'hygiène annuel.",
+        },
     },
     {
         "key": "no_answer_overdue_checkup",
@@ -68,13 +66,11 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "contacted_no_answer",
         "attempts": 2,
-        "note": t(
-            {
-                "es": "Revisión anual; no contesta al teléfono fijo.",
-                "en": "Annual checkup; no answer on landline.",
-                "fr": "Contrôle annuel ; pas de réponse au téléphone fixe.",
-            }
-        ),
+        "note": {
+            "es": "Revisión anual; no contesta al teléfono fijo.",
+            "en": "Annual checkup; no answer on landline.",
+            "fr": "Contrôle annuel ; pas de réponse au téléphone fixe.",
+        },
     },
     {
         "key": "scheduled_postop_high",
@@ -83,13 +79,11 @@ _SCENARIOS = (
         "priority": "high",
         "status": "contacted_scheduled",
         "attempts": 1,
-        "note": t(
-            {
-                "es": "Postoperatorio de cirugía 36; cita confirmada.",
-                "en": "Post-op surgery 36; appointment confirmed.",
-                "fr": "Post-opératoire chirurgie 36 ; rendez-vous confirmé.",
-            }
-        ),
+        "note": {
+            "es": "Postoperatorio de cirugía 36; cita confirmada.",
+            "en": "Post-op surgery 36; appointment confirmed.",
+            "fr": "Post-opératoire chirurgie 36 ; rendez-vous confirmé.",
+        },
     },
     {
         "key": "done_last_month_hygiene",
@@ -98,13 +92,11 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "done",
         "attempts": 1,
-        "note": t(
-            {
-                "es": "Higiene completada en visita previa.",
-                "en": "Hygiene completed at previous visit.",
-                "fr": "Hygiène complétée lors de la visite précédente.",
-            }
-        ),
+        "note": {
+            "es": "Higiene completada en visita previa.",
+            "en": "Hygiene completed at previous visit.",
+            "fr": "Hygiène complétée lors de la visite précédente.",
+        },
     },
     {
         "key": "pending_next_month_ortho",
@@ -113,13 +105,11 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "pending",
         "attempts": 0,
-        "note": t(
-            {
-                "es": "Revisión mensual de ortodoncia.",
-                "en": "Monthly orthodontic review.",
-                "fr": "Revue mensuelle d'orthodontie.",
-            }
-        ),
+        "note": {
+            "es": "Revisión mensual de ortodoncia.",
+            "en": "Monthly orthodontic review.",
+            "fr": "Revue mensuelle d'orthodontie.",
+        },
     },
     {
         "key": "needs_review_implant",
@@ -128,13 +118,11 @@ _SCENARIOS = (
         "priority": "high",
         "status": "needs_review",
         "attempts": 0,
-        "note": t(
-            {
-                "es": "Revisión de implante 46; revisar contacto.",
-                "en": "Implant 46 review; check contact.",
-                "fr": "Révision implant 46 ; vérifier le contact.",
-            }
-        ),
+        "note": {
+            "es": "Revisión de implante 46; revisar contacto.",
+            "en": "Implant 46 review; check contact.",
+            "fr": "Révision implant 46 ; vérifier le contact.",
+        },
     },
     {
         "key": "cancelled_treatment_followup",
@@ -143,13 +131,11 @@ _SCENARIOS = (
         "priority": "low",
         "status": "cancelled",
         "attempts": 1,
-        "note": t(
-            {
-                "es": "Paciente declina seguimiento.",
-                "en": "Patient declines follow-up.",
-                "fr": "Patient décline le suivi.",
-            }
-        ),
+        "note": {
+            "es": "Paciente declina seguimiento.",
+            "en": "Patient declines follow-up.",
+            "fr": "Patient décline le suivi.",
+        },
     },
     {
         "key": "pending_three_months_implant",
@@ -158,46 +144,36 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "pending",
         "attempts": 0,
-        "note": t(
-            {
-                "es": "Control de implante a los 3 meses.",
-                "en": "Implant check at 3 months.",
-                "fr": "Contrôle d'implant à 3 mois.",
-            }
-        ),
+        "note": {
+            "es": "Control de implante a los 3 meses.",
+            "en": "Implant check at 3 months.",
+            "fr": "Contrôle d'implant à 3 mois.",
+        },
     },
 )
 
 
 _ATTEMPT_NOTES = (
-    t(
-        {
-            "es": "Llamada al móvil sin respuesta.",
-            "en": "Called mobile, no answer.",
-            "fr": "Appel mobile sans réponse.",
-        }
-    ),
-    t(
-        {
-            "es": "Buzón de voz; mensaje dejado.",
-            "en": "Voicemail; message left.",
-            "fr": "Messagerie ; message laissé.",
-        }
-    ),
-    t(
-        {
-            "es": "Indica que llamemos la próxima semana.",
-            "en": "Asks us to call next week.",
-            "fr": "Demande de rappeler la semaine prochaine.",
-        }
-    ),
-    t(
-        {
-            "es": "Acuerda agendar tras revisar agenda laboral.",
-            "en": "Agrees to schedule after checking work calendar.",
-            "fr": "Accepte de planifier après vérification de l'agenda.",
-        }
-    ),
+    {
+        "es": "Llamada al móvil sin respuesta.",
+        "en": "Called mobile, no answer.",
+        "fr": "Appel mobile sans réponse.",
+    },
+    {
+        "es": "Buzón de voz; mensaje dejado.",
+        "en": "Voicemail; message left.",
+        "fr": "Messagerie ; message laissé.",
+    },
+    {
+        "es": "Indica que llamemos la próxima semana.",
+        "en": "Asks us to call next week.",
+        "fr": "Demande de rappeler la semaine prochaine.",
+    },
+    {
+        "es": "Acuerda agendar tras revisar agenda laboral.",
+        "en": "Agrees to schedule after checking work calendar.",
+        "fr": "Accepte de planifier après vérification de l'agenda.",
+    },
 )
 
 
@@ -280,7 +256,7 @@ async def seed_recalls_demo(
             due_month=due_month,
             due_date=None,
             reason=scenario["reason"],
-            reason_note=scenario["note"],
+            reason_note=t(scenario["note"]),
             priority=scenario["priority"],
             status=scenario["status"],
             recommended_by=dentist_id,
@@ -320,7 +296,7 @@ async def seed_recalls_demo(
                     channel=channel,
                     outcome=outcome,
                     attempted_at=now - timedelta(days=k + 1, hours=2 * k),
-                    note=_ATTEMPT_NOTES[(i + k) % len(_ATTEMPT_NOTES)],
+                    note=t(_ATTEMPT_NOTES[(i + k) % len(_ATTEMPT_NOTES)]),
                 )
             )
             stats["attempts"] += 1

--- a/backend/app/modules/recalls/seed.py
+++ b/backend/app/modules/recalls/seed.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.agenda.models import Appointment
 from app.modules.patients.models import Patient
+from app.seeds.demo_data import t
 
 from .models import Recall, RecallContactAttempt
 from .service import RecallSettingsService
@@ -52,7 +53,13 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "pending",
         "attempts": 0,
-        "note": "Recordatorio de higiene anual.",
+        "note": t(
+            {
+                "es": "Recordatorio de higiene anual.",
+                "en": "Annual hygiene reminder.",
+                "fr": "Rappel d'hygiène annuel.",
+            }
+        ),
     },
     {
         "key": "no_answer_overdue_checkup",
@@ -61,7 +68,13 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "contacted_no_answer",
         "attempts": 2,
-        "note": "Revisión anual; no contesta al teléfono fijo.",
+        "note": t(
+            {
+                "es": "Revisión anual; no contesta al teléfono fijo.",
+                "en": "Annual checkup; no answer on landline.",
+                "fr": "Contrôle annuel ; pas de réponse au téléphone fixe.",
+            }
+        ),
     },
     {
         "key": "scheduled_postop_high",
@@ -70,7 +83,13 @@ _SCENARIOS = (
         "priority": "high",
         "status": "contacted_scheduled",
         "attempts": 1,
-        "note": "Postoperatorio de cirugía 36; cita confirmada.",
+        "note": t(
+            {
+                "es": "Postoperatorio de cirugía 36; cita confirmada.",
+                "en": "Post-op surgery 36; appointment confirmed.",
+                "fr": "Post-opératoire chirurgie 36 ; rendez-vous confirmé.",
+            }
+        ),
     },
     {
         "key": "done_last_month_hygiene",
@@ -79,7 +98,13 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "done",
         "attempts": 1,
-        "note": "Higiene completada en visita previa.",
+        "note": t(
+            {
+                "es": "Higiene completada en visita previa.",
+                "en": "Hygiene completed at previous visit.",
+                "fr": "Hygiène complétée lors de la visite précédente.",
+            }
+        ),
     },
     {
         "key": "pending_next_month_ortho",
@@ -88,7 +113,13 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "pending",
         "attempts": 0,
-        "note": "Revisión mensual de ortodoncia.",
+        "note": t(
+            {
+                "es": "Revisión mensual de ortodoncia.",
+                "en": "Monthly orthodontic review.",
+                "fr": "Revue mensuelle d'orthodontie.",
+            }
+        ),
     },
     {
         "key": "needs_review_implant",
@@ -97,7 +128,13 @@ _SCENARIOS = (
         "priority": "high",
         "status": "needs_review",
         "attempts": 0,
-        "note": "Revisión de implante 46; revisar contacto.",
+        "note": t(
+            {
+                "es": "Revisión de implante 46; revisar contacto.",
+                "en": "Implant 46 review; check contact.",
+                "fr": "Révision implant 46 ; vérifier le contact.",
+            }
+        ),
     },
     {
         "key": "cancelled_treatment_followup",
@@ -106,7 +143,13 @@ _SCENARIOS = (
         "priority": "low",
         "status": "cancelled",
         "attempts": 1,
-        "note": "Paciente declina seguimiento.",
+        "note": t(
+            {
+                "es": "Paciente declina seguimiento.",
+                "en": "Patient declines follow-up.",
+                "fr": "Patient décline le suivi.",
+            }
+        ),
     },
     {
         "key": "pending_three_months_implant",
@@ -115,16 +158,46 @@ _SCENARIOS = (
         "priority": "normal",
         "status": "pending",
         "attempts": 0,
-        "note": "Control de implante a los 3 meses.",
+        "note": t(
+            {
+                "es": "Control de implante a los 3 meses.",
+                "en": "Implant check at 3 months.",
+                "fr": "Contrôle d'implant à 3 mois.",
+            }
+        ),
     },
 )
 
 
 _ATTEMPT_NOTES = (
-    "Llamada al móvil sin respuesta.",
-    "Buzón de voz; mensaje dejado.",
-    "Indica que llamemos la próxima semana.",
-    "Acuerda agendar tras revisar agenda laboral.",
+    t(
+        {
+            "es": "Llamada al móvil sin respuesta.",
+            "en": "Called mobile, no answer.",
+            "fr": "Appel mobile sans réponse.",
+        }
+    ),
+    t(
+        {
+            "es": "Buzón de voz; mensaje dejado.",
+            "en": "Voicemail; message left.",
+            "fr": "Messagerie ; message laissé.",
+        }
+    ),
+    t(
+        {
+            "es": "Indica que llamemos la próxima semana.",
+            "en": "Asks us to call next week.",
+            "fr": "Demande de rappeler la semaine prochaine.",
+        }
+    ),
+    t(
+        {
+            "es": "Acuerda agendar tras revisar agenda laboral.",
+            "en": "Agrees to schedule after checking work calendar.",
+            "fr": "Accepte de planifier après vérification de l'agenda.",
+        }
+    ),
 )
 
 

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - fix(agents): `find_free_slots` now returns contiguous free **windows**
   (`free_windows` with real `start`/`end`/`minutes`) instead of a single
   fixed-size slot per gap that masked its true extent. The agent could not

--- a/backend/app/modules/schedules/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/schedules/frontend/i18n/locales/fr.json
@@ -1,0 +1,82 @@
+{
+  "schedules": {
+    "nav": {
+      "clinicHours": "Horaires de la clinique",
+      "professionalSchedules": "Emplois du temps des professionnels"
+    },
+    "settingsCards": {
+      "clinicHoursTitle": "Horaires de la clinique",
+      "clinicHoursDescription": "Définir les horaires d'ouverture hebdomadaires de la clinique et les dates spéciales (congés, horaires réduits).",
+      "professionalHoursTitle": "Emplois du temps des professionnels",
+      "professionalHoursDescription": "Définir les emplois du temps individuels de chaque professionnel et gérer les congés ou autres périodes d'indisponibilité."
+    },
+    "clinicHours": {
+      "title": "Horaires de la clinique",
+      "subtitle": "Définir les horaires d'ouverture de la clinique pour chaque jour de la semaine.",
+      "weeklyTemplate": "Modèle hebdomadaire",
+      "overrides": "Dates spéciales",
+      "addOverride": "Ajouter une date spéciale",
+      "editOverride": "Modifier la date spéciale",
+      "save": "Enregistrer les modifications",
+      "saved": "Emploi du temps mis à jour",
+      "savedError": "Échec de l'enregistrement de l'emploi du temps"
+    },
+    "professionalHours": {
+      "title": "Emplois du temps des professionnels",
+      "selectProfessional": "Sélectionner un professionnel",
+      "weeklyTemplate": "Emploi du temps hebdomadaire",
+      "overrides": "Absences et horaires spéciaux",
+      "addOverride": "Ajouter une absence",
+      "editOverride": "Modifier l'absence",
+      "save": "Enregistrer les modifications",
+      "saved": "Emploi du temps mis à jour"
+    },
+    "weekday": {
+      "0": "Lundi",
+      "1": "Mardi",
+      "2": "Mercredi",
+      "3": "Jeudi",
+      "4": "Vendredi",
+      "5": "Samedi",
+      "6": "Dimanche",
+      "closed": "Fermé",
+      "addShift": "Ajouter un créneau",
+      "removeShift": "Supprimer le créneau",
+      "start": "Début",
+      "end": "Fin"
+    },
+    "overrides": {
+      "startDate": "Date de début",
+      "endDate": "Date de fin",
+      "kind": "Type",
+      "reason": "Motif",
+      "reasonPlaceholder": "Par exemple : Noël, conférence...",
+      "closed": "Fermé",
+      "customHours": "Horaires personnalisés",
+      "unavailable": "Indisponible",
+      "noOverrides": "Aucune date spéciale planifiée",
+      "delete": "Supprimer",
+      "confirmDelete": "Supprimer cette période ?",
+      "add": "Ajouter",
+      "save": "Enregistrer",
+      "cancel": "Annuler"
+    },
+    "analytics": {
+      "occupancyTitle": "Taux d'occupation par cabine",
+      "utilizationTitle": "Utilisation par professionnel",
+      "peakHoursTitle": "Heures de pointe",
+      "bookedMinutes": "Minutes réservées",
+      "availableMinutes": "Minutes disponibles",
+      "rate": "Taux d'occupation",
+      "noData": "Aucune donnée pour la période sélectionnée"
+    },
+    "availability": {
+      "clinicClosed": "Clinique fermée",
+      "professionalOff": "Professionnel indisponible",
+      "outsideHours": "En dehors des horaires configurés",
+      "confirmOutside": "Ce créneau est en dehors des heures de travail. Créer le rendez-vous quand même ?",
+      "confirm": "Créer quand même",
+      "cancel": "Annuler"
+    }
+  }
+}

--- a/backend/app/modules/schedules/frontend/nuxt.config.ts
+++ b/backend/app/modules/schedules/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: add `fr` fallback to plan item name resolution in service
+  layer so French-localized treatment names display correctly.
+
 - refactor(scheduler): declare the ``auto_close_expired_plans`` cron job
   via ``get_scheduled_jobs()`` instead of being imported by name in
   ``app/core/scheduler.py``.

--- a/backend/app/modules/treatment_plan/service.py
+++ b/backend/app/modules/treatment_plan/service.py
@@ -948,7 +948,7 @@ class TreatmentPlanService:
             patient_id_str = str(item.treatment.patient_id)
             if item.treatment.catalog_item:
                 names = item.treatment.catalog_item.names or {}
-                item_name = names.get("es") or names.get("en")
+                item_name = names.get("es") or names.get("en") or names.get("fr")
                 if item.treatment.catalog_item.category:
                     treatment_category_key = item.treatment.catalog_item.category.key
 

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - fix(frontend): the queue tabs (Pendientes/Rechazadas/Fallos) rendered
   the same unfiltered list — `listQueue` passed `{ params }`, which
   `useApi` dropped. Switched to the new `useApi` `query` option so the

--- a/backend/app/modules/verifactu/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/verifactu/frontend/i18n/locales/fr.json
@@ -1,0 +1,351 @@
+{
+  "verifactu": {
+    "nav": { "settings": "Verifactu (AEAT)" },
+    "settingsCards": {
+      "title": "Verifactu (AEAT)",
+      "description": "Facturation électronique conforme à la réglementation espagnole. Gérez le certificat, le producteur SIF, la file d'envoi et le registre fiscal.",
+      "open": "Ouvrir"
+    },
+    "title": "Verifactu (AEAT)",
+    "subtitle": "Facturation électronique conforme à la réglementation espagnole (RRSIF / Veri*Factu).",
+    "hero": {
+      "loading": { "title": "Chargement…", "description": "" },
+      "setup": {
+        "title": "Configuration en cours",
+        "description": "Complétez les étapes suivantes avant d'activer Verifactu."
+      },
+      "inactive": {
+        "title": "Prêt à activer",
+        "description": "Toute la configuration est terminée. Activez Verifactu pour commencer à envoyer des factures à l'AEAT."
+      },
+      "active-test": {
+        "title": "Verifactu actif en test",
+        "description": "Les factures sont envoyées au sandbox de l'AEAT. Utile pour valider l'intégration avant de passer en production."
+      },
+      "active-prod": {
+        "title": "Verifactu actif en production",
+        "description": "Les factures sont envoyées comme données fiscales réelles à l'AEAT. Toute erreur est officiellement enregistrée."
+      },
+      "activate": "Activer Verifactu",
+      "deactivate": "Désactiver Verifactu"
+    },
+    "setup": {
+      "clinicNif": "Configurez le numéro fiscal de la clinique (CIF/NIF)",
+      "clinicNifCta": "Informations clinique",
+      "producer": "Remplissez les détails du producteur du SIF",
+      "producerCta": "Producteur",
+      "declaration": "Signez la déclaration responsable du producteur",
+      "declarationCta": "Signer",
+      "certificate": "Téléchargez le certificat numérique (FNMT)",
+      "certificateCta": "Télécharger"
+    },
+    "cards": {
+      "manage": "Gérer",
+      "emisor": {
+        "title": "Données de l'émetteur",
+        "editHint": "Ces données proviennent des informations de la clinique. Pour les modifier, éditez-les là.",
+        "editLink": "Informations clinique"
+      },
+      "producer": {
+        "empty": "Producteur SIF non configuré."
+      },
+      "vatMapping": {
+        "title": "Classification TVA AEAT",
+        "description": "Associez chaque type de TVA du catalogue à sa classification AEAT (S1, E1, N1…)."
+      },
+      "activity": {
+        "title": "Activité"
+      }
+    },
+    "modal": {
+      "confirmProdTitle": "Passer en production ?",
+      "confirmProdAction": "Oui, passer en production"
+    },
+    "vatMapping": {
+      "title": "Classification TVA AEAT",
+      "subtitle": "Définissez comment chaque type de TVA du catalogue se traduit par sa classification AEAT dans chaque enregistrement Verifactu.",
+      "legalIntroTitle": "Fonctionnement",
+      "legalIntro": "Laisser une ligne sur « Auto » utilise une heuristique (taux>0 → S1, taux=0 → N1). Pour les services cliniques dentaires, il est généralement préférable de définir « E1 — Exonéré art. 20 LIVA ». Les cliniques espagnoles n'ont généralement besoin que d'une exception sur le type TVA « Exonéré ».",
+      "empty": "Aucun type de TVA dans le catalogue de la clinique.",
+      "rate": "Taux",
+      "defaultBadge": "Par défaut",
+      "autoOption": "Auto ({code}) — utiliser l'heuristique",
+      "sourceAuto": "automatique",
+      "sourceOverride": "exception définie",
+      "save": "Enregistrer",
+      "saved": "Classification enregistrée.",
+      "saveFailed": "Impossible d'enregistrer la classification.",
+      "notesPlaceholder": "Notes (ex. « art. 20.uno.3.º LIVA »)"
+    },
+    "environment": {
+      "test": "Test",
+      "prod": "Production",
+      "switchToProd": "Passer en production",
+      "switchToTest": "Passer en test",
+      "warningProd": "Vous allez passer en production. À partir de maintenant, chaque facture émise sera envoyée à l'AEAT comme enregistrement fiscal réel.",
+      "label": "Environnement"
+    },
+    "errors": {
+      "cannotPromoteToProd": "Votre rôle ne permet pas de passer Verifactu en production. Demandez à un administrateur d'effectuer ce changement."
+    },
+    "status": {
+      "enabled": "Activé",
+      "disabled": "Désactivé",
+      "noCertificate": "Aucun certificat",
+      "certificateExpiringSoon": "Le certificat expire dans {days} jours",
+      "certificateExpired": "Certificat expiré"
+    },
+    "settings": {
+      "title": "Paramètres Verifactu",
+      "enable": "Activer Verifactu",
+      "enableHint": "Lorsque activé, chaque facture émise est automatiquement envoyée à l'AEAT.",
+      "nifEmisor": "NIF de l'émetteur",
+      "nifEmisorHint": "Le NIF de la clinique. Doit correspondre au certificat.",
+      "nombreRazon": "Raison sociale de l'émetteur",
+      "save": "Enregistrer",
+      "saved": "Paramètres enregistrés"
+    },
+    "certificate": {
+      "title": "Certificat numérique",
+      "description": "Téléchargez le certificat FNMT de la clinique (.pfx / .p12). Stocké chiffré.",
+      "active": "Certificat actif",
+      "healthy": "Valide",
+      "subject": "Titulaire",
+      "issuer": "Émetteur",
+      "nif": "NIF du titulaire",
+      "validFrom": "Valide du",
+      "validUntil": "Valide jusqu'au",
+      "uploadFile": "Fichier du certificat",
+      "uploadHint": "Accepte les formats .pfx et .p12.",
+      "password": "Mot de passe du certificat",
+      "passwordHint": "Le mot de passe protégeant le fichier. Jamais stocké en clair.",
+      "passwordPlaceholder": "••••••••",
+      "togglePassword": "Afficher/masquer le mot de passe",
+      "uploadButton": "Télécharger le certificat",
+      "uploadTitle": "Télécharger le certificat",
+      "replaceTitle": "Remplacer le certificat",
+      "uploadSubmit": "Télécharger le certificat",
+      "replaceSubmit": "Remplacer le certificat",
+      "uploaded": "Certificat téléchargé et actif",
+      "uploadFailed": "Impossible de télécharger le certificat",
+      "invalidFormat": "Format invalide. Téléchargez un fichier .pfx ou .p12.",
+      "history": "Historique des certificats",
+      "historyEmpty": "Aucun certificat téléchargé.",
+      "noActive": "Aucun certificat actif",
+      "noActiveHint": "Téléchargez votre certificat FNMT (.pfx / .p12) pour activer Verifactu et signer les envois à l'AEAT.",
+      "dropzoneTitle": "Déposez votre certificat ici",
+      "dropzoneSubtitle": "ou cliquez pour sélectionner un fichier",
+      "dropzoneFormats": "Format .pfx ou .p12",
+      "removeFile": "Supprimer le fichier",
+      "encryptionNote": "Le fichier et le mot de passe sont chiffrés avec la clé du serveur. Jamais stockés en clair.",
+      "helpTitle": "Où obtenir le certificat ?",
+      "helpBody": "Pour signer les envois à l'AEAT, vous avez besoin d'un certificat numérique pour la clinique, émis par la FNMT. Trois types valides :",
+      "helpItem1": "Certificat de représentant légal — pour les sociétés (S.L., S.A.).",
+      "helpItem2": "Certificat personnel — pour les travailleurs indépendants dont le NIF correspond à l'émetteur.",
+      "helpItem3": "Sceau d'entreprise — alternative pour les entités.",
+      "fnmtLink": "Demander le certificat sur le portail FNMT"
+    },
+    "queue": {
+      "title": "File d'envoi",
+      "tabs": { "pending": "En attente", "rejected": "Rejeté", "transient": "Erreurs transitoires" },
+      "empty": "Aucun enregistrement dans cet état.",
+      "retry": "Réessayer",
+      "regenerateAndRetry": "Régénérer et renvoyer",
+      "regenerateTooltip": "Recalcule l'enregistrement à partir des données actuelles (NIF, lignes…) et le renvoie en Subsanación.",
+      "retryAll": "Tout régénérer",
+      "retryAllConfirm": "Sur le point de régénérer tous les enregistrements rejetés pour cette clinique. Continuer ?",
+      "retryAllResult": "{n} enregistrements régénérés ({failed} échoués).",
+      "viewInvoice": "Voir la facture",
+      "viewHistory": "Historique AEAT",
+      "errorCode": "Code",
+      "transportError": "Erreur de transport",
+      "aeatFault": "Réponse d'erreur AEAT",
+      "rawError": "Message brut AEAT",
+      "submissionAttempt": "Tentative {n}",
+      "processNow": "Traiter maintenant",
+      "processed": "{n} enregistrements traités",
+      "regeneratedToast": "Enregistrement régénéré et renvoyé.",
+      "blockingBanner": {
+        "title": "{n} enregistrement(s) Verifactu rejeté(s)",
+        "description": "Vous ne pouvez pas émettre de nouvelles factures tant qu'ils ne sont pas résolus (cela briserait la chaîne de hachage).",
+        "cta": "Ouvrir la file",
+        "adminContact": "Demandez à l'administrateur {email} si vous n'avez pas accès."
+      },
+      "ctas": {
+        "edit_clinic": "Corriger mes données fiscales",
+        "edit_billing_party": "Modifier les données client",
+        "edit_lines": "Vérifier les lignes de facture",
+        "edit_producer": "Modifier le producteur SIF",
+        "retry": "Réessayer",
+        "contact_support": "Contacter le support"
+      },
+      "history": {
+        "title": "Historique des envois AEAT",
+        "empty": "Aucune tentative antérieure archivée (premier envoi).",
+        "attempt": "Tentative #{n}",
+        "huella": "Hash",
+        "code": "Code AEAT"
+      }
+    },
+    "billingParty": {
+      "modalTitle": "Modifier les données client",
+      "intro": "Ces informations seront envoyées à l'AEAT comme destinataire lors du prochain envoi.",
+      "fields": {
+        "name": "Nom / raison sociale",
+        "taxId": "Numéro fiscal",
+        "address": "Adresse"
+      },
+      "save": "Enregistrer et renvoyer",
+      "saved": "Enregistré. Verifactu renverra l'enregistrement automatiquement.",
+      "concurrentEdit": "Quelqu'un d'autre a modifié cette facture entre-temps. Rechargez et réessayez.",
+      "saveFailed": "Impossible d'enregistrer."
+    },
+    "invoiceBanner": {
+      "rejectedTitle": "L'AEAT a rejeté cet enregistrement Verifactu",
+      "rejectedBody": "Corrigez les données ci-dessous et nous le renverrons automatiquement en Subsanación.",
+      "pdfStaleTitle": "Le PDF téléchargé peut être obsolète",
+      "pdfStaleBody": "Le QR change après correction et réenvoi. Retéléchargez le PDF si vous l'avez déjà envoyé au patient.",
+      "downloadAgain": "Télécharger un nouveau PDF"
+    },
+    "nif": {
+      "warningInvalid": "Le format du numéro fiscal ne semble pas correct. L'AEAT pourrait le rejeter."
+    },
+    "globalBanner": {
+      "title": "Verifactu : {n} facture(s) rejetée(s) par l'AEAT",
+      "description": "Résolvez-les avant d'émettre de nouvelles factures (cela briserait la chaîne de hachage).",
+      "cta": "Résoudre"
+    },
+    "badge": {
+      "short": "AEAT",
+      "tooltip": {
+        "ok": "Accepté par l'AEAT",
+        "warning": "Accepté avec observations par l'AEAT",
+        "pending": "En attente d'envoi à l'AEAT",
+        "error": "Rejeté par l'AEAT"
+      }
+    },
+    "filter": {
+      "label": "Verifactu",
+      "options": {
+        "ok": "Accepté",
+        "warning": "Avec observations",
+        "pending": "En attente",
+        "error": "Rejeté"
+      },
+      "shortcut": "Uniquement les problèmes",
+      "empty": "Toutes les factures Verifactu sont à jour."
+    },
+    "records": {
+      "title": "Registre fiscal",
+      "subtitle": "Historique immuable des enregistrements envoyés à l'AEAT.",
+      "filterState": "État",
+      "filterTipo": "Type",
+      "columns": {
+        "createdAt": "Date",
+        "tipoFactura": "Type",
+        "serieNumero": "Numéro",
+        "importe": "Montant",
+        "state": "État",
+        "csv": "CSV AEAT"
+      },
+      "viewXml": "Voir le XML",
+      "verifyChain": "Vérifier la chaîne"
+    },
+    "tipoFactura": {
+      "F1": "F1 — Facture complète",
+      "F2": "F2 — Simplifiée",
+      "F3": "F3 — Substitution",
+      "R1": "R1 — Rectification",
+      "R2": "R2 — Créance irrécouvrable",
+      "R5": "R5 — Rectification simplifiée"
+    },
+    "recordState": {
+      "pending": "En attente",
+      "sending": "Envoi en cours",
+      "accepted": "Accepté",
+      "accepted_with_errors": "Accepté avec erreurs",
+      "rejected": "Rejeté",
+      "failed_transient": "Nouvelle tentative",
+      "failed_validation": "Erreur de validation"
+    },
+    "panel": {
+      "verifactuTitle": "Verifactu",
+      "huella": "Hash",
+      "csv": "CSV AEAT",
+      "qr": "Code QR",
+      "viewRecord": "Voir l'enregistrement complet",
+      "submittedAt": "Envoyé",
+      "stillPending": "En attente d'envoi à l'AEAT"
+    },
+    "producer": {
+      "title": "Producteur SIF",
+      "subtitle": "Identification légale de la personne qui met le logiciel en production et signe la déclaration responsable.",
+      "legalIntroTitle": "Responsabilité légale",
+      "legalIntro": "L'art. 13 du RD 1007/2023 exige que le producteur du Sistema Informático de Facturación signe une déclaration responsable. Si DentalPin est proposé en tant que SaaS géré, le producteur est l'opérateur SaaS. Si une clinique s'auto-héberge (autodesarrollo), la clinique elle-même est le producteur. Si un intégrateur le déploie, l'intégrateur est le producteur.",
+      "process": {
+        "title": "Ce que vous devez faire",
+        "s1": "Identifier qui est le producteur du SIF (étape 1) — données légales qui apparaissent dans la déclaration et dans chaque enregistrement envoyé à l'AEAT.",
+        "s2": "Lire la déclaration responsable et la signer électroniquement (étape 2). Le système scelle la date et l'utilisateur signataire comme preuve.",
+        "s3": "Télécharger le PDF signé (étape 3) pour l'archivage et, si vous exploitez un SaaS, pour le distribuer à vos cliniques.",
+        "legalNote": "La signature électronique stockée dans le système constitue une preuve suffisante pour un audit AEAT. Le PDF est un document informatif dérivé de cette signature."
+      },
+      "step1": {
+        "title": "Données du producteur",
+        "description": "Ces champs identifient légalement le producteur du SIF et sont intégrés à la fois dans la déclaration responsable et dans le bloc SistemaInformatico de chaque enregistrement envoyé à l'AEAT.",
+        "lockedTitle": "Données scellées",
+        "lockedDescription": "La déclaration a déjà été signée avec ces données, elle est donc verrouillée. Contactez le support pour révoquer la signature si vous devez les modifier."
+      },
+      "step2": {
+        "title": "Signer la déclaration",
+        "description": "Lisez attentivement le texte. Une fois satisfait, cochez la case et cliquez sur Signer électroniquement. La signature est scellée dans le système avec la date et l'utilisateur."
+      },
+      "step3": {
+        "title": "Télécharger la déclaration signée",
+        "description": "Document imprimable avec les données du producteur et le cachet de signature électronique. Utile pour l'archivage interne, l'audit AEAT ou la distribution aux cliniques utilisant le système.",
+        "lockedHint": "Disponible après la signature de la déclaration (étape 2)."
+      },
+      "fields": {
+        "name": "Raison sociale du producteur",
+        "nameHint": "Raison sociale de la société ou du travailleur indépendant agissant comme producteur du SIF.",
+        "nif": "NIF du producteur",
+        "nifHint": "NIF du producteur du SIF. Apparaît sur chaque enregistrement envoyé à l'AEAT.",
+        "idSistema": "ID du système",
+        "idSistemaHint": "Identifiant court (1-2 caractères) que le producteur attribue au système. Par défaut : DP.",
+        "version": "Version du système",
+        "versionHint": "Version du logiciel déployé en production (ex. 0.1.0)."
+      },
+      "declaration": {
+        "heading": "Déclaration responsable",
+        "legalRef": "Sistema Informático de Facturación — Veri*Factu (RD 1007/2023, art. 13)",
+        "preamble": "En application de l'article 13 du Décret royal 1007/2023 (RRSIF) et de l'ordre HAC/1177/2024 :",
+        "identity": "{name}, avec le NIF {nif}, agissant en qualité de producteur du Sistema Informático de Facturación dénommé DentalPin (identifiant du système {idSistema}, version {version}), déclare responsablement que :",
+        "item1": "Le système répond aux exigences de l'article 29.2.j) de la loi 58/2003 (General Tributaria) et du RRSIF.",
+        "item2": "Le système garantit l'intégrité, la conservation, l'accessibilité, la lisibilité, la traçabilité et l'inaltérabilité des enregistrements de facturation.",
+        "item3": "Le système met en œuvre l'envoi continu des enregistrements à l'AEAT en mode Veri*Factu.",
+        "item4": "Le producteur s'engage à maintenir le système à jour au fur et à mesure de l'évolution de la réglementation."
+      },
+      "statusSigned": "Signé",
+      "statusUnsigned": "En attente de signature",
+      "readAndAccept": "J'ai lu et j'accepte la déclaration responsable en tant que producteur du SIF.",
+      "signButton": "Signer électroniquement",
+      "signNote": "Le clic sur le bouton enregistre la signature avec la date et votre utilisateur. L'action ne peut pas être annulée depuis l'interface.",
+      "signedToast": "Déclaration signée et enregistrée.",
+      "sealedNote": "Les données du producteur sont scellées comme preuve pour tout audit AEAT potentiel.",
+      "saveDraft": "Enregistrer sans signer",
+      "draftSaved": "Brouillon enregistré (signature en attente).",
+      "downloadPdf": "Télécharger le PDF signé",
+      "revokeAction": "Révoquer la signature pour modifier",
+      "revokeTitle": "Révoquer la signature ?",
+      "revokeBody": "La révocation de la signature électronique vous permet de modifier à nouveau les données du producteur. Avant de continuer :",
+      "revokeBullet1": "La signature actuelle perd sa valeur légale comme preuve AEAT.",
+      "revokeBullet2": "Verifactu se désactive automatiquement jusqu'à la signature de la nouvelle déclaration.",
+      "revokeBullet3": "Les enregistrements déjà envoyés à l'AEAT ne sont pas affectés — seul le producteur déclaré pour les envois futurs change.",
+      "revokeConfirm": "Révoquer et modifier",
+      "revokedToast": "Signature révoquée. Vous pouvez maintenant modifier les données du producteur.",
+      "signLabel": "Signer la déclaration responsable",
+      "alreadySigned": "Déclaration signée",
+      "signedAt": "Signée électroniquement le {at}",
+      "saveFailed": "Impossible d'enregistrer les informations du producteur."
+    }
+  }
+}

--- a/backend/app/modules/verifactu/frontend/nuxt.config.ts
+++ b/backend/app/modules/verifactu/frontend/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/whatsapp_kapso/CHANGELOG.md
+++ b/backend/app/modules/whatsapp_kapso/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add French locale (`fr.json`) with full UI coverage.
+
 - feat: initial release. WhatsApp delivery for the notifications gateway via
   Kapso (Meta Cloud API). Community, installable/removable (issue #63).
 - `KapsoAdapter` (template + free-form session sends) registered into the

--- a/backend/app/modules/whatsapp_kapso/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/whatsapp_kapso/frontend/i18n/locales/fr.json
@@ -1,0 +1,38 @@
+{
+  "whatsapp_kapso": {
+    "settings": {
+      "title": "WhatsApp (Kapso)",
+      "description": "Connectez le numéro WhatsApp de la clinique via Kapso pour envoyer et recevoir des messages."
+    },
+    "connection": "Connexion",
+    "verified": "Vérifié",
+    "notVerified": "Non vérifié",
+    "apiKey": "Clé API Kapso",
+    "phoneNumberId": "Phone number ID",
+    "businessAccountId": "Business account ID",
+    "businessAccountHelp": "Nécessaire pour synchroniser les modèles approuvés.",
+    "displayPhone": "Numéro visible",
+    "webhookSecret": "Secret du webhook",
+    "secretStored": "Enregistré. Laissez vide pour le conserver.",
+    "webhook": "Webhook",
+    "webhookHelp": "Collez cette URL dans les paramètres webhook de Kapso pour recevoir les statuts et les réponses.",
+    "copy": "Copier",
+    "copied": "URL copiée",
+    "templates": "Modèles",
+    "sync": "Synchroniser",
+    "noTemplates": "Aucun modèle approuvé. Synchronisez pour les récupérer depuis Kapso.",
+    "notificationType": "Type de notification",
+    "template": "Modèle",
+    "map": "Associer",
+    "mapped": "Modèle associé",
+    "mapError": "Impossible d'associer le modèle",
+    "test": "Envoi test",
+    "sendTest": "Envoyer un test",
+    "testOk": "Message test envoyé",
+    "testFail": "Échec de l'envoi du test",
+    "saved": "Paramètres enregistrés",
+    "saveError": "Impossible d'enregistrer",
+    "synced": "{n} modèles synchronisés",
+    "syncError": "Impossible de synchroniser"
+  }
+}

--- a/backend/app/modules/whatsapp_kapso/frontend/nuxt.config.ts
+++ b/backend/app/modules/whatsapp_kapso/frontend/nuxt.config.ts
@@ -9,7 +9,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', file: 'en.json' },
-      { code: 'es', file: 'es.json' }
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/seeds/demo_data.py
+++ b/backend/app/seeds/demo_data.py
@@ -15,7 +15,7 @@ from uuid import UUID, uuid4
 # Language Configuration
 # =============================================================================
 
-SupportedLang = Literal["es", "en"]
+SupportedLang = Literal["es", "en", "fr"]
 LANG: SupportedLang = "en"  # Default language
 
 
@@ -81,18 +81,18 @@ def get_clinic_data() -> dict:
     """Get clinic data in current language."""
     return {
         "id": CLINIC_ID,
-        "name": t({"es": "Clínica Dental Demo", "en": "Demo Dental Clinic"}),
-        "tax_id": t({"es": "B12345678", "en": "12-3456789"}),
+        "name": t({"es": "Clínica Dental Demo", "en": "Demo Dental Clinic", "fr": "Clinique Dentaire Démo"}),
+        "tax_id": t({"es": "B12345678", "en": "12-3456789", "fr": "12-3456789"}),
         "address": {
-            "street": t({"es": "Calle Gran Vía 123", "en": "123 Main Street"}),
-            "city": t({"es": "Madrid", "en": "New York"}),
-            "postal_code": t({"es": "28013", "en": "10001"}),
-            "country": t({"es": "España", "en": "USA"}),
+            "street": t({"es": "Calle Gran Vía 123", "en": "123 Main Street", "fr": "123 Rue Principale"}),
+            "city": t({"es": "Madrid", "en": "New York", "fr": "Paris"}),
+            "postal_code": t({"es": "28013", "en": "10001", "fr": "75001"}),
+            "country": t({"es": "España", "en": "USA", "fr": "France"}),
         },
-        "phone": t({"es": "+34 912 345 678", "en": "+1 (212) 555-0100"}),
+        "phone": t({"es": "+34 912 345 678", "en": "+1 (212) 555-0100", "fr": "+33 1 23 45 67 89"}),
         "email": "info@demo.clinic",
-        "currency": t({"es": "EUR", "en": "USD"}),
-        "timezone": t({"es": "Europe/Madrid", "en": "America/New_York"}),
+        "currency": t({"es": "EUR", "en": "USD", "fr": "EUR"}),
+        "timezone": t({"es": "Europe/Madrid", "en": "America/New_York", "fr": "Europe/Paris"}),
         "settings": {
             "slot_duration_min": 30,
             "working_hours": {
@@ -104,8 +104,8 @@ def get_clinic_data() -> dict:
             },
         },
         "cabinets": [
-            {"name": t({"es": "Gabinete 1", "en": "Room 1"}), "color": "#3B82F6"},
-            {"name": t({"es": "Gabinete 2", "en": "Room 2"}), "color": "#10B981"},
+            {"name": t({"es": "Gabinete 1", "en": "Room 1", "fr": "Cabinet 1"}), "color": "#3B82F6"},
+            {"name": t({"es": "Gabinete 2", "en": "Room 2", "fr": "Cabinet 2"}), "color": "#10B981"},
         ],
     }
 
@@ -115,22 +115,27 @@ USERS_I18N = {
     "admin": {
         "es": {"first_name": "Admin", "last_name": "Demo"},
         "en": {"first_name": "Admin", "last_name": "Demo"},
+        "fr": {"first_name": "Admin", "last_name": "Démo"},
     },
     "dentist": {
         "es": {"first_name": "María", "last_name": "García López"},
         "en": {"first_name": "Sarah", "last_name": "Johnson"},
+        "fr": {"first_name": "Marie", "last_name": "Dubois Laurent"},
     },
     "hygienist": {
         "es": {"first_name": "Carlos", "last_name": "López Martínez"},
         "en": {"first_name": "Michael", "last_name": "Williams"},
+        "fr": {"first_name": "Thomas", "last_name": "Moreau"},
     },
     "assistant": {
         "es": {"first_name": "Ana", "last_name": "Martínez Ruiz"},
         "en": {"first_name": "Emily", "last_name": "Davis"},
+        "fr": {"first_name": "Camille", "last_name": "Petit"},
     },
     "receptionist": {
         "es": {"first_name": "Laura", "last_name": "Sánchez Pérez"},
         "en": {"first_name": "Jessica", "last_name": "Brown"},
+        "fr": {"first_name": "Julie", "last_name": "Bernard"},
     },
 }
 
@@ -151,7 +156,7 @@ def get_users_data() -> list[dict]:
             "email": "dentist@demo.clinic",
             "first_name": USERS_I18N["dentist"][LANG]["first_name"],
             "last_name": USERS_I18N["dentist"][LANG]["last_name"],
-            "professional_id": t({"es": "28/12345", "en": "DDS-12345"}),
+            "professional_id": t({"es": "28/12345", "en": "DDS-12345", "fr": "DF-12345"}),
             "role": "dentist",
             "membership_id": MEMBERSHIP_DENTIST_ID,
         },
@@ -160,7 +165,7 @@ def get_users_data() -> list[dict]:
             "email": "hygienist@demo.clinic",
             "first_name": USERS_I18N["hygienist"][LANG]["first_name"],
             "last_name": USERS_I18N["hygienist"][LANG]["last_name"],
-            "professional_id": t({"es": "28/54321", "en": "RDH-54321"}),
+            "professional_id": t({"es": "28/54321", "en": "RDH-54321", "fr": "OEF-54321"}),
             "role": "hygienist",
             "membership_id": MEMBERSHIP_HYGIENIST_ID,
         },
@@ -203,7 +208,12 @@ PATIENTS_I18N = [
             "last_name": "Miller",
             "notes": "Pediatric patient. First visit for checkup.",
         },
-        "phone": {"es": "+34 612 345 001", "en": "+1 (212) 555-0001"},
+        "fr": {
+            "first_name": "Hugo",
+            "last_name": "Morel",
+            "notes": "Patient pédiatrique. Première visite pour contrôle.",
+        },
+        "phone": {"es": "+34 612 345 001", "en": "+1 (212) 555-0001", "fr": "+33 6 12 34 56 01"},
         "email": None,
         "date_of_birth": date(2016, 3, 15),
         "emergency_contact": {
@@ -219,6 +229,13 @@ PATIENTS_I18N = [
                 "relationship": "Father",
                 "phone": "+1 (212) 555-0100",
                 "email": "john.miller@email.com",
+                "is_legal_guardian": True,
+            },
+            "fr": {
+                "name": "Marc Morel",
+                "relationship": "Père",
+                "phone": "+33 6 12 34 56 51",
+                "email": "marc.morel@email.com",
                 "is_legal_guardian": True,
             },
         },
@@ -239,8 +256,13 @@ PATIENTS_I18N = [
             "last_name": "Wilson",
             "notes": "Orthodontic treatment in progress.",
         },
-        "phone": {"es": "+34 612 345 002", "en": "+1 (212) 555-0002"},
-        "email": {"es": "lucia.rodriguez@email.com", "en": "olivia.wilson@email.com"},
+        "fr": {
+            "first_name": "Léa",
+            "last_name": "Laurent",
+            "notes": "Traitement d'orthodontie en cours.",
+        },
+        "phone": {"es": "+34 612 345 002", "en": "+1 (212) 555-0002", "fr": "+33 6 12 34 56 02"},
+        "email": {"es": "lucia.rodriguez@email.com", "en": "olivia.wilson@email.com", "fr": "lea.laurent@email.com"},
         "date_of_birth": date(2010, 7, 22),
         "emergency_contact": {
             "es": {
@@ -257,6 +279,13 @@ PATIENTS_I18N = [
                 "email": "sarah.wilson@email.com",
                 "is_legal_guardian": True,
             },
+            "fr": {
+                "name": "Isabelle Laurent",
+                "relationship": "Mère",
+                "phone": "+33 6 12 34 56 52",
+                "email": "isabelle.laurent@email.com",
+                "is_legal_guardian": True,
+            },
         },
         "medical_history": {
             "allergies": [],
@@ -268,8 +297,9 @@ PATIENTS_I18N = [
         "id": PATIENT_IDS[2],
         "es": {"first_name": "Miguel", "last_name": "González Torres", "notes": None},
         "en": {"first_name": "James", "last_name": "Anderson", "notes": None},
-        "phone": {"es": "+34 612 345 003", "en": "+1 (212) 555-0003"},
-        "email": {"es": "miguel.gonzalez@email.com", "en": "james.anderson@email.com"},
+        "fr": {"first_name": "Lucas", "last_name": "Rousseau", "notes": None},
+        "phone": {"es": "+34 612 345 003", "en": "+1 (212) 555-0003", "fr": "+33 6 12 34 56 03"},
+        "email": {"es": "miguel.gonzalez@email.com", "en": "james.anderson@email.com", "fr": "lucas.rousseau@email.com"},
         "date_of_birth": date(1998, 11, 8),
         "emergency_contact": {
             "es": {
@@ -283,6 +313,13 @@ PATIENTS_I18N = [
                 "name": "Laura Anderson",
                 "relationship": "Sister",
                 "phone": "+1 (212) 555-0102",
+                "email": None,
+                "is_legal_guardian": False,
+            },
+            "fr": {
+                "name": "Claire Rousseau",
+                "relationship": "Soeur",
+                "phone": "+33 6 12 34 56 53",
                 "email": None,
                 "is_legal_guardian": False,
             },
@@ -304,8 +341,13 @@ PATIENTS_I18N = [
             "last_name": "Taylor",
             "notes": "Dental sensitivity. Use anesthesia with caution.",
         },
-        "phone": {"es": "+34 612 345 004", "en": "+1 (212) 555-0004"},
-        "email": {"es": "carmen.diaz@email.com", "en": "emma.taylor@email.com"},
+        "fr": {
+            "first_name": "Chloé",
+            "last_name": "Bertrand",
+            "notes": "Sensibilité dentaire. Utiliser l'anesthésie avec précaution.",
+        },
+        "phone": {"es": "+34 612 345 004", "en": "+1 (212) 555-0004", "fr": "+33 6 12 34 56 04"},
+        "email": {"es": "carmen.diaz@email.com", "en": "emma.taylor@email.com", "fr": "chloe.bertrand@email.com"},
         "date_of_birth": date(1995, 5, 30),
         "emergency_contact": {
             "es": {
@@ -322,19 +364,27 @@ PATIENTS_I18N = [
                 "email": "peter.taylor@email.com",
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Jean-Pierre Bertrand",
+                "relationship": "Mari",
+                "phone": "+33 6 12 34 56 54",
+                "email": "jean-pierre.bertrand@email.com",
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [
                 {
-                    "name": {"es": "Látex", "en": "Latex"},
+                    "name": {"es": "Látex", "en": "Latex", "fr": "Latex"},
                     "severity": "medium",
-                    "reaction": {"es": "Irritación cutánea", "en": "Skin irritation"},
+                    "reaction": {"es": "Irritación cutánea", "en": "Skin irritation", "fr": "Irritation cutanée"},
                 },
             ],
             "adverse_reactions_to_anesthesia": True,
             "anesthesia_reaction_details": {
                 "es": "Mareos y náuseas post-anestesia",
                 "en": "Dizziness and nausea post-anesthesia",
+                "fr": "Vertige et nausée post-anesthésie",
             },
             "systemic_diseases": [],
         },
@@ -343,7 +393,8 @@ PATIENTS_I18N = [
         "id": PATIENT_IDS[4],
         "es": {"first_name": "David", "last_name": "Martín López", "notes": None},
         "en": {"first_name": "William", "last_name": "Thomas", "notes": None},
-        "phone": {"es": "+34 612 345 005", "en": "+1 (212) 555-0005"},
+        "fr": {"first_name": "Alexandre", "last_name": "Moreau", "notes": None},
+        "phone": {"es": "+34 612 345 005", "en": "+1 (212) 555-0005", "fr": "+33 6 12 34 56 05"},
         "email": None,
         "date_of_birth": date(1992, 2, 14),
         "emergency_contact": None,
@@ -365,8 +416,13 @@ PATIENTS_I18N = [
             "last_name": "Martinez",
             "notes": "Pregnant (third trimester). Avoid X-rays.",
         },
-        "phone": {"es": "+34 612 345 006", "en": "+1 (212) 555-0006"},
-        "email": {"es": "elena.ruiz@email.com", "en": "sophia.martinez@email.com"},
+        "fr": {
+            "first_name": "Manon",
+            "last_name": "Lefebvre",
+            "notes": "Enceinte (troisième trimestre). Éviter les radiographies.",
+        },
+        "phone": {"es": "+34 612 345 006", "en": "+1 (212) 555-0006", "fr": "+33 6 12 34 56 06"},
+        "email": {"es": "elena.ruiz@email.com", "en": "sophia.martinez@email.com", "fr": "manon.lefebvre@email.com"},
         "date_of_birth": date(1985, 9, 3),
         "emergency_contact": {
             "es": {
@@ -381,6 +437,13 @@ PATIENTS_I18N = [
                 "relationship": "Husband",
                 "phone": "+1 (212) 555-0104",
                 "email": "andrew.martinez@email.com",
+                "is_legal_guardian": False,
+            },
+            "fr": {
+                "name": "Antoine Lefebvre",
+                "relationship": "Mari",
+                "phone": "+33 6 12 34 56 55",
+                "email": "antoine.lefebvre@email.com",
                 "is_legal_guardian": False,
             },
         },
@@ -403,8 +466,13 @@ PATIENTS_I18N = [
             "last_name": "Garcia",
             "notes": "Type 2 diabetic. Monitor healing.",
         },
-        "phone": {"es": "+34 612 345 007", "en": "+1 (212) 555-0007"},
-        "email": {"es": "javier.sanchez@email.com", "en": "daniel.garcia@email.com"},
+        "fr": {
+            "first_name": "Nicolas",
+            "last_name": "Simon",
+            "notes": "Diabétique de type 2. Surveillance de la cicatrisation.",
+        },
+        "phone": {"es": "+34 612 345 007", "en": "+1 (212) 555-0007", "fr": "+33 6 12 34 56 07"},
+        "email": {"es": "javier.sanchez@email.com", "en": "daniel.garcia@email.com", "fr": "nicolas.simon@email.com"},
         "date_of_birth": date(1980, 12, 25),
         "emergency_contact": {
             "es": {
@@ -421,16 +489,24 @@ PATIENTS_I18N = [
                 "email": "anna.garcia@email.com",
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Nathalie Simon",
+                "relationship": "Épouse",
+                "phone": "+33 6 12 34 56 56",
+                "email": "nathalie.simon@email.com",
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Diabetes Mellitus Tipo 2", "en": "Type 2 Diabetes Mellitus"},
+                    "name": {"es": "Diabetes Mellitus Tipo 2", "en": "Type 2 Diabetes Mellitus", "fr": "Diabète de type 2"},
                     "is_critical": True,
                     "notes": {
                         "es": "Controlada con metformina. HbA1c: 7.2%",
                         "en": "Controlled with metformin. HbA1c: 7.2%",
+                        "fr": "Contrôlé avec metformine. HbA1c : 7,2%",
                     },
                 },
             ],
@@ -440,7 +516,8 @@ PATIENTS_I18N = [
         "id": PATIENT_IDS[7],
         "es": {"first_name": "Isabel", "last_name": "López Navarro", "notes": None},
         "en": {"first_name": "Mia", "last_name": "Robinson", "notes": None},
-        "phone": {"es": "+34 612 345 008", "en": "+1 (212) 555-0008"},
+        "fr": {"first_name": "Clémentine", "last_name": "Michel", "notes": None},
+        "phone": {"es": "+34 612 345 008", "en": "+1 (212) 555-0008", "fr": "+33 6 12 34 56 08"},
         "email": None,
         "date_of_birth": date(1978, 6, 17),
         "emergency_contact": {
@@ -455,6 +532,13 @@ PATIENTS_I18N = [
                 "name": "Robert Robinson",
                 "relationship": "Brother",
                 "phone": "+1 (212) 555-0106",
+                "email": None,
+                "is_legal_guardian": False,
+            },
+            "fr": {
+                "name": "Philippe Michel",
+                "relationship": "Frère",
+                "phone": "+33 6 12 34 56 57",
                 "email": None,
                 "is_legal_guardian": False,
             },
@@ -477,8 +561,13 @@ PATIENTS_I18N = [
             "last_name": "Clark",
             "notes": "Allergic to penicillin.",
         },
-        "phone": {"es": "+34 612 345 009", "en": "+1 (212) 555-0009"},
-        "email": {"es": "francisco.garcia@email.com", "en": "alexander.clark@email.com"},
+        "fr": {
+            "first_name": "Guillaume",
+            "last_name": "Laurent",
+            "notes": "Allergique à la pénicilline.",
+        },
+        "phone": {"es": "+34 612 345 009", "en": "+1 (212) 555-0009", "fr": "+33 6 12 34 56 09"},
+        "email": {"es": "francisco.garcia@email.com", "en": "alexander.clark@email.com", "fr": "guillaume.laurent@email.com"},
         "date_of_birth": date(1975, 4, 9),
         "emergency_contact": {
             "es": {
@@ -495,18 +584,25 @@ PATIENTS_I18N = [
                 "email": "martha.clark@email.com",
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Catherine Laurent",
+                "relationship": "Épouse",
+                "phone": "+33 6 12 34 56 58",
+                "email": "catherine.laurent@email.com",
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [
                 {
-                    "name": {"es": "Penicilina", "en": "Penicillin"},
+                    "name": {"es": "Penicilina", "en": "Penicillin", "fr": "Pénicilline"},
                     "severity": "critical",
-                    "reaction": {"es": "Anafilaxia", "en": "Anaphylaxis"},
+                    "reaction": {"es": "Anafilaxia", "en": "Anaphylaxis", "fr": "Anaphylaxie"},
                 },
                 {
-                    "name": {"es": "Amoxicilina", "en": "Amoxicillin"},
+                    "name": {"es": "Amoxicilina", "en": "Amoxicillin", "fr": "Amoxicilline"},
                     "severity": "high",
-                    "reaction": {"es": "Urticaria severa", "en": "Severe urticaria"},
+                    "reaction": {"es": "Urticaria severa", "en": "Severe urticaria", "fr": "Urticaire sévère"},
                 },
             ],
             "systemic_diseases": [],
@@ -524,8 +620,13 @@ PATIENTS_I18N = [
             "last_name": "Lewis",
             "notes": "Hypertensive. Check blood pressure before procedures.",
         },
-        "phone": {"es": "+34 612 345 010", "en": "+1 (212) 555-0010"},
-        "email": {"es": "rosa.martinez@email.com", "en": "charlotte.lewis@email.com"},
+        "fr": {
+            "first_name": "Sophie",
+            "last_name": "Garnier",
+            "notes": "Hypertendue. Vérifier la tension avant les soins.",
+        },
+        "phone": {"es": "+34 612 345 010", "en": "+1 (212) 555-0010", "fr": "+33 6 12 34 56 10"},
+        "email": {"es": "rosa.martinez@email.com", "en": "charlotte.lewis@email.com", "fr": "sophie.garnier@email.com"},
         "date_of_birth": date(1970, 8, 21),
         "emergency_contact": {
             "es": {
@@ -542,16 +643,24 @@ PATIENTS_I18N = [
                 "email": None,
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Patrick Garnier",
+                "relationship": "Mari",
+                "phone": "+33 6 12 34 56 59",
+                "email": None,
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Hipertensión Arterial", "en": "Arterial Hypertension"},
+                    "name": {"es": "Hipertensión Arterial", "en": "Arterial Hypertension", "fr": "Hypertension artérielle"},
                     "is_critical": True,
                     "notes": {
                         "es": "Tratamiento con enalapril 10mg/día. PA habitual: 130/85",
                         "en": "Treatment with enalapril 10mg/day. Usual BP: 130/85",
+                        "fr": "Traitement par énalapril 10mg/j. PA habituelle : 130/85",
                     },
                 },
             ],
@@ -570,7 +679,12 @@ PATIENTS_I18N = [
             "last_name": "Walker",
             "notes": "Upper partial denture.",
         },
-        "phone": {"es": "+34 612 345 011", "en": "+1 (212) 555-0011"},
+        "fr": {
+            "first_name": "François",
+            "last_name": "David",
+            "notes": "Prothèse partielle supérieure.",
+        },
+        "phone": {"es": "+34 612 345 011", "en": "+1 (212) 555-0011", "fr": "+33 6 12 34 56 11"},
         "email": None,
         "date_of_birth": date(1960, 1, 5),
         "emergency_contact": {
@@ -588,20 +702,27 @@ PATIENTS_I18N = [
                 "email": "carmen.walker@email.com",
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Marie-Anne David",
+                "relationship": "Fille",
+                "phone": "+33 6 12 34 56 60",
+                "email": "marie-anne.david@email.com",
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [
                 {
-                    "name": {"es": "Yodo", "en": "Iodine"},
+                    "name": {"es": "Yodo", "en": "Iodine", "fr": "Iode"},
                     "severity": "medium",
-                    "reaction": {"es": "Erupción cutánea", "en": "Skin rash"},
+                    "reaction": {"es": "Erupción cutánea", "en": "Skin rash", "fr": "Éruption cutanée"},
                 },
             ],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Artrosis", "en": "Osteoarthritis"},
+                    "name": {"es": "Artrosis", "en": "Osteoarthritis", "fr": "Arthrose"},
                     "is_critical": False,
-                    "notes": {"es": "Afecta movilidad cervical", "en": "Affects cervical mobility"},
+                    "notes": {"es": "Afecta movilidad cervical", "en": "Affects cervical mobility", "fr": "Affecte la mobilité cervicale"},
                 },
             ],
         },
@@ -618,7 +739,12 @@ PATIENTS_I18N = [
             "last_name": "Hall",
             "notes": "Patient with implants. Periodic review.",
         },
-        "phone": {"es": "+34 612 345 012", "en": "+1 (212) 555-0012"},
+        "fr": {
+            "first_name": "Anne-Marie",
+            "last_name": "Bertrand",
+            "notes": "Patiente avec implants. Révision périodique.",
+        },
+        "phone": {"es": "+34 612 345 012", "en": "+1 (212) 555-0012", "fr": "+33 6 12 34 56 12"},
         "email": None,
         "date_of_birth": date(1955, 10, 12),
         "emergency_contact": {
@@ -636,16 +762,24 @@ PATIENTS_I18N = [
                 "email": "fernando.hall@email.com",
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Laurent Bertrand",
+                "relationship": "Fils",
+                "phone": "+33 6 12 34 56 61",
+                "email": "laurent.bertrand@email.com",
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Osteoporosis", "en": "Osteoporosis"},
+                    "name": {"es": "Osteoporosis", "en": "Osteoporosis", "fr": "Ostéoporose"},
                     "is_critical": False,
                     "notes": {
                         "es": "Tratamiento con bisfosfonatos. Precaución con extracciones.",
                         "en": "Treatment with bisphosphonates. Caution with extractions.",
+                        "fr": "Traitement par bisphosphonates. Prudence avec les extractions.",
                     },
                 },
             ],
@@ -663,8 +797,13 @@ PATIENTS_I18N = [
             "last_name": "Allen",
             "notes": "On blood thinners. Coordinate with physician before extractions.",
         },
-        "phone": {"es": "+34 612 345 013", "en": "+1 (212) 555-0013"},
-        "email": {"es": "joseluis.munoz@email.com", "en": "richard.allen@email.com"},
+        "fr": {
+            "first_name": "Pierre",
+            "last_name": "Roux",
+            "notes": "Prend des anticoagulants. Coordonné avec le médecin avant extractions.",
+        },
+        "phone": {"es": "+34 612 345 013", "en": "+1 (212) 555-0013", "fr": "+33 6 12 34 56 13"},
+        "email": {"es": "joseluis.munoz@email.com", "en": "richard.allen@email.com", "fr": "pierre.roux@email.com"},
         "date_of_birth": date(1950, 3, 28),
         "emergency_contact": {
             "es": {
@@ -681,6 +820,13 @@ PATIENTS_I18N = [
                 "email": None,
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Monique Roux",
+                "relationship": "Épouse",
+                "phone": "+33 6 12 34 56 62",
+                "email": None,
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [],
@@ -689,11 +835,12 @@ PATIENTS_I18N = [
             "inr_value": 2.5,
             "systemic_diseases": [
                 {
-                    "name": {"es": "Fibrilación Auricular", "en": "Atrial Fibrillation"},
+                    "name": {"es": "Fibrilación Auricular", "en": "Atrial Fibrillation", "fr": "Fibrillation auriculaire"},
                     "is_critical": True,
                     "notes": {
                         "es": "Anticoagulado. Requiere control INR antes de procedimientos.",
                         "en": "Anticoagulated. Requires INR control before procedures.",
+                        "fr": "Anticoagulé. Contrôle INR requis avant les soins.",
                     },
                 },
             ],
@@ -703,7 +850,8 @@ PATIENTS_I18N = [
         "id": PATIENT_IDS[13],
         "es": {"first_name": "Dolores", "last_name": "Vega Ortiz", "notes": None},
         "en": {"first_name": "Barbara", "last_name": "Young", "notes": None},
-        "phone": {"es": "+34 612 345 014", "en": "+1 (212) 555-0014"},
+        "fr": {"first_name": "Catherine", "last_name": "Duval", "notes": None},
+        "phone": {"es": "+34 612 345 014", "en": "+1 (212) 555-0014", "fr": "+33 6 12 34 56 14"},
         "email": None,
         "date_of_birth": date(1948, 7, 7),
         "emergency_contact": {
@@ -719,6 +867,13 @@ PATIENTS_I18N = [
                 "relationship": "Son",
                 "phone": "+1 (212) 555-0112",
                 "email": "george.young@email.com",
+                "is_legal_guardian": False,
+            },
+            "fr": {
+                "name": "Bernard Duval",
+                "relationship": "Fils",
+                "phone": "+33 6 12 34 56 63",
+                "email": "bernard.duval@email.com",
                 "is_legal_guardian": False,
             },
         },
@@ -739,7 +894,12 @@ PATIENTS_I18N = [
             "last_name": "King",
             "notes": "Complete denture. Requires frequent adjustments.",
         },
-        "phone": {"es": "+34 612 345 015", "en": "+1 (212) 555-0015"},
+        "fr": {
+            "first_name": "Philippe",
+            "last_name": "Lambert",
+            "notes": "Prothèse complète. Nécessite des ajustements fréquents.",
+        },
+        "phone": {"es": "+34 612 345 015", "en": "+1 (212) 555-0015", "fr": "+33 6 12 34 56 15"},
         "email": None,
         "date_of_birth": date(1945, 11, 19),
         "emergency_contact": {
@@ -757,31 +917,40 @@ PATIENTS_I18N = [
                 "email": "teresa.king@email.com",
                 "is_legal_guardian": False,
             },
+            "fr": {
+                "name": "Sylvie Lambert",
+                "relationship": "Fille",
+                "phone": "+33 6 12 34 56 64",
+                "email": "sylvie.lambert@email.com",
+                "is_legal_guardian": False,
+            },
         },
         "medical_history": {
             "allergies": [
                 {
-                    "name": {"es": "AINEs", "en": "NSAIDs"},
+                    "name": {"es": "AINEs", "en": "NSAIDs", "fr": "AINS"},
                     "severity": "high",
                     "reaction": {
                         "es": "Problemas gástricos severos",
                         "en": "Severe gastric problems",
+                        "fr": "Problèmes gastriques sévères",
                     },
                 },
             ],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Insuficiencia Renal Crónica", "en": "Chronic Kidney Disease"},
+                    "name": {"es": "Insuficiencia Renal Crónica", "en": "Chronic Kidney Disease", "fr": "Insuffisance rénale chronique"},
                     "is_critical": True,
                     "notes": {
                         "es": "Estadio 3. Ajustar dosis de medicamentos.",
                         "en": "Stage 3. Adjust medication doses.",
+                        "fr": "Stade 3. Ajuster les doses de médicaments.",
                     },
                 },
                 {
-                    "name": {"es": "Diabetes Mellitus Tipo 2", "en": "Type 2 Diabetes Mellitus"},
+                    "name": {"es": "Diabetes Mellitus Tipo 2", "en": "Type 2 Diabetes Mellitus", "fr": "Diabète de type 2"},
                     "is_critical": True,
-                    "notes": {"es": "Insulinodependiente", "en": "Insulin-dependent"},
+                    "notes": {"es": "Insulinodependiente", "en": "Insulin-dependent", "fr": "Insulino-dépendant"},
                 },
             ],
         },
@@ -1291,51 +1460,51 @@ PAYMENT_IDS = [UUID(f"fd00bc99-9c0b-4ef8-bb6d-6bb9bd380{i:03x}") for i in range(
 
 # Appointment visuals + duration by catalog_code prefix. Ordered most-specific first.
 _APPT_LOOK_BY_PREFIX: list[tuple[str, dict]] = [
-    ("DX-VISIT", {"name": {"es": "Revisión", "en": "Checkup"}, "duration": 30, "color": "#3B82F6"}),
-    ("DX-RX", {"name": {"es": "Radiografía", "en": "X-ray"}, "duration": 30, "color": "#60A5FA"}),
-    ("DX", {"name": {"es": "Diagnóstico", "en": "Diagnosis"}, "duration": 30, "color": "#3B82F6"}),
+    ("DX-VISIT", {"name": {"es": "Revisión", "en": "Checkup", "fr": "Contrôle"}, "duration": 30, "color": "#3B82F6"}),
+    ("DX-RX", {"name": {"es": "Radiografía", "en": "X-ray", "fr": "Radiographie"}, "duration": 30, "color": "#60A5FA"}),
+    ("DX", {"name": {"es": "Diagnóstico", "en": "Diagnosis", "fr": "Diagnostique"}, "duration": 30, "color": "#3B82F6"}),
     (
         "PREV",
         {
-            "name": {"es": "Limpieza dental", "en": "Dental cleaning"},
+            "name": {"es": "Limpieza dental", "en": "Dental cleaning", "fr": "Détartrage"},
             "duration": 45,
             "color": "#10B981",
         },
     ),
-    ("REST-CROWN", {"name": {"es": "Corona", "en": "Crown"}, "duration": 60, "color": "#A855F7"}),
-    ("REST-VEN", {"name": {"es": "Carilla", "en": "Veneer"}, "duration": 60, "color": "#F472B6"}),
-    ("REST-COMP", {"name": {"es": "Empaste", "en": "Filling"}, "duration": 45, "color": "#F59E0B"}),
+    ("REST-CROWN", {"name": {"es": "Corona", "en": "Crown", "fr": "Couronne"}, "duration": 60, "color": "#A855F7"}),
+    ("REST-VEN", {"name": {"es": "Carilla", "en": "Veneer", "fr": "Facette"}, "duration": 60, "color": "#F472B6"}),
+    ("REST-COMP", {"name": {"es": "Empaste", "en": "Filling", "fr": "Plombage"}, "duration": 45, "color": "#F59E0B"}),
     (
         "REST",
-        {"name": {"es": "Restauración", "en": "Restoration"}, "duration": 45, "color": "#F59E0B"},
+        {"name": {"es": "Restauración", "en": "Restoration", "fr": "Restauration"}, "duration": 45, "color": "#F59E0B"},
     ),
     (
         "SURG-EXT",
-        {"name": {"es": "Extracción", "en": "Extraction"}, "duration": 60, "color": "#EF4444"},
+        {"name": {"es": "Extracción", "en": "Extraction", "fr": "Extraction"}, "duration": 60, "color": "#EF4444"},
     ),
-    ("SURG", {"name": {"es": "Cirugía", "en": "Surgery"}, "duration": 60, "color": "#DC2626"}),
+    ("SURG", {"name": {"es": "Cirugía", "en": "Surgery", "fr": "Chirurgie"}, "duration": 60, "color": "#DC2626"}),
     (
         "ENDO-MULTI",
         {
-            "name": {"es": "Endodoncia multirradicular", "en": "Multi-root canal"},
+            "name": {"es": "Endodoncia multirradicular", "en": "Multi-root canal", "fr": "Endodontie multiradiculaire"},
             "duration": 90,
             "color": "#8B5CF6",
         },
     ),
     (
         "ENDO",
-        {"name": {"es": "Endodoncia", "en": "Root canal"}, "duration": 75, "color": "#8B5CF6"},
+        {"name": {"es": "Endodoncia", "en": "Root canal", "fr": "Endodontie"}, "duration": 75, "color": "#8B5CF6"},
     ),
     (
         "PERIO",
-        {"name": {"es": "Periodoncia", "en": "Periodontics"}, "duration": 60, "color": "#14B8A6"},
+        {"name": {"es": "Periodoncia", "en": "Periodontics", "fr": "Parodontie"}, "duration": 60, "color": "#14B8A6"},
     ),
     (
         "EST-BLAN",
-        {"name": {"es": "Blanqueamiento", "en": "Whitening"}, "duration": 60, "color": "#06B6D4"},
+        {"name": {"es": "Blanqueamiento", "en": "Whitening", "fr": "Blanchiment"}, "duration": 60, "color": "#06B6D4"},
     ),
-    ("EST", {"name": {"es": "Estética", "en": "Aesthetics"}, "duration": 45, "color": "#06B6D4"}),
-    ("PROT", {"name": {"es": "Prótesis", "en": "Prosthesis"}, "duration": 90, "color": "#84CC16"}),
+    ("EST", {"name": {"es": "Estética", "en": "Aesthetics", "fr": "Esthétique"}, "duration": 45, "color": "#06B6D4"}),
+    ("PROT", {"name": {"es": "Prótesis", "en": "Prosthesis", "fr": "Prothèse"}, "duration": 90, "color": "#84CC16"}),
 ]
 
 
@@ -1344,7 +1513,7 @@ def _appt_look_for(code: str) -> dict:
     for prefix, meta in _APPT_LOOK_BY_PREFIX:
         if code.startswith(prefix):
             return meta
-    return {"name": {"es": "Tratamiento", "en": "Treatment"}, "duration": 45, "color": "#64748B"}
+    return {"name": {"es": "Tratamiento", "en": "Treatment", "fr": "Traitement"}, "duration": 45, "color": "#64748B"}
 
 
 # PATIENT_JOURNEYS: one entry per patient captures the full clinical narrative.
@@ -1366,10 +1535,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 0,
             "status": "active",
-            "title": {"es": "Plan preventivo infantil", "en": "Pediatric preventive plan"},
+            "title": {"es": "Plan preventivo infantil", "en": "Pediatric preventive plan", "fr": "Plan préventif pédiatrique"},
             "diagnosis_notes": {
                 "es": "Primera visita. Revisión pediátrica.",
                 "en": "First visit. Pediatric checkup.",
+                "fr": "Première visite. Contrôle pédiatrique.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True},
@@ -1389,10 +1559,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 1,
             "status": "active",
-            "title": {"es": "Tratamiento conservador", "en": "Conservative treatment"},
+            "title": {"es": "Tratamiento conservador", "en": "Conservative treatment", "fr": "Traitement conservateur"},
             "diagnosis_notes": {
                 "es": "Caries en molares inferiores deciduos.",
                 "en": "Caries on lower deciduous molars.",
+                "fr": "Caries sur les molaires inférieures temporaires.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True},
@@ -1413,10 +1584,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 2,
             "status": "pending",
-            "title": {"es": "Revisión y limpieza", "en": "Checkup and cleaning"},
+            "title": {"es": "Revisión y limpieza", "en": "Checkup and cleaning", "fr": "Contrôle et détartrage"},
             "diagnosis_notes": {
                 "es": "Paciente joven, buen estado general.",
                 "en": "Young patient, good general condition.",
+                "fr": "Patient jeune, bon état général.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True},
@@ -1428,7 +1600,7 @@ PATIENT_JOURNEYS = [
             "status": "draft",
             "global_discount": None,
             "signature": False,
-            "notes": {"es": "Borrador pendiente de revisión", "en": "Draft pending review"},
+            "notes": {"es": "Borrador pendiente de revisión", "en": "Draft pending review", "fr": "Brouillon en attente de révision"},
         },
         "appointments": [],
         "invoice": {
@@ -1436,7 +1608,7 @@ PATIENT_JOURNEYS = [
             "status": "draft",
             "payments": [],
             "covers": [0, 1],
-            "notes": {"es": "Borrador - pendiente de emitir", "en": "Draft - pending issuance"},
+            "notes": {"es": "Borrador - pendiente de emitir", "en": "Draft - pending issuance", "fr": "Brouillon - en attente d'émission"},
         },
     },
     # Patient 3 — Carmen / Emma (pending plan with sent budget, surfaces in
@@ -1446,10 +1618,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 3,
             "status": "pending",
-            "title": {"es": "Plan de tratamiento inicial", "en": "Initial treatment plan"},
+            "title": {"es": "Plan de tratamiento inicial", "en": "Initial treatment plan", "fr": "Plan de traitement initial"},
             "diagnosis_notes": {
                 "es": "Paciente con sensibilidad dental. Requiere empaste en molar.",
                 "en": "Patient with dental sensitivity. Requires filling on molar.",
+                "fr": "Patiente avec sensibilité dentaire. Nécessite un plombage sur la molaire.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True},
@@ -1465,6 +1638,7 @@ PATIENT_JOURNEYS = [
             "notes": {
                 "es": "Presupuesto enviado, esperando respuesta",
                 "en": "Quote sent, awaiting response",
+                "fr": "Devis envoyé, en attente de réponse",
             },
         },
         "appointments": [],
@@ -1476,10 +1650,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 4,
             "status": "active",
-            "title": {"es": "Plan estético", "en": "Aesthetic plan"},
+            "title": {"es": "Plan estético", "en": "Aesthetic plan", "fr": "Plan esthétique"},
             "diagnosis_notes": {
                 "es": "Paciente interesado en blanqueamiento.",
                 "en": "Patient interested in whitening.",
+                "fr": "Patient intéressé par le blanchiment.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1492,7 +1667,7 @@ PATIENT_JOURNEYS = [
             "status": "accepted",
             "global_discount": {"type": "percentage", "value": 5},
             "signature": True,
-            "notes": {"es": "Aceptado, pendiente de agendar", "en": "Accepted, pending scheduling"},
+            "notes": {"es": "Aceptado, pendiente de agendar", "en": "Accepted, pending scheduling", "fr": "Accepté, en attente de planification"},
         },
         # No appointments — surfaces in bandeja tab "Sin cita".
         "appointments": [],
@@ -1503,10 +1678,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 5,
             "status": "active",
-            "title": {"es": "Diagnóstico y restauración", "en": "Diagnosis and restoration"},
+            "title": {"es": "Diagnóstico y restauración", "en": "Diagnosis and restoration", "fr": "Diagnostic et restauration"},
             "diagnosis_notes": {
                 "es": "Embarazada. Evitar radiografías no esenciales.",
                 "en": "Pregnant. Avoid non-essential x-rays.",
+                "fr": "Enceinte. Éviter les radiographies non essentielles.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1522,6 +1698,7 @@ PATIENT_JOURNEYS = [
             "notes": {
                 "es": "Paciente embarazada - tratamiento en curso",
                 "en": "Pregnant patient - treatment in progress",
+                "fr": "Patiente enceinte - traitement en cours",
             },
         },
         "appointments": [
@@ -1533,7 +1710,7 @@ PATIENT_JOURNEYS = [
             "status": "partial",
             "payments": [{"method": "card", "percent": 50}],
             "covers": [0, 1, 2],
-            "notes": {"es": "Pago parcial recibido", "en": "Partial payment received"},
+            "notes": {"es": "Pago parcial recibido", "en": "Partial payment received", "fr": "Paiement partiel reçu"},
         },
     },
     # Patient 6 — Javier / Daniel (diabetic; accepted+signed budget, paid invoice)
@@ -1542,10 +1719,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 6,
             "status": "active",
-            "title": {"es": "Endodoncia y corona", "en": "Root canal and crown"},
+            "title": {"es": "Endodoncia y corona", "en": "Root canal and crown", "fr": "Endodontie et couronne"},
             "diagnosis_notes": {
                 "es": "Paciente diabético. Control especial de cicatrización.",
                 "en": "Diabetic patient. Special healing monitoring.",
+                "fr": "Patient diabétique. Surveillance spéciale de la cicatrisation.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1561,6 +1739,7 @@ PATIENT_JOURNEYS = [
             "notes": {
                 "es": "Paciente diabético - control especial",
                 "en": "Diabetic patient - special care",
+                "fr": "Patient diabétique - soins spéciaux",
             },
         },
         # Past appointments only — surfaces in bandeja tab "Sin próxima cita".
@@ -1573,7 +1752,7 @@ PATIENT_JOURNEYS = [
             "status": "paid",
             "payments": [{"method": "bank_transfer", "percent": 100}],
             "covers": [0, 1],
-            "notes": {"es": "Pagado por transferencia", "en": "Paid by bank transfer"},
+            "notes": {"es": "Pagado por transferencia", "en": "Paid by bank transfer", "fr": "Payé par virement"},
         },
     },
     # Patient 7 — Isabel / Mia (rejected budget, no invoice)
@@ -1586,11 +1765,13 @@ PATIENT_JOURNEYS = [
             "closure_note": {
                 "es": "Paciente rechazó carillas estéticas por precio.",
                 "en": "Patient rejected aesthetic veneers due to pricing.",
+                "fr": "Patiente a rejeté les facettes esthétiques en raison du prix.",
             },
-            "title": {"es": "Plan estético rechazado", "en": "Rejected aesthetic plan"},
+            "title": {"es": "Plan estético rechazado", "en": "Rejected aesthetic plan", "fr": "Plan esthétique rejeté"},
             "diagnosis_notes": {
                 "es": "Control semestral. Paciente rechazó carillas estéticas.",
                 "en": "Bi-annual checkup. Patient rejected aesthetic veneers.",
+                "fr": "Contrôle semestriel. Patiente a rejeté les facettes esthétiques.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1605,12 +1786,14 @@ PATIENT_JOURNEYS = [
             "rejection_note": {
                 "es": "Precio de carillas demasiado alto",
                 "en": "Veneer pricing too high",
+                "fr": "Prix des facettes trop élevé",
             },
             "global_discount": None,
             "signature": False,
             "notes": {
                 "es": "Rechazado por precio de carillas",
                 "en": "Rejected due to veneer pricing",
+                "fr": "Rejeté en raison du prix des facettes",
             },
         },
         "appointments": [
@@ -1623,10 +1806,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 8,
             "status": "active",
-            "title": {"es": "Tratamiento periodontal", "en": "Periodontal treatment"},
+            "title": {"es": "Tratamiento periodontal", "en": "Periodontal treatment", "fr": "Traitement parodontal"},
             "diagnosis_notes": {
                 "es": "ALÉRGICO A PENICILINA. Usar alternativas.",
                 "en": "ALLERGIC TO PENICILLIN. Use alternatives.",
+                "fr": "ALLERGIQUE À LA PÉNICILLINE. Utiliser des alternatives.",
             },
             "items": [
                 {"catalog_code": "PERIO-RAR", "is_global": True, "completed": True},
@@ -1639,7 +1823,7 @@ PATIENT_JOURNEYS = [
             "status": "accepted",
             "global_discount": {"type": "absolute", "value": 50},
             "signature": True,
-            "notes": {"es": "Alérgico a penicilina", "en": "Allergic to penicillin"},
+            "notes": {"es": "Alérgico a penicilina", "en": "Allergic to penicillin", "fr": "Allergique à la pénicilline"},
         },
         "appointments": [
             {"week": "past", "covers": [0], "status": "completed"},
@@ -1654,7 +1838,7 @@ PATIENT_JOURNEYS = [
                 {"method": "card", "percent": 60},
             ],
             "covers": [0, 1],
-            "notes": {"es": "Pagado en dos plazos", "en": "Paid in two installments"},
+            "notes": {"es": "Pagado en dos plazos", "en": "Paid in two installments", "fr": "Payé en deux tranches"},
         },
     },
     # Patient 9 — Rosa / Charlotte (hypertensive; accepted+signed, paid invoice)
@@ -1663,10 +1847,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 9,
             "status": "active",
-            "title": {"es": "Rehabilitación oral", "en": "Oral rehabilitation"},
+            "title": {"es": "Rehabilitación oral", "en": "Oral rehabilitation", "fr": "Réhabilitation bucco-dentaire"},
             "diagnosis_notes": {
                 "es": "Hipertensa - verificar presión antes de procedimientos.",
                 "en": "Hypertensive - check blood pressure before procedures.",
+                "fr": "Hypertendue - vérifier la tension avant les soins.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1685,7 +1870,7 @@ PATIENT_JOURNEYS = [
             "status": "accepted",
             "global_discount": {"type": "percentage", "value": 10},
             "signature": True,
-            "notes": {"es": "Tratamiento en curso", "en": "Treatment in progress"},
+            "notes": {"es": "Tratamiento en curso", "en": "Treatment in progress", "fr": "Traitement en cours"},
         },
         "appointments": [
             {"week": "past", "covers": [0], "status": "completed"},
@@ -1697,7 +1882,7 @@ PATIENT_JOURNEYS = [
             "status": "paid",
             "payments": [{"method": "card", "percent": 100}],
             "covers": [0, 1],
-            "notes": {"es": "Primera fase facturada", "en": "First phase billed"},
+            "notes": {"es": "Primera fase facturada", "en": "First phase billed", "fr": "Première phase facturée"},
         },
     },
     # Patient 10 — Antonio / Robert (completed prosthetic workflow)
@@ -1706,10 +1891,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 10,
             "status": "completed",
-            "title": {"es": "Prótesis parcial superior", "en": "Upper partial denture"},
+            "title": {"es": "Prótesis parcial superior", "en": "Upper partial denture", "fr": "Prothèse partielle supérieure"},
             "diagnosis_notes": {
                 "es": "Prótesis parcial superior entregada y ajustada.",
                 "en": "Upper partial denture delivered and adjusted.",
+                "fr": "Prothèse partielle supérieure livrée et ajustée.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1721,7 +1907,7 @@ PATIENT_JOURNEYS = [
             "status": "completed",
             "global_discount": None,
             "signature": True,
-            "notes": {"es": "Prótesis parcial entregada", "en": "Partial denture delivered"},
+            "notes": {"es": "Prótesis parcial entregada", "en": "Partial denture delivered", "fr": "Prothèse partielle livrée"},
         },
         "appointments": [
             {"week": "past", "covers": [0], "status": "completed"},
@@ -1745,10 +1931,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 11,
             "status": "active",
-            "title": {"es": "Corona en dos sesiones", "en": "Two-session crown"},
+            "title": {"es": "Corona en dos sesiones", "en": "Two-session crown", "fr": "Couronne en deux séances"},
             "diagnosis_notes": {
                 "es": "Corona metal-cerámica en 36 — cobro fraccionado por sesión.",
                 "en": "Metal-ceramic crown on tooth 36 — billed per session.",
+                "fr": "Couronne métal-céramique sur 36 - facturation par séance.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1772,10 +1959,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 12,
             "status": "completed",
-            "title": {"es": "Endodoncia urgente", "en": "Urgent root canal"},
+            "title": {"es": "Endodoncia urgente", "en": "Urgent root canal", "fr": "Endodontie urgente"},
             "diagnosis_notes": {
                 "es": "Endodoncia urgente por absceso. Paciente anticoagulado.",
                 "en": "Urgent root canal due to abscess. Anticoagulated patient.",
+                "fr": "Endodontie urgente pour abcès. Patient anticoagulé.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -1790,6 +1978,7 @@ PATIENT_JOURNEYS = [
             "notes": {
                 "es": "Anticoagulado - cuidado post-operatorio",
                 "en": "Anticoagulated - post-op care",
+                "fr": "Anticoagulé - soins post-opératoires",
             },
         },
         "appointments": [
@@ -1802,7 +1991,7 @@ PATIENT_JOURNEYS = [
             "overdue": True,
             "payments": [],
             "covers": [0, 1],
-            "notes": {"es": "Factura vencida", "en": "Overdue invoice"},
+            "notes": {"es": "Factura vencida", "en": "Overdue invoice", "fr": "Facture échue"},
         },
     },
     # Patient 13 — Dolores / Barbara (evaluation; no budget)
@@ -1811,8 +2000,8 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 13,
             "status": "active",
-            "title": {"es": "Evaluación y limpieza", "en": "Evaluation and cleaning"},
-            "diagnosis_notes": {"es": "Evaluación periódica.", "en": "Periodic evaluation."},
+            "title": {"es": "Evaluación y limpieza", "en": "Evaluation and cleaning", "fr": "Évaluation et détartrage"},
+            "diagnosis_notes": {"es": "Evaluación periódica.", "en": "Periodic evaluation.", "fr": "Évaluation périodique."},
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True},
                 {"catalog_code": "DX-RXPAN", "is_global": True},
@@ -1830,10 +2019,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 14,
             "status": "active",
-            "title": {"es": "Mantenimiento protésico", "en": "Prosthetic maintenance"},
+            "title": {"es": "Mantenimiento protésico", "en": "Prosthetic maintenance", "fr": "Entretien prothétique"},
             "diagnosis_notes": {
                 "es": "Ajustes periódicos de prótesis completa.",
                 "en": "Periodic complete denture adjustments.",
+                "fr": "Ajustements périodiques de prothèse complète.",
             },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True, "completed": True},
@@ -2465,7 +2655,7 @@ def generate_invoice_series_data() -> list[dict]:
             "id": INVOICE_SERIES_IDS[0],
             "prefix": "FAC",
             "series_type": "invoice",
-            "description": t({"es": "Serie principal de facturas", "en": "Main invoice series"}),
+            "description": t({"es": "Serie principal de facturas", "en": "Main invoice series", "fr": "Série principale de factures"}),
             "current_number": num_invoices + 1,
             "is_default": True,
         },
@@ -2473,7 +2663,7 @@ def generate_invoice_series_data() -> list[dict]:
             "id": INVOICE_SERIES_IDS[1],
             "prefix": "RECT",
             "series_type": "credit_note",
-            "description": t({"es": "Notas de crédito", "en": "Credit notes"}),
+            "description": t({"es": "Notas de crédito", "en": "Credit notes", "fr": "Notes de crédit"}),
             "current_number": 1,
             "is_default": True,
         },

--- a/backend/app/seeds/demo_data.py
+++ b/backend/app/seeds/demo_data.py
@@ -81,10 +81,18 @@ def get_clinic_data() -> dict:
     """Get clinic data in current language."""
     return {
         "id": CLINIC_ID,
-        "name": t({"es": "Clínica Dental Demo", "en": "Demo Dental Clinic", "fr": "Clinique Dentaire Démo"}),
+        "name": t(
+            {
+                "es": "Clínica Dental Demo",
+                "en": "Demo Dental Clinic",
+                "fr": "Clinique Dentaire Démo",
+            }
+        ),
         "tax_id": t({"es": "B12345678", "en": "12-3456789", "fr": "12-3456789"}),
         "address": {
-            "street": t({"es": "Calle Gran Vía 123", "en": "123 Main Street", "fr": "123 Rue Principale"}),
+            "street": t(
+                {"es": "Calle Gran Vía 123", "en": "123 Main Street", "fr": "123 Rue Principale"}
+            ),
             "city": t({"es": "Madrid", "en": "New York", "fr": "Paris"}),
             "postal_code": t({"es": "28013", "en": "10001", "fr": "75001"}),
             "country": t({"es": "España", "en": "USA", "fr": "France"}),
@@ -104,8 +112,14 @@ def get_clinic_data() -> dict:
             },
         },
         "cabinets": [
-            {"name": t({"es": "Gabinete 1", "en": "Room 1", "fr": "Cabinet 1"}), "color": "#3B82F6"},
-            {"name": t({"es": "Gabinete 2", "en": "Room 2", "fr": "Cabinet 2"}), "color": "#10B981"},
+            {
+                "name": t({"es": "Gabinete 1", "en": "Room 1", "fr": "Cabinet 1"}),
+                "color": "#3B82F6",
+            },
+            {
+                "name": t({"es": "Gabinete 2", "en": "Room 2", "fr": "Cabinet 2"}),
+                "color": "#10B981",
+            },
         ],
     }
 
@@ -262,7 +276,11 @@ PATIENTS_I18N = [
             "notes": "Traitement d'orthodontie en cours.",
         },
         "phone": {"es": "+34 612 345 002", "en": "+1 (212) 555-0002", "fr": "+33 6 12 34 56 02"},
-        "email": {"es": "lucia.rodriguez@email.com", "en": "olivia.wilson@email.com", "fr": "lea.laurent@email.com"},
+        "email": {
+            "es": "lucia.rodriguez@email.com",
+            "en": "olivia.wilson@email.com",
+            "fr": "lea.laurent@email.com",
+        },
         "date_of_birth": date(2010, 7, 22),
         "emergency_contact": {
             "es": {
@@ -299,7 +317,11 @@ PATIENTS_I18N = [
         "en": {"first_name": "James", "last_name": "Anderson", "notes": None},
         "fr": {"first_name": "Lucas", "last_name": "Rousseau", "notes": None},
         "phone": {"es": "+34 612 345 003", "en": "+1 (212) 555-0003", "fr": "+33 6 12 34 56 03"},
-        "email": {"es": "miguel.gonzalez@email.com", "en": "james.anderson@email.com", "fr": "lucas.rousseau@email.com"},
+        "email": {
+            "es": "miguel.gonzalez@email.com",
+            "en": "james.anderson@email.com",
+            "fr": "lucas.rousseau@email.com",
+        },
         "date_of_birth": date(1998, 11, 8),
         "emergency_contact": {
             "es": {
@@ -347,7 +369,11 @@ PATIENTS_I18N = [
             "notes": "Sensibilité dentaire. Utiliser l'anesthésie avec précaution.",
         },
         "phone": {"es": "+34 612 345 004", "en": "+1 (212) 555-0004", "fr": "+33 6 12 34 56 04"},
-        "email": {"es": "carmen.diaz@email.com", "en": "emma.taylor@email.com", "fr": "chloe.bertrand@email.com"},
+        "email": {
+            "es": "carmen.diaz@email.com",
+            "en": "emma.taylor@email.com",
+            "fr": "chloe.bertrand@email.com",
+        },
         "date_of_birth": date(1995, 5, 30),
         "emergency_contact": {
             "es": {
@@ -377,7 +403,11 @@ PATIENTS_I18N = [
                 {
                     "name": {"es": "Látex", "en": "Latex", "fr": "Latex"},
                     "severity": "medium",
-                    "reaction": {"es": "Irritación cutánea", "en": "Skin irritation", "fr": "Irritation cutanée"},
+                    "reaction": {
+                        "es": "Irritación cutánea",
+                        "en": "Skin irritation",
+                        "fr": "Irritation cutanée",
+                    },
                 },
             ],
             "adverse_reactions_to_anesthesia": True,
@@ -422,7 +452,11 @@ PATIENTS_I18N = [
             "notes": "Enceinte (troisième trimestre). Éviter les radiographies.",
         },
         "phone": {"es": "+34 612 345 006", "en": "+1 (212) 555-0006", "fr": "+33 6 12 34 56 06"},
-        "email": {"es": "elena.ruiz@email.com", "en": "sophia.martinez@email.com", "fr": "manon.lefebvre@email.com"},
+        "email": {
+            "es": "elena.ruiz@email.com",
+            "en": "sophia.martinez@email.com",
+            "fr": "manon.lefebvre@email.com",
+        },
         "date_of_birth": date(1985, 9, 3),
         "emergency_contact": {
             "es": {
@@ -472,7 +506,11 @@ PATIENTS_I18N = [
             "notes": "Diabétique de type 2. Surveillance de la cicatrisation.",
         },
         "phone": {"es": "+34 612 345 007", "en": "+1 (212) 555-0007", "fr": "+33 6 12 34 56 07"},
-        "email": {"es": "javier.sanchez@email.com", "en": "daniel.garcia@email.com", "fr": "nicolas.simon@email.com"},
+        "email": {
+            "es": "javier.sanchez@email.com",
+            "en": "daniel.garcia@email.com",
+            "fr": "nicolas.simon@email.com",
+        },
         "date_of_birth": date(1980, 12, 25),
         "emergency_contact": {
             "es": {
@@ -501,7 +539,11 @@ PATIENTS_I18N = [
             "allergies": [],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Diabetes Mellitus Tipo 2", "en": "Type 2 Diabetes Mellitus", "fr": "Diabète de type 2"},
+                    "name": {
+                        "es": "Diabetes Mellitus Tipo 2",
+                        "en": "Type 2 Diabetes Mellitus",
+                        "fr": "Diabète de type 2",
+                    },
                     "is_critical": True,
                     "notes": {
                         "es": "Controlada con metformina. HbA1c: 7.2%",
@@ -567,7 +609,11 @@ PATIENTS_I18N = [
             "notes": "Allergique à la pénicilline.",
         },
         "phone": {"es": "+34 612 345 009", "en": "+1 (212) 555-0009", "fr": "+33 6 12 34 56 09"},
-        "email": {"es": "francisco.garcia@email.com", "en": "alexander.clark@email.com", "fr": "guillaume.laurent@email.com"},
+        "email": {
+            "es": "francisco.garcia@email.com",
+            "en": "alexander.clark@email.com",
+            "fr": "guillaume.laurent@email.com",
+        },
         "date_of_birth": date(1975, 4, 9),
         "emergency_contact": {
             "es": {
@@ -602,7 +648,11 @@ PATIENTS_I18N = [
                 {
                     "name": {"es": "Amoxicilina", "en": "Amoxicillin", "fr": "Amoxicilline"},
                     "severity": "high",
-                    "reaction": {"es": "Urticaria severa", "en": "Severe urticaria", "fr": "Urticaire sévère"},
+                    "reaction": {
+                        "es": "Urticaria severa",
+                        "en": "Severe urticaria",
+                        "fr": "Urticaire sévère",
+                    },
                 },
             ],
             "systemic_diseases": [],
@@ -626,7 +676,11 @@ PATIENTS_I18N = [
             "notes": "Hypertendue. Vérifier la tension avant les soins.",
         },
         "phone": {"es": "+34 612 345 010", "en": "+1 (212) 555-0010", "fr": "+33 6 12 34 56 10"},
-        "email": {"es": "rosa.martinez@email.com", "en": "charlotte.lewis@email.com", "fr": "sophie.garnier@email.com"},
+        "email": {
+            "es": "rosa.martinez@email.com",
+            "en": "charlotte.lewis@email.com",
+            "fr": "sophie.garnier@email.com",
+        },
         "date_of_birth": date(1970, 8, 21),
         "emergency_contact": {
             "es": {
@@ -655,7 +709,11 @@ PATIENTS_I18N = [
             "allergies": [],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Hipertensión Arterial", "en": "Arterial Hypertension", "fr": "Hypertension artérielle"},
+                    "name": {
+                        "es": "Hipertensión Arterial",
+                        "en": "Arterial Hypertension",
+                        "fr": "Hypertension artérielle",
+                    },
                     "is_critical": True,
                     "notes": {
                         "es": "Tratamiento con enalapril 10mg/día. PA habitual: 130/85",
@@ -715,14 +773,22 @@ PATIENTS_I18N = [
                 {
                     "name": {"es": "Yodo", "en": "Iodine", "fr": "Iode"},
                     "severity": "medium",
-                    "reaction": {"es": "Erupción cutánea", "en": "Skin rash", "fr": "Éruption cutanée"},
+                    "reaction": {
+                        "es": "Erupción cutánea",
+                        "en": "Skin rash",
+                        "fr": "Éruption cutanée",
+                    },
                 },
             ],
             "systemic_diseases": [
                 {
                     "name": {"es": "Artrosis", "en": "Osteoarthritis", "fr": "Arthrose"},
                     "is_critical": False,
-                    "notes": {"es": "Afecta movilidad cervical", "en": "Affects cervical mobility", "fr": "Affecte la mobilité cervicale"},
+                    "notes": {
+                        "es": "Afecta movilidad cervical",
+                        "en": "Affects cervical mobility",
+                        "fr": "Affecte la mobilité cervicale",
+                    },
                 },
             ],
         },
@@ -803,7 +869,11 @@ PATIENTS_I18N = [
             "notes": "Prend des anticoagulants. Coordonné avec le médecin avant extractions.",
         },
         "phone": {"es": "+34 612 345 013", "en": "+1 (212) 555-0013", "fr": "+33 6 12 34 56 13"},
-        "email": {"es": "joseluis.munoz@email.com", "en": "richard.allen@email.com", "fr": "pierre.roux@email.com"},
+        "email": {
+            "es": "joseluis.munoz@email.com",
+            "en": "richard.allen@email.com",
+            "fr": "pierre.roux@email.com",
+        },
         "date_of_birth": date(1950, 3, 28),
         "emergency_contact": {
             "es": {
@@ -835,7 +905,11 @@ PATIENTS_I18N = [
             "inr_value": 2.5,
             "systemic_diseases": [
                 {
-                    "name": {"es": "Fibrilación Auricular", "en": "Atrial Fibrillation", "fr": "Fibrillation auriculaire"},
+                    "name": {
+                        "es": "Fibrilación Auricular",
+                        "en": "Atrial Fibrillation",
+                        "fr": "Fibrillation auriculaire",
+                    },
                     "is_critical": True,
                     "notes": {
                         "es": "Anticoagulado. Requiere control INR antes de procedimientos.",
@@ -939,7 +1013,11 @@ PATIENTS_I18N = [
             ],
             "systemic_diseases": [
                 {
-                    "name": {"es": "Insuficiencia Renal Crónica", "en": "Chronic Kidney Disease", "fr": "Insuffisance rénale chronique"},
+                    "name": {
+                        "es": "Insuficiencia Renal Crónica",
+                        "en": "Chronic Kidney Disease",
+                        "fr": "Insuffisance rénale chronique",
+                    },
                     "is_critical": True,
                     "notes": {
                         "es": "Estadio 3. Ajustar dosis de medicamentos.",
@@ -948,9 +1026,17 @@ PATIENTS_I18N = [
                     },
                 },
                 {
-                    "name": {"es": "Diabetes Mellitus Tipo 2", "en": "Type 2 Diabetes Mellitus", "fr": "Diabète de type 2"},
+                    "name": {
+                        "es": "Diabetes Mellitus Tipo 2",
+                        "en": "Type 2 Diabetes Mellitus",
+                        "fr": "Diabète de type 2",
+                    },
                     "is_critical": True,
-                    "notes": {"es": "Insulinodependiente", "en": "Insulin-dependent", "fr": "Insulino-dépendant"},
+                    "notes": {
+                        "es": "Insulinodependiente",
+                        "en": "Insulin-dependent",
+                        "fr": "Insulino-dépendant",
+                    },
                 },
             ],
         },
@@ -1460,9 +1546,30 @@ PAYMENT_IDS = [UUID(f"fd00bc99-9c0b-4ef8-bb6d-6bb9bd380{i:03x}") for i in range(
 
 # Appointment visuals + duration by catalog_code prefix. Ordered most-specific first.
 _APPT_LOOK_BY_PREFIX: list[tuple[str, dict]] = [
-    ("DX-VISIT", {"name": {"es": "Revisión", "en": "Checkup", "fr": "Contrôle"}, "duration": 30, "color": "#3B82F6"}),
-    ("DX-RX", {"name": {"es": "Radiografía", "en": "X-ray", "fr": "Radiographie"}, "duration": 30, "color": "#60A5FA"}),
-    ("DX", {"name": {"es": "Diagnóstico", "en": "Diagnosis", "fr": "Diagnostique"}, "duration": 30, "color": "#3B82F6"}),
+    (
+        "DX-VISIT",
+        {
+            "name": {"es": "Revisión", "en": "Checkup", "fr": "Contrôle"},
+            "duration": 30,
+            "color": "#3B82F6",
+        },
+    ),
+    (
+        "DX-RX",
+        {
+            "name": {"es": "Radiografía", "en": "X-ray", "fr": "Radiographie"},
+            "duration": 30,
+            "color": "#60A5FA",
+        },
+    ),
+    (
+        "DX",
+        {
+            "name": {"es": "Diagnóstico", "en": "Diagnosis", "fr": "Diagnostique"},
+            "duration": 30,
+            "color": "#3B82F6",
+        },
+    ),
     (
         "PREV",
         {
@@ -1471,40 +1578,106 @@ _APPT_LOOK_BY_PREFIX: list[tuple[str, dict]] = [
             "color": "#10B981",
         },
     ),
-    ("REST-CROWN", {"name": {"es": "Corona", "en": "Crown", "fr": "Couronne"}, "duration": 60, "color": "#A855F7"}),
-    ("REST-VEN", {"name": {"es": "Carilla", "en": "Veneer", "fr": "Facette"}, "duration": 60, "color": "#F472B6"}),
-    ("REST-COMP", {"name": {"es": "Empaste", "en": "Filling", "fr": "Plombage"}, "duration": 45, "color": "#F59E0B"}),
+    (
+        "REST-CROWN",
+        {
+            "name": {"es": "Corona", "en": "Crown", "fr": "Couronne"},
+            "duration": 60,
+            "color": "#A855F7",
+        },
+    ),
+    (
+        "REST-VEN",
+        {
+            "name": {"es": "Carilla", "en": "Veneer", "fr": "Facette"},
+            "duration": 60,
+            "color": "#F472B6",
+        },
+    ),
+    (
+        "REST-COMP",
+        {
+            "name": {"es": "Empaste", "en": "Filling", "fr": "Plombage"},
+            "duration": 45,
+            "color": "#F59E0B",
+        },
+    ),
     (
         "REST",
-        {"name": {"es": "Restauración", "en": "Restoration", "fr": "Restauration"}, "duration": 45, "color": "#F59E0B"},
+        {
+            "name": {"es": "Restauración", "en": "Restoration", "fr": "Restauration"},
+            "duration": 45,
+            "color": "#F59E0B",
+        },
     ),
     (
         "SURG-EXT",
-        {"name": {"es": "Extracción", "en": "Extraction", "fr": "Extraction"}, "duration": 60, "color": "#EF4444"},
+        {
+            "name": {"es": "Extracción", "en": "Extraction", "fr": "Extraction"},
+            "duration": 60,
+            "color": "#EF4444",
+        },
     ),
-    ("SURG", {"name": {"es": "Cirugía", "en": "Surgery", "fr": "Chirurgie"}, "duration": 60, "color": "#DC2626"}),
+    (
+        "SURG",
+        {
+            "name": {"es": "Cirugía", "en": "Surgery", "fr": "Chirurgie"},
+            "duration": 60,
+            "color": "#DC2626",
+        },
+    ),
     (
         "ENDO-MULTI",
         {
-            "name": {"es": "Endodoncia multirradicular", "en": "Multi-root canal", "fr": "Endodontie multiradiculaire"},
+            "name": {
+                "es": "Endodoncia multirradicular",
+                "en": "Multi-root canal",
+                "fr": "Endodontie multiradiculaire",
+            },
             "duration": 90,
             "color": "#8B5CF6",
         },
     ),
     (
         "ENDO",
-        {"name": {"es": "Endodoncia", "en": "Root canal", "fr": "Endodontie"}, "duration": 75, "color": "#8B5CF6"},
+        {
+            "name": {"es": "Endodoncia", "en": "Root canal", "fr": "Endodontie"},
+            "duration": 75,
+            "color": "#8B5CF6",
+        },
     ),
     (
         "PERIO",
-        {"name": {"es": "Periodoncia", "en": "Periodontics", "fr": "Parodontie"}, "duration": 60, "color": "#14B8A6"},
+        {
+            "name": {"es": "Periodoncia", "en": "Periodontics", "fr": "Parodontie"},
+            "duration": 60,
+            "color": "#14B8A6",
+        },
     ),
     (
         "EST-BLAN",
-        {"name": {"es": "Blanqueamiento", "en": "Whitening", "fr": "Blanchiment"}, "duration": 60, "color": "#06B6D4"},
+        {
+            "name": {"es": "Blanqueamiento", "en": "Whitening", "fr": "Blanchiment"},
+            "duration": 60,
+            "color": "#06B6D4",
+        },
     ),
-    ("EST", {"name": {"es": "Estética", "en": "Aesthetics", "fr": "Esthétique"}, "duration": 45, "color": "#06B6D4"}),
-    ("PROT", {"name": {"es": "Prótesis", "en": "Prosthesis", "fr": "Prothèse"}, "duration": 90, "color": "#84CC16"}),
+    (
+        "EST",
+        {
+            "name": {"es": "Estética", "en": "Aesthetics", "fr": "Esthétique"},
+            "duration": 45,
+            "color": "#06B6D4",
+        },
+    ),
+    (
+        "PROT",
+        {
+            "name": {"es": "Prótesis", "en": "Prosthesis", "fr": "Prothèse"},
+            "duration": 90,
+            "color": "#84CC16",
+        },
+    ),
 ]
 
 
@@ -1513,7 +1686,11 @@ def _appt_look_for(code: str) -> dict:
     for prefix, meta in _APPT_LOOK_BY_PREFIX:
         if code.startswith(prefix):
             return meta
-    return {"name": {"es": "Tratamiento", "en": "Treatment", "fr": "Traitement"}, "duration": 45, "color": "#64748B"}
+    return {
+        "name": {"es": "Tratamiento", "en": "Treatment", "fr": "Traitement"},
+        "duration": 45,
+        "color": "#64748B",
+    }
 
 
 # PATIENT_JOURNEYS: one entry per patient captures the full clinical narrative.
@@ -1535,7 +1712,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 0,
             "status": "active",
-            "title": {"es": "Plan preventivo infantil", "en": "Pediatric preventive plan", "fr": "Plan préventif pédiatrique"},
+            "title": {
+                "es": "Plan preventivo infantil",
+                "en": "Pediatric preventive plan",
+                "fr": "Plan préventif pédiatrique",
+            },
             "diagnosis_notes": {
                 "es": "Primera visita. Revisión pediátrica.",
                 "en": "First visit. Pediatric checkup.",
@@ -1559,7 +1740,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 1,
             "status": "active",
-            "title": {"es": "Tratamiento conservador", "en": "Conservative treatment", "fr": "Traitement conservateur"},
+            "title": {
+                "es": "Tratamiento conservador",
+                "en": "Conservative treatment",
+                "fr": "Traitement conservateur",
+            },
             "diagnosis_notes": {
                 "es": "Caries en molares inferiores deciduos.",
                 "en": "Caries on lower deciduous molars.",
@@ -1584,7 +1769,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 2,
             "status": "pending",
-            "title": {"es": "Revisión y limpieza", "en": "Checkup and cleaning", "fr": "Contrôle et détartrage"},
+            "title": {
+                "es": "Revisión y limpieza",
+                "en": "Checkup and cleaning",
+                "fr": "Contrôle et détartrage",
+            },
             "diagnosis_notes": {
                 "es": "Paciente joven, buen estado general.",
                 "en": "Young patient, good general condition.",
@@ -1600,7 +1789,11 @@ PATIENT_JOURNEYS = [
             "status": "draft",
             "global_discount": None,
             "signature": False,
-            "notes": {"es": "Borrador pendiente de revisión", "en": "Draft pending review", "fr": "Brouillon en attente de révision"},
+            "notes": {
+                "es": "Borrador pendiente de revisión",
+                "en": "Draft pending review",
+                "fr": "Brouillon en attente de révision",
+            },
         },
         "appointments": [],
         "invoice": {
@@ -1608,7 +1801,11 @@ PATIENT_JOURNEYS = [
             "status": "draft",
             "payments": [],
             "covers": [0, 1],
-            "notes": {"es": "Borrador - pendiente de emitir", "en": "Draft - pending issuance", "fr": "Brouillon - en attente d'émission"},
+            "notes": {
+                "es": "Borrador - pendiente de emitir",
+                "en": "Draft - pending issuance",
+                "fr": "Brouillon - en attente d'émission",
+            },
         },
     },
     # Patient 3 — Carmen / Emma (pending plan with sent budget, surfaces in
@@ -1618,7 +1815,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 3,
             "status": "pending",
-            "title": {"es": "Plan de tratamiento inicial", "en": "Initial treatment plan", "fr": "Plan de traitement initial"},
+            "title": {
+                "es": "Plan de tratamiento inicial",
+                "en": "Initial treatment plan",
+                "fr": "Plan de traitement initial",
+            },
             "diagnosis_notes": {
                 "es": "Paciente con sensibilidad dental. Requiere empaste en molar.",
                 "en": "Patient with dental sensitivity. Requires filling on molar.",
@@ -1667,7 +1868,11 @@ PATIENT_JOURNEYS = [
             "status": "accepted",
             "global_discount": {"type": "percentage", "value": 5},
             "signature": True,
-            "notes": {"es": "Aceptado, pendiente de agendar", "en": "Accepted, pending scheduling", "fr": "Accepté, en attente de planification"},
+            "notes": {
+                "es": "Aceptado, pendiente de agendar",
+                "en": "Accepted, pending scheduling",
+                "fr": "Accepté, en attente de planification",
+            },
         },
         # No appointments — surfaces in bandeja tab "Sin cita".
         "appointments": [],
@@ -1678,7 +1883,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 5,
             "status": "active",
-            "title": {"es": "Diagnóstico y restauración", "en": "Diagnosis and restoration", "fr": "Diagnostic et restauration"},
+            "title": {
+                "es": "Diagnóstico y restauración",
+                "en": "Diagnosis and restoration",
+                "fr": "Diagnostic et restauration",
+            },
             "diagnosis_notes": {
                 "es": "Embarazada. Evitar radiografías no esenciales.",
                 "en": "Pregnant. Avoid non-essential x-rays.",
@@ -1710,7 +1919,11 @@ PATIENT_JOURNEYS = [
             "status": "partial",
             "payments": [{"method": "card", "percent": 50}],
             "covers": [0, 1, 2],
-            "notes": {"es": "Pago parcial recibido", "en": "Partial payment received", "fr": "Paiement partiel reçu"},
+            "notes": {
+                "es": "Pago parcial recibido",
+                "en": "Partial payment received",
+                "fr": "Paiement partiel reçu",
+            },
         },
     },
     # Patient 6 — Javier / Daniel (diabetic; accepted+signed budget, paid invoice)
@@ -1719,7 +1932,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 6,
             "status": "active",
-            "title": {"es": "Endodoncia y corona", "en": "Root canal and crown", "fr": "Endodontie et couronne"},
+            "title": {
+                "es": "Endodoncia y corona",
+                "en": "Root canal and crown",
+                "fr": "Endodontie et couronne",
+            },
             "diagnosis_notes": {
                 "es": "Paciente diabético. Control especial de cicatrización.",
                 "en": "Diabetic patient. Special healing monitoring.",
@@ -1752,7 +1969,11 @@ PATIENT_JOURNEYS = [
             "status": "paid",
             "payments": [{"method": "bank_transfer", "percent": 100}],
             "covers": [0, 1],
-            "notes": {"es": "Pagado por transferencia", "en": "Paid by bank transfer", "fr": "Payé par virement"},
+            "notes": {
+                "es": "Pagado por transferencia",
+                "en": "Paid by bank transfer",
+                "fr": "Payé par virement",
+            },
         },
     },
     # Patient 7 — Isabel / Mia (rejected budget, no invoice)
@@ -1767,7 +1988,11 @@ PATIENT_JOURNEYS = [
                 "en": "Patient rejected aesthetic veneers due to pricing.",
                 "fr": "Patiente a rejeté les facettes esthétiques en raison du prix.",
             },
-            "title": {"es": "Plan estético rechazado", "en": "Rejected aesthetic plan", "fr": "Plan esthétique rejeté"},
+            "title": {
+                "es": "Plan estético rechazado",
+                "en": "Rejected aesthetic plan",
+                "fr": "Plan esthétique rejeté",
+            },
             "diagnosis_notes": {
                 "es": "Control semestral. Paciente rechazó carillas estéticas.",
                 "en": "Bi-annual checkup. Patient rejected aesthetic veneers.",
@@ -1806,7 +2031,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 8,
             "status": "active",
-            "title": {"es": "Tratamiento periodontal", "en": "Periodontal treatment", "fr": "Traitement parodontal"},
+            "title": {
+                "es": "Tratamiento periodontal",
+                "en": "Periodontal treatment",
+                "fr": "Traitement parodontal",
+            },
             "diagnosis_notes": {
                 "es": "ALÉRGICO A PENICILINA. Usar alternativas.",
                 "en": "ALLERGIC TO PENICILLIN. Use alternatives.",
@@ -1823,7 +2052,11 @@ PATIENT_JOURNEYS = [
             "status": "accepted",
             "global_discount": {"type": "absolute", "value": 50},
             "signature": True,
-            "notes": {"es": "Alérgico a penicilina", "en": "Allergic to penicillin", "fr": "Allergique à la pénicilline"},
+            "notes": {
+                "es": "Alérgico a penicilina",
+                "en": "Allergic to penicillin",
+                "fr": "Allergique à la pénicilline",
+            },
         },
         "appointments": [
             {"week": "past", "covers": [0], "status": "completed"},
@@ -1838,7 +2071,11 @@ PATIENT_JOURNEYS = [
                 {"method": "card", "percent": 60},
             ],
             "covers": [0, 1],
-            "notes": {"es": "Pagado en dos plazos", "en": "Paid in two installments", "fr": "Payé en deux tranches"},
+            "notes": {
+                "es": "Pagado en dos plazos",
+                "en": "Paid in two installments",
+                "fr": "Payé en deux tranches",
+            },
         },
     },
     # Patient 9 — Rosa / Charlotte (hypertensive; accepted+signed, paid invoice)
@@ -1847,7 +2084,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 9,
             "status": "active",
-            "title": {"es": "Rehabilitación oral", "en": "Oral rehabilitation", "fr": "Réhabilitation bucco-dentaire"},
+            "title": {
+                "es": "Rehabilitación oral",
+                "en": "Oral rehabilitation",
+                "fr": "Réhabilitation bucco-dentaire",
+            },
             "diagnosis_notes": {
                 "es": "Hipertensa - verificar presión antes de procedimientos.",
                 "en": "Hypertensive - check blood pressure before procedures.",
@@ -1870,7 +2111,11 @@ PATIENT_JOURNEYS = [
             "status": "accepted",
             "global_discount": {"type": "percentage", "value": 10},
             "signature": True,
-            "notes": {"es": "Tratamiento en curso", "en": "Treatment in progress", "fr": "Traitement en cours"},
+            "notes": {
+                "es": "Tratamiento en curso",
+                "en": "Treatment in progress",
+                "fr": "Traitement en cours",
+            },
         },
         "appointments": [
             {"week": "past", "covers": [0], "status": "completed"},
@@ -1882,7 +2127,11 @@ PATIENT_JOURNEYS = [
             "status": "paid",
             "payments": [{"method": "card", "percent": 100}],
             "covers": [0, 1],
-            "notes": {"es": "Primera fase facturada", "en": "First phase billed", "fr": "Première phase facturée"},
+            "notes": {
+                "es": "Primera fase facturada",
+                "en": "First phase billed",
+                "fr": "Première phase facturée",
+            },
         },
     },
     # Patient 10 — Antonio / Robert (completed prosthetic workflow)
@@ -1891,7 +2140,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 10,
             "status": "completed",
-            "title": {"es": "Prótesis parcial superior", "en": "Upper partial denture", "fr": "Prothèse partielle supérieure"},
+            "title": {
+                "es": "Prótesis parcial superior",
+                "en": "Upper partial denture",
+                "fr": "Prothèse partielle supérieure",
+            },
             "diagnosis_notes": {
                 "es": "Prótesis parcial superior entregada y ajustada.",
                 "en": "Upper partial denture delivered and adjusted.",
@@ -1907,7 +2160,11 @@ PATIENT_JOURNEYS = [
             "status": "completed",
             "global_discount": None,
             "signature": True,
-            "notes": {"es": "Prótesis parcial entregada", "en": "Partial denture delivered", "fr": "Prothèse partielle livrée"},
+            "notes": {
+                "es": "Prótesis parcial entregada",
+                "en": "Partial denture delivered",
+                "fr": "Prothèse partielle livrée",
+            },
         },
         "appointments": [
             {"week": "past", "covers": [0], "status": "completed"},
@@ -1931,7 +2188,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 11,
             "status": "active",
-            "title": {"es": "Corona en dos sesiones", "en": "Two-session crown", "fr": "Couronne en deux séances"},
+            "title": {
+                "es": "Corona en dos sesiones",
+                "en": "Two-session crown",
+                "fr": "Couronne en deux séances",
+            },
             "diagnosis_notes": {
                 "es": "Corona metal-cerámica en 36 — cobro fraccionado por sesión.",
                 "en": "Metal-ceramic crown on tooth 36 — billed per session.",
@@ -1959,7 +2220,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 12,
             "status": "completed",
-            "title": {"es": "Endodoncia urgente", "en": "Urgent root canal", "fr": "Endodontie urgente"},
+            "title": {
+                "es": "Endodoncia urgente",
+                "en": "Urgent root canal",
+                "fr": "Endodontie urgente",
+            },
             "diagnosis_notes": {
                 "es": "Endodoncia urgente por absceso. Paciente anticoagulado.",
                 "en": "Urgent root canal due to abscess. Anticoagulated patient.",
@@ -2000,8 +2265,16 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 13,
             "status": "active",
-            "title": {"es": "Evaluación y limpieza", "en": "Evaluation and cleaning", "fr": "Évaluation et détartrage"},
-            "diagnosis_notes": {"es": "Evaluación periódica.", "en": "Periodic evaluation.", "fr": "Évaluation périodique."},
+            "title": {
+                "es": "Evaluación y limpieza",
+                "en": "Evaluation and cleaning",
+                "fr": "Évaluation et détartrage",
+            },
+            "diagnosis_notes": {
+                "es": "Evaluación periódica.",
+                "en": "Periodic evaluation.",
+                "fr": "Évaluation périodique.",
+            },
             "items": [
                 {"catalog_code": "DX-VISIT", "is_global": True},
                 {"catalog_code": "DX-RXPAN", "is_global": True},
@@ -2019,7 +2292,11 @@ PATIENT_JOURNEYS = [
         "plan": {
             "id_idx": 14,
             "status": "active",
-            "title": {"es": "Mantenimiento protésico", "en": "Prosthetic maintenance", "fr": "Entretien prothétique"},
+            "title": {
+                "es": "Mantenimiento protésico",
+                "en": "Prosthetic maintenance",
+                "fr": "Entretien prothétique",
+            },
             "diagnosis_notes": {
                 "es": "Ajustes periódicos de prótesis completa.",
                 "en": "Periodic complete denture adjustments.",
@@ -2655,7 +2932,13 @@ def generate_invoice_series_data() -> list[dict]:
             "id": INVOICE_SERIES_IDS[0],
             "prefix": "FAC",
             "series_type": "invoice",
-            "description": t({"es": "Serie principal de facturas", "en": "Main invoice series", "fr": "Série principale de factures"}),
+            "description": t(
+                {
+                    "es": "Serie principal de facturas",
+                    "en": "Main invoice series",
+                    "fr": "Série principale de factures",
+                }
+            ),
             "current_number": num_invoices + 1,
             "is_default": True,
         },
@@ -2663,7 +2946,9 @@ def generate_invoice_series_data() -> list[dict]:
             "id": INVOICE_SERIES_IDS[1],
             "prefix": "RECT",
             "series_type": "credit_note",
-            "description": t({"es": "Notas de crédito", "en": "Credit notes", "fr": "Notes de crédit"}),
+            "description": t(
+                {"es": "Notas de crédito", "en": "Credit notes", "fr": "Notes de crédit"}
+            ),
             "current_number": 1,
             "is_default": True,
         },

--- a/backend/scripts/scaffold_module_docs.py
+++ b/backend/scripts/scaffold_module_docs.py
@@ -69,11 +69,10 @@ from check_docs_coverage import (  # noqa: E402
 
 from app.core.plugins.loader import discover_modules  # noqa: E402
 
-LOCALE_LABELS = {"en": "English", "es": "Español", "fr": "Français"}
+LOCALE_LABELS = {"en": "English", "es": "Español"}
 STUB_NOTE_BY_LOCALE = {
     "en": "_Scaffolded stub — replace with proper documentation when this module is next touched._",
     "es": "_Esqueleto generado automáticamente — reemplazar con documentación real cuando se toque este módulo._",
-    "fr": "_Bogue généré automatiquement — remplacer par une documentation réelle lors de la prochaine modification de ce module._",
 }
 
 

--- a/backend/scripts/scaffold_module_docs.py
+++ b/backend/scripts/scaffold_module_docs.py
@@ -69,10 +69,11 @@ from check_docs_coverage import (  # noqa: E402
 
 from app.core.plugins.loader import discover_modules  # noqa: E402
 
-LOCALE_LABELS = {"en": "English", "es": "Español"}
+LOCALE_LABELS = {"en": "English", "es": "Español", "fr": "Français"}
 STUB_NOTE_BY_LOCALE = {
     "en": "_Scaffolded stub — replace with proper documentation when this module is next touched._",
     "es": "_Esqueleto generado automáticamente — reemplazar con documentación real cuando se toque este módulo._",
+    "fr": "_Bogue généré automatiquement — remplacer par une documentation réelle lors de la prochaine modification de ce module._",
 }
 
 

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -602,12 +602,13 @@ Examples:
   python scripts/seed_demo.py              # Default (English)
   python scripts/seed_demo.py --lang es    # Spanish
   python scripts/seed_demo.py --lang en    # English (explicit)
+  python scripts/seed_demo.py --lang fr    # French
         """,
     )
     parser.add_argument(
         "--lang",
         "-l",
-        choices=["en", "es"],
+        choices=["en", "es", "fr"],
         default="en",
         help="Language for demo data (default: en)",
     )
@@ -617,7 +618,8 @@ Examples:
 async def main(lang: str = "en") -> None:
     """Seed the full demo clinical workflow."""
     set_language(lang)
-    lang_name = "English" if lang == "en" else "Spanish"
+    lang_names = {"en": "English", "es": "Spanish", "fr": "French"}
+    lang_name = lang_names.get(lang, lang)
 
     print("\n" + "=" * 60)
     print(f"DentalPin Demo Data Seeder ({lang_name})")

--- a/backend/templates/email/base.html
+++ b/backend/templates/email/base.html
@@ -238,7 +238,7 @@
             <!-- Footer -->
             <div class="email-footer">
                 {% block footer %}
-                <p>Este email fue enviado por {{ clinic_name | default('DentalPin') }}</p>
+                <p>{{ footer_sent_by | default('Este email fue enviado por ' ~ (clinic_name | default('DentalPin'))) }}</p>
                 {% if clinic_phone %}
                 <p>Tel: {{ clinic_phone }}</p>
                 {% endif %}

--- a/backend/templates/email/en/appointment_cancelled.html
+++ b/backend/templates/email/en/appointment_cancelled.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Appointment cancelled - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Appointment cancelled</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>Your appointment at <strong>{{ clinic_name | default('DentalPin') }}</strong> has been cancelled.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Time</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Professional</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if cancellation_reason %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Reason</div>
+            <div class="value">{{ cancellation_reason }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<p>To schedule a new appointment, please contact us.</p>
+{% endblock %}

--- a/backend/templates/email/en/appointment_confirmation.html
+++ b/backend/templates/email/en/appointment_confirmation.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Appointment confirmation - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Appointment confirmation</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>We confirm your appointment at <strong>{{ clinic_name | default('DentalPin') }}</strong>:</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Time</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Professional</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<p>If you need to reschedule or cancel, please contact us as soon as possible.</p>
+{% endblock %}

--- a/backend/templates/email/en/appointment_reminder.html
+++ b/backend/templates/email/en/appointment_reminder.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Appointment reminder - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Appointment reminder</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>This is a friendly reminder of your upcoming appointment at <strong>{{ clinic_name | default('DentalPin') }}</strong>:</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Time</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Professional</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<p>Please arrive a few minutes early. If you need to reschedule, contact us as soon as possible.</p>
+{% endblock %}

--- a/backend/templates/email/en/budget_accepted.html
+++ b/backend/templates/email/en/budget_accepted.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Estimate accepted - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Estimate accepted</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>Your estimate <strong>#{{ budget_number }}</strong> from <strong>{{ clinic_name | default('DentalPin') }}</strong> has been accepted.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div class="label">Estimate</div>
+        <div class="value">#{{ budget_number }}</div>
+    </div>
+    <div class="info-row">
+        <div class="label">Accepted on</div>
+        <div class="value">{{ accepted_date }}</div>
+    </div>
+    <div class="info-row">
+        <div class="label">Total</div>
+        <div class="value" style="font-size: 18px; font-weight: 700;">{{ total }}</div>
+    </div>
+</div>
+
+<p>We will contact you shortly to schedule the corresponding appointments.</p>
+{% endblock %}

--- a/backend/templates/email/en/budget_sent.html
+++ b/backend/templates/email/en/budget_sent.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}Treatment estimate - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Treatment estimate</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>Please find below the treatment estimate <strong>#{{ budget_number }}</strong> from <strong>{{ clinic_name | default('DentalPin') }}</strong>:</p>
+
+{% if treatments %}
+<div class="info-box">
+    {% for t in treatments %}
+    <div class="info-row">
+        <div style="flex: 2;">
+            <div class="label">{{ t.name }}{% if t.tooth %} — Tooth {{ t.tooth }}{% endif %}</div>
+        </div>
+        <div style="flex: 1; text-align: right;">
+            <div class="value">{{ t.price }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
+<div class="info-box">
+    {% if discount_amount %}
+    <div class="info-row">
+        <div class="label">Subtotal</div>
+        <div class="value">{{ subtotal }}</div>
+    </div>
+    <div class="info-row">
+        <div class="label">Discount</div>
+        <div class="value">-{{ discount_amount }}</div>
+    </div>
+    {% endif %}
+    <div class="info-row">
+        <div class="label">Total</div>
+        <div class="value" style="font-size: 18px; font-weight: 700;">{{ total }}</div>
+    </div>
+    {% if validity_days %}
+    <div class="info-row">
+        <div class="label">Valid for</div>
+        <div class="value">{{ validity_days }} days</div>
+    </div>
+    {% endif %}
+</div>
+
+{% if notes %}
+<p><strong>Notes:</strong> {{ notes }}</p>
+{% endif %}
+
+{% if custom_message %}
+<div class="alert alert-info">
+    {{ custom_message }}
+</div>
+{% endif %}
+
+<p>Please contact us if you have any questions about this estimate.</p>
+{% endblock %}

--- a/backend/templates/email/en/invoice_sent.html
+++ b/backend/templates/email/en/invoice_sent.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+{% block title %}Invoice - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Invoice</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>Please find the details of invoice <strong>#{{ invoice_number }}</strong> from <strong>{{ clinic_name | default('DentalPin') }}</strong>:</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Invoice number</div>
+            <div class="value">#{{ invoice_number }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ invoice_date or '—' }}</div>
+        </div>
+    </div>
+    {% if due_date %}
+    <div class="info-row">
+        <div class="label">Due date</div>
+        <div class="value">{{ due_date }}</div>
+    </div>
+    {% endif %}
+</div>
+
+{% if items %}
+<div class="info-box">
+    {% for item in items %}
+    <div class="info-row">
+        <div style="flex: 3;">
+            <div class="label">{{ item.description }}{% if item.quantity > 1 %} × {{ item.quantity }}{% endif %}</div>
+        </div>
+        <div style="flex: 1; text-align: right;">
+            <div class="value">{{ item.line_total }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
+<div class="info-box">
+    {% if total_discount %}
+    <div class="info-row">
+        <div class="label">Subtotal</div>
+        <div class="value">{{ subtotal }}</div>
+    </div>
+    <div class="info-row">
+        <div class="label">Discount</div>
+        <div class="value">-{{ total_discount }}</div>
+    </div>
+    {% endif %}
+    {% if total_tax %}
+    <div class="info-row">
+        <div class="label">Tax</div>
+        <div class="value">{{ total_tax }}</div>
+    </div>
+    {% endif %}
+    <div class="info-row">
+        <div class="label">Total</div>
+        <div class="value" style="font-size: 18px; font-weight: 700;">{{ total }}</div>
+    </div>
+    {% if balance_due and balance_due != total %}
+    <div class="info-row">
+        <div class="label">Balance due</div>
+        <div class="value" style="color: #ef4444; font-weight: 700;">{{ balance_due }}</div>
+    </div>
+    {% endif %}
+</div>
+
+{% if custom_message %}
+<div class="alert alert-info">
+    {{ custom_message }}
+</div>
+{% endif %}
+
+<p>Please contact us if you have any questions about this invoice.</p>
+{% endblock %}

--- a/backend/templates/email/en/verifactu_cert_expiry.html
+++ b/backend/templates/email/en/verifactu_cert_expiry.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}Verifactu certificate expiry - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Verifactu certificate</h2>
+
+<p>Hello {{ admin_name }},</p>
+
+{% if is_expired %}
+<div class="alert alert-error">
+    <strong>Your Verifactu certificate has expired.</strong> You must renew it as soon as possible to continue issuing invoices compliant with Spanish tax regulations.
+</div>
+{% else %}
+<div class="alert alert-warning">
+    <strong>Your Verifactu certificate will expire in {{ days_left }} days.</strong> Please renew it before the expiry date to avoid interruptions.
+</div>
+{% endif %}
+
+<div class="info-box">
+    {% if subject_cn %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Certificate subject</div>
+            <div class="value">{{ subject_cn }}</div>
+        </div>
+    </div>
+    {% endif %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Expiry date</div>
+            <div class="value">{{ valid_until }}</div>
+        </div>
+    </div>
+</div>
+
+<p>You can manage your certificate in the Verifactu settings of your clinic.</p>
+{% endblock %}

--- a/backend/templates/email/en/verifactu_record_rejected.html
+++ b/backend/templates/email/en/verifactu_record_rejected.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Invoice rejected by AEAT - action required - {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Invoice rejected by AEAT</h2>
+
+<p>Hello {{ admin_name }},</p>
+
+<div class="alert alert-error">
+    <strong>Action required:</strong> An invoice has been rejected by the Spanish Tax Agency (AEAT).
+</div>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Invoice</div>
+            <div class="value">{{ invoice_number }}</div>
+        </div>
+    </div>
+    {% if codigo_error %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Error code</div>
+            <div class="value">{{ codigo_error }}</div>
+        </div>
+    </div>
+    {% endif %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Description</div>
+            <div class="value">{{ friendly_message }}</div>
+        </div>
+    </div>
+    {% if field %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Affected field</div>
+            <div class="value">{{ field }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+{% if suggested_cta %}
+<p><strong>Recommended action:</strong> {{ suggested_cta }}</p>
+{% endif %}
+
+<p>Please review the rejection in the Verifactu settings of your clinic and take the necessary corrective action.</p>
+{% endblock %}

--- a/backend/templates/email/en/welcome.html
+++ b/backend/templates/email/en/welcome.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Welcome to {{ clinic_name | default('DentalPin') }}{% endblock %}
+
+{% block content %}
+<h2>Welcome!</h2>
+
+<p>Hello {{ patient_name }},</p>
+
+<p>We are delighted to welcome you to <strong>{{ clinic_name | default('DentalPin') }}</strong>.</p>
+
+<p>You can now manage your appointments, view your treatment history, and access all our services through our platform.</p>
+
+<p>If you have any questions, do not hesitate to contact us.</p>
+{% endblock %}

--- a/backend/templates/email/fr/appointment_cancelled.html
+++ b/backend/templates/email/fr/appointment_cancelled.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Rendez-vous annulé - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ patient_name }},</h2>
+
+<p>Nous vous informons que votre rendez-vous a été annulé.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Heure</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Professionnel</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+{% if cancellation_reason %}
+<div class="alert alert-warning">
+    <strong>Motif :</strong> {{ cancellation_reason }}
+</div>
+{% endif %}
+
+<p>Si vous souhaitez reprogrammer votre rendez-vous, n'hésitez pas à nous contacter.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Prendre un nouveau rendez-vous</a>
+</div>
+{% endif %}
+
+<p>Nous nous excusons pour les désagréments occasionnés.</p>
+{% endblock %}

--- a/backend/templates/email/fr/appointment_confirmation.html
+++ b/backend/templates/email/fr/appointment_confirmation.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}Confirmation de rendez-vous - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ patient_name }},</h2>
+
+<p>Votre rendez-vous a été confirmé. Voici les détails :</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Heure</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Professionnel</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if cabinet_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Cabinet</div>
+            <div class="value">{{ cabinet_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if treatment_type %}
+    <div class="info-row">
+        <div>
+            <div class="label">Traitement</div>
+            <div class="value">{{ treatment_type }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+{% if notes %}
+<div class="alert alert-info">
+    <strong>Notes :</strong> {{ notes }}
+</div>
+{% endif %}
+
+<p>Merci d'arriver 10 minutes avant votre rendez-vous. Si vous devez annuler ou reprogrammer, prévenez-nous au moins 24 heures à l'avance.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Appeler la clinique</a>
+</div>
+{% endif %}
+
+<p>À bientôt !</p>
+{% endblock %}

--- a/backend/templates/email/fr/appointment_reminder.html
+++ b/backend/templates/email/fr/appointment_reminder.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block title %}Rappel de rendez-vous - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ patient_name }},</h2>
+
+<p>Nous vous rappelons que vous avez un rendez-vous prévu :</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Heure</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Professionnel</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if cabinet_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Cabinet</div>
+            <div class="value">{{ cabinet_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if treatment_type %}
+    <div class="info-row">
+        <div>
+            <div class="label">Traitement</div>
+            <div class="value">{{ treatment_type }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<div class="alert alert-info">
+    <strong>Rappel :</strong> Merci d'arriver 10 minutes avant votre rendez-vous.
+</div>
+
+{% if notes %}
+<p><strong>Notes :</strong> {{ notes }}</p>
+{% endif %}
+
+<p>Si vous ne pouvez pas vous présenter, merci de nous en informer à l'avance afin que nous puissions réattribuer le créneau.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Confirmer ma présence</a>
+</div>
+{% endif %}
+
+<p>À bientôt !</p>
+{% endblock %}

--- a/backend/templates/email/fr/budget_accepted.html
+++ b/backend/templates/email/fr/budget_accepted.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Devis accepté - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ patient_name }},</h2>
+
+<p>Nous avons bien enregistré l'acceptation de votre devis. Merci de votre confiance.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">N° Devis</div>
+            <div class="value">{{ budget_number }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Date d'acceptation</div>
+            <div class="value">{{ accepted_date }}</div>
+        </div>
+    </div>
+    <div class="info-row">
+        <div>
+            <div class="label">Total du traitement</div>
+            <div class="value" style="font-size: 20px; color: #3b82f6;">{{ total }} €</div>
+        </div>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <strong>Étape suivante !</strong> Nous vous contacterons pour planifier les rendez-vous nécessaires à votre traitement.
+</div>
+
+{% if notes %}
+<p><strong>Notes :</strong> {{ notes }}</p>
+{% endif %}
+
+<p>Si vous avez des questions ou souhaitez programmer votre premier rendez-vous, contactez-nous.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Prendre rendez-vous</a>
+</div>
+{% endif %}
+
+<p>Merci de votre confiance !</p>
+{% endblock %}

--- a/backend/templates/email/fr/budget_sent.html
+++ b/backend/templates/email/fr/budget_sent.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+
+{% block title %}Devis - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ patient_name }},</h2>
+
+<p>Nous vous envoyons le devis détaillé pour votre traitement dentaire.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">N° Devis</div>
+            <div class="value">{{ budget_number }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Date</div>
+            <div class="value">{{ budget_date }}</div>
+        </div>
+    </div>
+</div>
+
+{% if treatments %}
+<table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+    <thead>
+        <tr style="border-bottom: 2px solid #e4e4e7;">
+            <th style="text-align: left; padding: 12px 0; font-size: 12px; font-weight: 600; text-transform: uppercase; color: #71717a;">Traitement</th>
+            <th style="text-align: right; padding: 12px 0; font-size: 12px; font-weight: 600; text-transform: uppercase; color: #71717a;">Montant</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for treatment in treatments %}
+        <tr style="border-bottom: 1px solid #f4f4f5;">
+            <td style="padding: 12px 0;">
+                <div style="font-weight: 500;">{{ treatment.name }}</div>
+                {% if treatment.tooth %}
+                <div style="font-size: 14px; color: #71717a;">Dent : {{ treatment.tooth }}</div>
+                {% endif %}
+            </td>
+            <td style="text-align: right; padding: 12px 0;">{{ treatment.price }} €</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        {% if subtotal and total != subtotal %}
+        <tr>
+            <td style="padding: 12px 0; text-align: right; font-weight: 500;">Sous-total :</td>
+            <td style="padding: 12px 0; text-align: right;">{{ subtotal }} €</td>
+        </tr>
+        {% endif %}
+        {% if discount_amount %}
+        <tr>
+            <td style="padding: 12px 0; text-align: right; font-weight: 500; color: #22c55e;">Réduction :</td>
+            <td style="padding: 12px 0; text-align: right; color: #22c55e;">-{{ discount_amount }} €</td>
+        </tr>
+        {% endif %}
+        <tr style="border-top: 2px solid #18181b;">
+            <td style="padding: 16px 0; text-align: right; font-size: 18px; font-weight: 600;">Total :</td>
+            <td style="padding: 16px 0; text-align: right; font-size: 18px; font-weight: 600;">{{ total }} €</td>
+        </tr>
+    </tfoot>
+</table>
+{% endif %}
+
+{% if validity_days %}
+<div class="alert alert-info">
+    <strong>Validité :</strong> Ce devis est valide pendant {{ validity_days }} jours à compter de la date d'émission.
+</div>
+{% endif %}
+
+{% if notes %}
+<p><strong>Observations :</strong> {{ notes }}</p>
+{% endif %}
+
+<p>Si vous avez des questions sur le devis ou souhaitez programmer votre traitement, n'hésitez pas à nous contacter.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Nous contacter</a>
+</div>
+{% endif %}
+
+<p>Restant à votre disposition.</p>
+{% endblock %}

--- a/backend/templates/email/fr/copilot_morning_digest.html
+++ b/backend/templates/email/fr/copilot_morning_digest.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+
+{% block title %}Briefing du jour - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Briefing du {{ today }}</h2>
+
+{% if appointments is not none %}
+<h3>Rendez-vous du jour ({{ appointments | length }})</h3>
+{% if appointments %}
+<div class="info-box">
+    {% for a in appointments %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">{{ a.start_time[11:16] if a.start_time else '' }}</div>
+            <div class="value">{{ a.patient_name or '—' }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Statut</div>
+            <div class="value">{{ a.status }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Aucun rendez-vous prévu pour aujourd'hui.</p>
+{% endif %}
+{% endif %}
+
+{% if recalls is not none %}
+<h3>Rappels en retard ({{ recalls | length }})</h3>
+{% if recalls %}
+<div class="info-box">
+    {% for r in recalls %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">{{ r.reason }}</div>
+            <div class="value">{{ r.patient_name or '—' }}{% if r.phone %} · {{ r.phone }}{% endif %}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Priorité</div>
+            <div class="value">{{ r.priority }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Aucun rappel en retard.</p>
+{% endif %}
+{% endif %}
+
+{% if budgets is not none %}
+<h3>Devis en attente de réponse ({{ budgets | length }})</h3>
+{% if budgets %}
+<div class="info-box">
+    {% for b in budgets %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">{{ b.number }}</div>
+            <div class="value">{{ b.patient_name or '—' }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Montant</div>
+            <div class="value">{{ b.total }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Aucun devis en attente de réponse.</p>
+{% endif %}
+{% endif %}
+
+<p style="color: #71717a; font-size: 14px;">
+    Résumé automatique généré par le copilot de DentalPin. Vous pouvez
+    le désactiver ou modifier l'heure dans Paramètres → Copilot.
+</p>
+{% endblock %}

--- a/backend/templates/email/fr/verifactu_cert_expiry.html
+++ b/backend/templates/email/fr/verifactu_cert_expiry.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}{% if is_expired %}Votre certificat Verifactu a expiré{% else %}Votre certificat Verifactu expire bientôt{% endif %}{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ admin_name }},</h2>
+
+{% if is_expired %}
+<div class="alert alert-error">
+    Le certificat numérique de la clinique <strong>{{ clinic_name }}</strong> utilisé pour signer les envois à l'AEAT (Veri*Factu) <strong>a expiré</strong>. Tant que vous ne le renouvelez pas, les enregistrements resteront en file d'attente et l'AEAT rejettera tout envoi.
+</div>
+{% else %}
+<div class="alert alert-warning">
+    Le certificat numérique de la clinique <strong>{{ clinic_name }}</strong> utilisé pour signer les envois à l'AEAT (Veri*Factu) expire dans <strong>{{ days_left }} jour{% if days_left != 1 %}s{% endif %}</strong>. Nous vous recommandons de le renouveler avant la date limite pour éviter toute interruption de la facturation.
+</div>
+{% endif %}
+
+<div class="info-box">
+    <div class="label">Titulaire du certificat</div>
+    <div class="value">{{ subject_cn or '—' }}</div>
+</div>
+
+<div class="info-box">
+    <div class="label">Date d'expiration</div>
+    <div class="value">{{ valid_until.strftime('%d/%m/%Y') }}</div>
+</div>
+
+<h3 style="margin-top: 24px; margin-bottom: 12px; font-size: 16px; font-weight: 600;">Que devez-vous faire ?</h3>
+
+<ol style="padding-left: 20px; color: #3f3f46;">
+    <li style="margin-bottom: 8px;">Demandez un nouveau certificat auprès de la FNMT (Représentant de Personne Juridique, Personne Physique ou Sceau d'Entreprise).</li>
+    <li style="margin-bottom: 8px;">Connectez-vous à DentalPin en tant qu'administrateur et accédez à <em>Paramètres → Verifactu → Certificat</em>.</li>
+    <li style="margin-bottom: 8px;">Téléversez le nouveau fichier <code>.pfx</code> et saisissez son mot de passe. L'ancien certificat est archivé pour audit.</li>
+</ol>
+
+<p>Si vous avez besoin d'aide, répondez à cet email et nous vous guiderons pas à pas.</p>
+{% endblock %}

--- a/backend/templates/email/fr/verifactu_cert_expiry.txt
+++ b/backend/templates/email/fr/verifactu_cert_expiry.txt
@@ -1,0 +1,17 @@
+Bonjour {{ admin_name }},
+
+{% if is_expired -%}
+Le certificat numérique de la clinique "{{ clinic_name }}" utilisé pour signer les envois à l'AEAT (Veri*Factu) A EXPIRÉ. Tant que vous ne le renouvelez pas, les enregistrements resteront en file d'attente et l'AEAT rejettera tout envoi.
+{%- else -%}
+Le certificat numérique de la clinique "{{ clinic_name }}" utilisé pour signer les envois à l'AEAT (Veri*Factu) expire dans {{ days_left }} jour(s). Nous vous recommandons de le renouveler avant la date limite pour éviter toute interruption de la facturation.
+{%- endif %}
+
+Titulaire : {{ subject_cn or '—' }}
+Expiration : {{ valid_until.strftime('%d/%m/%Y') }}
+
+Étapes :
+1. Demandez un nouveau certificat auprès de la FNMT.
+2. Connectez-vous à DentalPin → Paramètres → Verifactu → Certificat.
+3. Téléversez le fichier .pfx et saisissez son mot de passe.
+
+Si vous avez besoin d'aide, répondez à cet email.

--- a/backend/templates/email/fr/verifactu_record_rejected.html
+++ b/backend/templates/email/fr/verifactu_record_rejected.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}Facture rejetée par l'AEAT — action requise{% endblock %}
+
+{% block content %}
+<h2>Bonjour {{ admin_name }},</h2>
+
+<div class="alert alert-error">
+    L'AEAT a <strong>rejeté</strong> l'enregistrement Verifactu de la facture <strong>{{ invoice_number }}</strong> de la clinique <strong>{{ clinic_name }}</strong>.
+    Tant que vous ne résolvez pas ce problème, <strong>vous ne pourrez pas émettre de nouvelles factures</strong> (la chaîne d'empreintes serait compromise).
+</div>
+
+<div class="info-box">
+    <div class="label">Facture</div>
+    <div class="value">{{ invoice_number }}</div>
+</div>
+
+<div class="info-box">
+    <div class="label">Code AEAT</div>
+    <div class="value">{{ codigo_error or '—' }}</div>
+</div>
+
+<div class="info-box">
+    <div class="label">Motif</div>
+    <div class="value">{{ friendly_message }}</div>
+</div>
+
+<h3 style="margin-top: 24px; margin-bottom: 12px; font-size: 16px; font-weight: 600;">Que faire maintenant ?</h3>
+
+<ol style="padding-left: 20px; color: #3f3f46;">
+    {% if suggested_cta == 'edit_clinic' %}
+    <li style="margin-bottom: 8px;">Accédez à <em>Paramètres → Clinique</em> et vérifiez le CIF/NIF de la clinique.</li>
+    <li style="margin-bottom: 8px;">Retournez dans <em>Paramètres → Verifactu → File d'attente</em> et cliquez sur <strong>« Régénérer et renvoyer »</strong>.</li>
+    {% elif suggested_cta == 'edit_billing_party' %}
+    <li style="margin-bottom: 8px;">Ouvrez la facture {{ invoice_number }} et cliquez sur <strong>« Modifier les données du client »</strong> dans la bannière rouge.</li>
+    <li style="margin-bottom: 8px;">Après enregistrement, l'enregistrement est renvoyé automatiquement.</li>
+    {% elif suggested_cta == 'edit_lines' %}
+    <li style="margin-bottom: 8px;">Vérifiez le mapping de la TVA et les montants de la facture {{ invoice_number }}.</li>
+    <li style="margin-bottom: 8px;">Créez une facture d'avoir si la facture était déjà payée ou réémettez-la si c'était un brouillon.</li>
+    {% else %}
+    <li style="margin-bottom: 8px;">Accédez à <em>Paramètres → Verifactu → File d'attente</em> pour voir les détails du rejet.</li>
+    <li style="margin-bottom: 8px;">Si la cause n'est pas claire, contactez le support en joignant le code d'erreur.</li>
+    {% endif %}
+</ol>
+
+{% if queue_url %}
+<p style="margin-top: 20px;">
+    <a href="{{ queue_url }}" style="display: inline-block; padding: 10px 16px; background: #18181b; color: #fff; text-decoration: none; border-radius: 6px;">Ouvrir la file Verifactu</a>
+</p>
+{% endif %}
+{% endblock %}

--- a/backend/templates/email/fr/verifactu_record_rejected.txt
+++ b/backend/templates/email/fr/verifactu_record_rejected.txt
@@ -1,0 +1,27 @@
+Bonjour {{ admin_name }},
+
+L'AEAT a REJETÉ l'enregistrement Verifactu de la facture {{ invoice_number }} de la clinique "{{ clinic_name }}".
+Tant que vous ne résolvez pas ce problème, vous ne pourrez pas émettre de nouvelles factures (la chaîne d'empreintes serait compromise).
+
+Facture : {{ invoice_number }}
+Code AEAT : {{ codigo_error or '—' }}
+Motif : {{ friendly_message }}
+
+Étapes :
+{% if suggested_cta == 'edit_clinic' -%}
+1. Accédez à Paramètres → Clinique et vérifiez le CIF/NIF.
+2. Retournez dans Paramètres → Verifactu → File d'attente et cliquez sur « Régénérer et renvoyer ».
+{% elif suggested_cta == 'edit_billing_party' -%}
+1. Ouvrez la facture {{ invoice_number }} et cliquez sur « Modifier les données du client » dans la bannière.
+2. Après enregistrement, l'enregistrement est renvoyé automatiquement.
+{% elif suggested_cta == 'edit_lines' -%}
+1. Vérifiez le mapping de la TVA et les montants de la facture.
+2. Créez une facture d'avoir si la facture était déjà payée.
+{% else -%}
+1. Accédez à Paramètres → Verifactu → File d'attente pour voir les détails.
+2. Si la cause n'est pas claire, contactez le support en joignant le code d'erreur.
+{% endif %}
+
+{% if queue_url -%}
+File Verifactu : {{ queue_url }}
+{%- endif %}

--- a/backend/templates/email/fr/welcome.html
+++ b/backend/templates/email/fr/welcome.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Bienvenue à {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bienvenue {{ patient_name }} !</h2>
+
+<p>Merci de vous être inscrit(e) auprès de {{ clinic_name }}. Nous sommes ravis de pouvoir vous aider à prendre soin de votre santé dentaire.</p>
+
+<div class="alert alert-success">
+    Votre dossier patient a été créé avec succès dans notre système.
+</div>
+
+<h3 style="margin-top: 24px; margin-bottom: 12px; font-size: 16px; font-weight: 600;">Que pouvez-vous faire maintenant ?</h3>
+
+<ul style="padding-left: 20px; color: #3f3f46;">
+    <li style="margin-bottom: 8px;">Prendre votre premier rendez-vous de bilan</li>
+    <li style="margin-bottom: 8px;">Consulter nos services et traitements</li>
+    <li style="margin-bottom: 8px;">Nous contacter pour toute question</li>
+</ul>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Prendre mon premier rendez-vous</a>
+</div>
+{% endif %}
+
+<div class="info-box">
+    <div class="label">Horaires d'ouverture</div>
+    <div class="value">{{ clinic_hours | default('Lundi à Vendredi : 9h00 - 20h00') }}</div>
+</div>
+
+<p>N'hésitez pas à nous contacter si vous avez des questions. Nous sommes là pour vous aider.</p>
+
+<p>À bientôt !</p>
+{% endblock %}

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
+import { fr, es, en } from '@nuxt/ui/locale'
+
 const { t, locale } = useI18n()
+
+const nuxtUILocales: Record<string, typeof en> = { en, fr, es }
+const nuxtUILocale = computed(() => nuxtUILocales[locale.value] || en)
 
 useHead(() => ({
   meta: [
@@ -20,7 +25,7 @@ useSeoMeta({
 </script>
 
 <template>
-  <UApp>
+  <UApp :locale="nuxtUILocale">
     <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>

--- a/frontend/app/components/charts/DonutChart.vue
+++ b/frontend/app/components/charts/DonutChart.vue
@@ -39,6 +39,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 defineEmits<{ 'slice-click': [key: string] }>()
 
+const { t } = useI18n()
+
 const PALETTE: Tone[] = ['primary', 'success', 'info', 'warning', 'danger', 'neutral']
 
 function toneVar(tone: Tone): string {
@@ -129,7 +131,7 @@ const isEmpty = computed(() => !total.value)
         :height="size"
         :viewBox="`0 0 ${size} ${size}`"
         role="img"
-        :aria-label="`Donut, ${slices.length} segments`"
+        :aria-label="t('charts.donut.ariaLabel', { count: slices.length })"
       >
         <path
           v-for="s in rendered"

--- a/frontend/app/components/charts/TrendAreaChart.vue
+++ b/frontend/app/components/charts/TrendAreaChart.vue
@@ -50,6 +50,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{ 'point-click': [x: string] }>()
 
+const { t } = useI18n()
+
 const W = 800
 const H = computed(() => props.height)
 const PAD_L = 8
@@ -178,7 +180,7 @@ const cursor = computed(() => {
         :viewBox="`0 0 ${W} ${H}`"
         preserveAspectRatio="none"
         role="img"
-        :aria-label="`Trend over ${series.length} points`"
+        :aria-label="t('charts.trend.ariaLabel', { count: series.length })"
         class="w-full h-full overflow-visible"
       >
         <path

--- a/frontend/app/components/settings/SettingsCategoryNav.vue
+++ b/frontend/app/components/settings/SettingsCategoryNav.vue
@@ -39,7 +39,7 @@ function categoryHref(cat: VisibleCategory): string {
   <nav
     class="flex flex-col gap-0.5"
     :class="fullWidth ? '' : 'sticky top-20'"
-    aria-label="Settings categories"
+    :aria-label="t('settings.navLabel')"
   >
     <NuxtLink
       v-for="cat in registry.categories.value"
@@ -65,7 +65,7 @@ function categoryHref(cat: VisibleCategory): string {
           <span
             v-if="cat.hasAttention"
             class="w-2 h-2 rounded-full bg-(--color-warning-accent) shrink-0"
-            aria-label="Atención requerida"
+            :aria-label="t('settings.attentionRequired')"
           />
         </div>
         <p

--- a/frontend/app/components/settings/modules/ModuleDetailModal.vue
+++ b/frontend/app/components/settings/modules/ModuleDetailModal.vue
@@ -30,7 +30,7 @@ async function fetchLog() {
     logEntries.value = await operations(props.module.name, 20)
   } catch (err: unknown) {
     const e = err as { data?: { detail?: string }, message?: string }
-    logError.value = e?.data?.detail ?? e?.message ?? 'error'
+    logError.value = e?.data?.detail ?? e?.message ?? t('common.error')
     logEntries.value = []
   } finally {
     loadingLog.value = false

--- a/frontend/app/components/shared/SearchBar.vue
+++ b/frontend/app/components/shared/SearchBar.vue
@@ -23,6 +23,8 @@ const emit = defineEmits<{
   'update:debounced': [value: string]
 }>()
 
+const { t } = useI18n()
+
 const local = ref(props.modelValue)
 let timer: ReturnType<typeof setTimeout> | null = null
 
@@ -66,7 +68,7 @@ function clear() {
           color="neutral"
           size="xs"
           icon="i-lucide-x"
-          :aria-label="'Clear'"
+          :aria-label="t('common.clear')"
           @click="clear"
         />
       </template>

--- a/frontend/app/components/shared/TreatmentMultiSelector.vue
+++ b/frontend/app/components/shared/TreatmentMultiSelector.vue
@@ -93,7 +93,7 @@ const totalDuration = computed(() =>
             v-if="item.default_duration_minutes"
             class="text-caption text-subtle"
           >
-            {{ item.default_duration_minutes }} min
+            {{ t('common.durationMinutes', { value: item.default_duration_minutes }) }}
           </span>
           <span class="text-sm font-semibold text-primary-accent">
             {{ formatPrice(item.default_price) }}
@@ -113,7 +113,7 @@ const totalDuration = computed(() =>
         v-if="totalDuration > 0"
         class="text-caption text-subtle text-right"
       >
-        {{ t('appointments.estimatedDuration') }}: {{ totalDuration }} min
+        {{ t('appointments.estimatedDuration') }}: {{ t('common.durationMinutes', { value: totalDuration }) }}
       </div>
     </div>
 

--- a/frontend/app/composables/useCurrency.ts
+++ b/frontend/app/composables/useCurrency.ts
@@ -21,8 +21,19 @@ export function useCurrency() {
     }).format(value)
   }
 
+  function symbol(): string {
+    const currency = currentClinic.value?.currency ?? 'EUR'
+    const parts = new Intl.NumberFormat(currentLocale.value, {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol'
+    }).formatToParts(0)
+    return parts.find(p => p.type === 'currency')?.value ?? currency
+  }
+
   return {
     format,
+    symbol,
     currency: computed(() => currentClinic.value?.currency ?? 'EUR')
   }
 }

--- a/frontend/app/composables/useLocale.ts
+++ b/frontend/app/composables/useLocale.ts
@@ -1,16 +1,17 @@
 import { STORAGE_KEYS } from '~/constants/storage'
+import type { CodeLang } from '~/types'
 
 export function useLocale() {
   const { locale, setLocale, locales } = useI18n()
 
   const availableLocales = computed(() =>
-    (locales.value as Array<{ code: string, name: string }>).map(l => ({
+    (locales.value as Array<{ code: CodeLang, name: string }>).map(l => ({
       code: l.code,
       name: l.name
     }))
   )
 
-  async function changeLocale(code: string): Promise<void> {
+  async function changeLocale(code: CodeLang): Promise<void> {
     if (import.meta.client) {
       localStorage.setItem(STORAGE_KEYS.LOCALE, code)
     }
@@ -18,6 +19,7 @@ export function useLocale() {
   }
 
   return {
+    locale,
     currentLocale: computed(() => locale.value),
     availableLocales,
     changeLocale

--- a/frontend/app/constants/languages.ts
+++ b/frontend/app/constants/languages.ts
@@ -1,0 +1,5 @@
+export const SUPPORTED_LOCALES = [
+  'en',
+  'es',
+  'fr'
+] as const

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -326,7 +326,7 @@ function isActive(to: string): boolean {
               class="w-4 h-4 text-subtle shrink-0"
             />
             <span class="text-ui text-muted truncate">
-              {{ clinic.clinicName.value || 'Clínica' }}
+              {{ clinic.clinicName.value || t('nav.defaultClinicName') }}
             </span>
           </div>
         </ClientOnly>

--- a/frontend/app/pages/settings/modules/index.vue
+++ b/frontend/app/pages/settings/modules/index.vue
@@ -128,7 +128,7 @@ async function onConfirm(force: boolean) {
     }
   } catch (err: unknown) {
     const e = err as { data?: { detail?: string }, message?: string }
-    const detail = e?.data?.detail ?? e?.message ?? 'error'
+    const detail = e?.data?.detail ?? e?.message ?? t('common.error')
     confirmError.value = detail
     // If uninstall was blocked by reverse-deps or removable=false, offer force.
     if (

--- a/frontend/app/plugins/locale.client.ts
+++ b/frontend/app/plugins/locale.client.ts
@@ -1,10 +1,12 @@
 import { STORAGE_KEYS } from '~/constants/storage'
+import type { Composer } from 'vue-i18n'
+import type { CodeLang } from '~/types'
+import { SUPPORTED_LOCALES } from '~/constants/languages'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
-  const i18n = nuxtApp.$i18n
-  const SUPPORTED_LOCALES = ['en', 'es']
+  const i18n = nuxtApp.$i18n as Composer
 
-  const savedLocale = localStorage.getItem(STORAGE_KEYS.LOCALE)
+  const savedLocale = localStorage.getItem(STORAGE_KEYS.LOCALE) as CodeLang
 
   if (savedLocale && SUPPORTED_LOCALES.includes(savedLocale) && savedLocale !== i18n.locale.value) {
     await i18n.setLocale(savedLocale)

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -1,4 +1,6 @@
 // User types
+import type { SUPPORTED_LOCALES } from '~/constants/languages'
+
 export interface User {
   id: string
   email: string
@@ -2268,6 +2270,7 @@ export interface NoteTemplate {
   id: string
   category: string
   i18n_key: string
+  body_i18n_key: string
   body: string
 }
 
@@ -2349,3 +2352,5 @@ export interface GenerateBudgetResponse {
   budget_id: string
   budget_number: string
 }
+
+export type CodeLang = typeof SUPPORTED_LOCALES[number]

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -22,6 +22,7 @@
     "invoices": "Invoices",
     "reports": "Reports",
     "settings": "Settings",
+    "defaultClinicName": "Clinic",
     "catalog": "Catalog",
     "menu": "Menu",
     "openMenu": "Open menu",
@@ -82,7 +83,8 @@
     "save": "Save",
     "create": "Create",
     "delete": "Delete",
-    "close": "Close"
+    "close": "Close",
+    "remove": "Remove"
   },
   "patients": {
     "title": "Patients",
@@ -297,6 +299,7 @@
     "editMedicalHistory": "Edit medical history",
     "medicalSnapshot": {
       "title": "Medical information",
+      "allergiesLabel": "Allergies",
       "allergiesEmpty": "No known allergies",
       "allergiesNotReviewed": "Medical history not recorded",
       "completeHistory": "Complete history",
@@ -330,6 +333,12 @@
     },
     "administrative": {
       "title": "Administrative"
+    },
+    "header": {
+      "ariaLabel": "Patient header"
+    },
+    "quickActions": {
+      "ariaLabel": "Patient quick actions"
     }
   },
   "patientDetail": {
@@ -345,7 +354,8 @@
       "budgets": "Budgets",
       "billing": "Billing",
       "payments": "Payments",
-      "documents": "Documents"
+      "documents": "Documents",
+      "gallery": "Gallery"
     },
     "historyPlaceholder": "Clinical notes available in future version",
     "noAppointments": "This patient has no appointments",
@@ -938,6 +948,8 @@
     "title": "Settings",
     "subtitle": "Manage your clinic, team and modules.",
     "allCategories": "All categories",
+    "navLabel": "Settings categories",
+    "attentionRequired": "Attention required",
     "categories": {
       "general": {
         "label": "General",
@@ -1196,6 +1208,7 @@
     "save": "Save",
     "add": "Add",
     "cancel": "Cancel",
+    "clear": "Clear",
     "close": "Close",
     "delete": "Delete",
     "comingSoon": "Coming soon",
@@ -1217,12 +1230,15 @@
     "viewDetails": "View details",
     "previous": "Previous",
     "next": "Next",
+    "previousYear": "Previous year",
+    "nextYear": "Next year",
     "undo": "Undo",
     "undone": "Undone",
     "added": "Added",
     "removed": "Removed",
     "page": "Page {current} of {total}",
     "noData": "No data",
+    "noValue": "no value",
     "noResults": "No results",
     "search": "Search...",
     "selectAll": "All",
@@ -1246,6 +1262,10 @@
     "readOnly": "Read only",
     "createdBy": "Created by",
     "date": "Date",
+    "upload": "Upload",
+    "uploading": "Uploading…",
+    "maxFileSize": "up to 10 MB",
+    "durationMinutes": "{value} min",
     "days": {
       "sunday": "Sunday",
       "monday": "Monday",
@@ -2368,7 +2388,7 @@
       "void": "Void payment",
       "amount": "Amount",
       "method": "Payment method",
-      "date": "Date",
+    "date": "Date",
       "reference": "Reference",
       "notes": "Notes",
       "noPayments": "No payments recorded",
@@ -2739,6 +2759,38 @@
       }
     }
   },
+  "invoiceSeries": {
+    "title": "Invoice Series",
+    "description": "Configure invoice prefixes and numbering",
+    "regularInvoices": "Invoices",
+    "creditNotes": "Credit Notes",
+    "new": "New series",
+    "newTitle": "New {type} series",
+    "editTitle": "Edit series",
+    "prefix": "Prefix",
+    "prefixHint": "e.g. INV, CR. The year will be added automatically.",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Optional series description...",
+    "nextNumber": "Next number",
+    "preview": "Preview",
+    "resetYearly": "Yearly reset",
+    "resetYearlyLabel": "Reset numbering every year",
+    "setAsDefault": "Set as default",
+    "activeLabel": "Active series",
+    "showInactive": "Show inactive",
+    "noItems": "No series configured",
+    "resetCounter": "Reset counter",
+    "currentNumber": "Current number",
+    "seriesPrefix": "Series prefix",
+    "newNumber": "New number",
+    "newNumberHint": "The number must be greater than the highest existing number in this series.",
+    "resetWarningTitle": "Warning",
+    "resetWarning": "This action will be recorded in the audit log and cannot be undone.",
+    "confirmReset": "Reset counter",
+    "created": "Series created successfully",
+    "saved": "Series updated successfully",
+    "resetSuccess": "Counter reset successfully"
+  },
   "documents": {
     "title": "Documents",
     "add": "Add",
@@ -2779,7 +2831,104 @@
     "deleteSuccess": "Document deleted",
     "deleteError": "Error deleting document",
     "updateSuccess": "Document updated",
-    "updateError": "Error updating document"
+    "updateError": "Error updating document",
+    "viewer": {
+      "loading": "Loading document...",
+      "error": "Could not load document",
+      "downloadInstead": "Download instead",
+      "unsupported": "Preview not available for this file type",
+      "zoomOut": "Zoom out",
+      "zoomIn": "Zoom in",
+      "resetZoom": "Reset to 100%",
+      "zoomHint": "Ctrl + scroll to zoom"
+    },
+    "typeDesc": {
+      "consent": "Signed document",
+      "id_scan": "DNI / passport",
+      "insurance": "Policy or card",
+      "report": "Clinical report",
+      "referral": "Referral letter",
+      "other": "Unclassified"
+    },
+    "errors": {
+      "mime": "File type not allowed. Only PDF, JPG or PNG.",
+      "size": "File exceeds 10 MB."
+    },
+    "pdfPreviewHint": "Preview available after upload",
+    "uploadHelp": "Classify the file so it appears in the correct category."
+  },
+  "photoGallery": {
+    "title": "Patient gallery",
+    "add": "Add photo",
+    "empty": "No photos yet",
+    "uploadFirst": "Upload the first one",
+    "showingOf": "Showing {count} of {total}",
+    "upload": "Upload photo",
+    "uploadHelp": "Classify so it appears in the correct category",
+    "dropHere": "Drag a photo here or click",
+    "category": "Type",
+    "subtype": "View",
+    "titlePlaceholder": "Frontal intraoral — 02/05",
+    "capturedAt": "Date",
+    "exifHint": "Auto from EXIF",
+    "cat": {
+      "all": "All",
+      "intraoral": "Intraoral",
+      "extraoral": "Extraoral",
+      "xray": "X-ray",
+      "clinical": "Before/After",
+      "other": "Other"
+    },
+    "catDesc": {
+      "intraoral": "Inside the mouth",
+      "extraoral": "Face and profile",
+      "xray": "Radiological image",
+      "clinical": "Treatment comparison",
+      "other": "Unclassified"
+    },
+    "sub": {
+      "frontal": "Frontal",
+      "lateral_left": "Left lateral",
+      "lateral_right": "Right lateral",
+      "occlusal_upper": "Upper occlusal",
+      "occlusal_lower": "Lower occlusal",
+      "palatal": "Palatal",
+      "lingual": "Lingual",
+      "smile": "Smile",
+      "rest": "Rest",
+      "frontal_face": "Frontal",
+      "profile_left": "Left profile",
+      "profile_right": "Right profile",
+      "three_quarter_left": "3/4 left",
+      "three_quarter_right": "3/4 right",
+      "panoramic": "Panoramic",
+      "periapical": "Periapical",
+      "bitewing": "Bitewing",
+      "ceph_lat": "Ceph lateral",
+      "ceph_pa": "Ceph PA",
+      "cbct": "CBCT",
+      "occlusal_xray": "Occlusal X-ray",
+      "before": "Before",
+      "after": "After",
+      "progress": "Progress",
+      "reference": "Reference",
+      "portrait": "Portrait",
+      "document_scan": "Document",
+      "model_photo": "Model"
+    },
+    "compare": {
+      "before": "Before",
+      "after": "After"
+    },
+    "pair": {
+      "pickHint": "Choose the photo to pair:",
+      "noCandidates": "No photos available. Upload another first.",
+      "paired": "Paired",
+      "exitCompare": "Exit comparison",
+      "compare": "Compare",
+      "unpair": "Remove",
+      "pair": "Pair before/after"
+    }
   },
   "help": {
     "label": "Help",
@@ -2787,5 +2936,13 @@
     "drawerTitle": "Help for this page",
     "unavailable": "No contextual help available for this page yet.",
     "openFullManual": "Open full manual"
+  },
+  "charts": {
+    "trend": {
+      "ariaLabel": "Trend over {count} points"
+    },
+    "donut": {
+      "ariaLabel": "Donut chart, {count} segments"
+    }
   }
 }

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -82,7 +82,8 @@
     "save": "Guardar",
     "create": "Crear",
     "delete": "Eliminar",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "remove": "Eliminar"
   },
   "patients": {
     "title": "Pacientes",
@@ -325,6 +326,7 @@
     "editMedicalHistory": "Editar historial médico",
     "medicalSnapshot": {
       "title": "Información médica",
+      "allergiesLabel": "Alergias",
       "allergiesEmpty": "Sin alergias conocidas",
       "allergiesNotReviewed": "Historial médico no registrado",
       "completeHistory": "Completar historial",
@@ -358,6 +360,12 @@
     },
     "administrative": {
       "title": "Administración"
+    },
+    "header": {
+      "ariaLabel": "Cabecera del paciente"
+    },
+    "quickActions": {
+      "ariaLabel": "Acciones rápidas del paciente"
     }
   },
   "patientDetail": {
@@ -373,7 +381,8 @@
       "budgets": "Presupuestos",
       "billing": "Facturación",
       "payments": "Pagos",
-      "documents": "Documentos"
+      "documents": "Documentos",
+      "gallery": "Galería"
     },
     "historyPlaceholder": "Notas clínicas disponibles en futura versión",
     "noAppointments": "Este paciente no tiene citas",
@@ -1218,6 +1227,7 @@
     "save": "Guardar",
     "add": "Añadir",
     "cancel": "Cancelar",
+    "clear": "Limpiar",
     "close": "Cerrar",
     "delete": "Eliminar",
     "comingSoon": "Próximamente",
@@ -1239,12 +1249,15 @@
     "viewDetails": "Ver detalle",
     "previous": "Anterior",
     "next": "Siguiente",
+    "previousYear": "Año anterior",
+    "nextYear": "Año siguiente",
     "undo": "Deshacer",
     "undone": "Deshecho",
     "added": "Añadido",
     "removed": "Eliminado",
     "page": "Página {current} de {total}",
     "noData": "Sin datos",
+    "noValue": "sin valor",
     "noResults": "Sin resultados",
     "search": "Buscar...",
     "selectAll": "Todos",
@@ -1268,6 +1281,9 @@
     "readOnly": "Solo lectura",
     "createdBy": "Creado por",
     "date": "Fecha",
+    "upload": "Subir foto",
+    "uploading": "Subiendo…",
+    "maxFileSize": "hasta 10 MB",
     "days": {
       "sunday": "Domingo",
       "monday": "Lunes",
@@ -2846,7 +2862,104 @@
     "deleteSuccess": "Documento eliminado",
     "deleteError": "Error al eliminar documento",
     "updateSuccess": "Documento actualizado",
-    "updateError": "Error al actualizar documento"
+    "updateError": "Error al actualizar documento",
+    "viewer": {
+      "loading": "Cargando documento...",
+      "error": "No se pudo cargar el documento",
+      "downloadInstead": "Descargar en su lugar",
+      "unsupported": "Vista previa no disponible para este tipo de archivo",
+      "zoomOut": "Alejar",
+      "zoomIn": "Acercar",
+      "resetZoom": "Restablecer a 100%",
+      "zoomHint": "Ctrl + rueda del ratón para zoom"
+    },
+    "typeDesc": {
+      "consent": "Documento firmado",
+      "id_scan": "DNI / pasaporte",
+      "insurance": "Póliza o tarjeta",
+      "report": "Reporte clínico",
+      "referral": "Carta de remisión",
+      "other": "Sin clasificar"
+    },
+    "errors": {
+      "mime": "Tipo no permitido. Solo PDF, JPG o PNG.",
+      "size": "El archivo supera 10 MB."
+    },
+    "pdfPreviewHint": "Vista previa tras subir",
+    "uploadHelp": "Clasifica el archivo para que aparezca en su categoría."
+  },
+  "photoGallery": {
+    "title": "Galería del paciente",
+    "add": "Añadir foto",
+    "empty": "No hay fotos todavía",
+    "uploadFirst": "Sube la primera",
+    "showingOf": "Mostrando {count} de {total}",
+    "upload": "Subir foto",
+    "uploadHelp": "Clasifica para que aparezca en la categoría correcta",
+    "dropHere": "Arrastra una foto o haz clic",
+    "category": "Tipo",
+    "subtype": "Vista",
+    "titlePlaceholder": "Frontal intraoral — 02/05",
+    "capturedAt": "Fecha",
+    "exifHint": "Auto desde EXIF",
+    "cat": {
+      "all": "Todas",
+      "intraoral": "Intraoral",
+      "extraoral": "Extraoral",
+      "xray": "Radiografía",
+      "clinical": "Antes/Después",
+      "other": "Otra"
+    },
+    "catDesc": {
+      "intraoral": "Dentro de la boca",
+      "extraoral": "Cara y perfil",
+      "xray": "Imagen radiológica",
+      "clinical": "Comparativa de tratamiento",
+      "other": "Sin clasificar"
+    },
+    "sub": {
+      "frontal": "Frontal",
+      "lateral_left": "Lateral izda",
+      "lateral_right": "Lateral dcha",
+      "occlusal_upper": "Oclusal sup",
+      "occlusal_lower": "Oclusal inf",
+      "palatal": "Palatal",
+      "lingual": "Lingual",
+      "smile": "Sonrisa",
+      "rest": "Reposo",
+      "frontal_face": "Frontal",
+      "profile_left": "Perfil izdo",
+      "profile_right": "Perfil dcho",
+      "three_quarter_left": "3/4 izdo",
+      "three_quarter_right": "3/4 dcho",
+      "panoramic": "Panorámica",
+      "periapical": "Periapical",
+      "bitewing": "Aleta",
+      "ceph_lat": "Cefalo lateral",
+      "ceph_pa": "Cefalo PA",
+      "cbct": "CBCT",
+      "occlusal_xray": "Oclusal Rx",
+      "before": "Antes",
+      "after": "Después",
+      "progress": "Progreso",
+      "reference": "Referencia",
+      "portrait": "Retrato",
+      "document_scan": "Documento",
+      "model_photo": "Modelo"
+    },
+    "compare": {
+      "before": "Antes",
+      "after": "Después"
+    },
+    "pair": {
+      "pickHint": "Elige la foto a emparejar:",
+      "noCandidates": "Sin fotos disponibles. Sube otra primero.",
+      "paired": "Emparejada",
+      "exitCompare": "Salir de la comparativa",
+      "compare": "Comparar",
+      "unpair": "Quitar",
+      "pair": "Emparejar antes/después"
+    }
   },
   "help": {
     "label": "Ayuda",
@@ -2854,5 +2967,13 @@
     "drawerTitle": "Ayuda de esta página",
     "unavailable": "Aún no hay ayuda contextual para esta página.",
     "openFullManual": "Abrir manual completo"
+  },
+  "charts": {
+    "trend": {
+      "ariaLabel": "Tendencia en {count} puntos"
+    },
+    "donut": {
+      "ariaLabel": "Gráfico circular, {count} segmentos"
+    }
   }
 }

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -26,7 +26,8 @@
     "menu": "Menú",
     "openMenu": "Abrir menú",
     "close": "Cerrar",
-    "toggleSidebar": "Alternar barra lateral"
+    "toggleSidebar": "Alternar barra lateral",
+    "defaultClinicName": "Clínica"
   },
   "auth": {
     "login": "Iniciar sesión",
@@ -1190,7 +1191,9 @@
         "scheduled": "Operación programada. Aplica los cambios para completarla.",
         "applied": "Cambios aplicados correctamente."
       }
-    }
+    },
+    "navLabel": "Categorías de ajustes",
+    "attentionRequired": "Atención requerida"
   },
   "selector": {
     "recentPatients": "Pacientes recientes",
@@ -1299,7 +1302,8 @@
     "yesterday": "Ayer",
     "copied": "Copiado al portapapeles",
     "copy": "Copiar",
-    "copyFailed": "No se pudo copiar"
+    "copyFailed": "No se pudo copiar",
+    "durationMinutes": "{value} min"
   },
   "cabinet": {
     "toast": {

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -1,0 +1,2948 @@
+{
+  "app": {
+    "name": "DentalPin",
+    "tagline": "Gestion de clinique dentaire"
+  },
+  "demo": {
+    "bannerMessage": "Démo publique — n'entrez pas de données réelles de patients. La base de données est réinitialisée périodiquement.",
+    "bannerDismiss": "Fermer",
+    "credentialsTitle": "Identifiants de la démo",
+    "credentialsNote": "Uniquement pour évaluation — affiché car il s'agit d'une instance de démo publique.",
+    "copyEmail": "Copier l'email",
+    "copyPassword": "Copier le mot de passe",
+    "copied": "Copié dans le presse-papiers"
+  },
+  "nav": {
+    "dashboard": "Accueil",
+    "patients": "Patients",
+    "appointments": "Agenda",
+    "recalls": "Rappels",
+    "treatmentPlans": "Plans de traitement",
+    "budgets": "Devis",
+    "invoices": "Factures",
+    "reports": "Rapports",
+    "settings": "Paramètres",
+    "defaultClinicName": "Clinique",
+    "catalog": "Catalogue",
+    "menu": "Menu",
+    "openMenu": "Ouvrir le menu",
+    "close": "Fermer",
+    "toggleSidebar": "Basculer la barre latérale"
+  },
+  "auth": {
+    "login": "Connexion",
+    "logout": "Déconnexion",
+    "email": "Email",
+    "password": "Mot de passe",
+    "loginButton": "Se connecter",
+    "loginSuccess": "Connexion réussie",
+    "invalidCredentials": "Email ou mot de passe incorrect",
+    "emailRequired": "Saisissez votre email",
+    "passwordRequired": "Saisissez votre mot de passe",
+    "emailInvalid": "Adresse email invalide",
+    "accountInactive": "Votre compte est inactif. Contactez votre administrateur",
+    "tooManyAttempts": "Trop de tentatives. Réessayez dans quelques minutes",
+    "sessionExpired": "Votre session a expiré",
+    "networkError": "Impossible de se connecter au serveur",
+    "serverError": "Le serveur est indisponible. Veuillez réessayer dans quelques minutes",
+    "unknownError": "Erreur inattendue. Veuillez réessayer"
+  },
+  "setup": {
+    "title": "Configuration initiale",
+    "subtitle": "Créez le compte administrateur et votre clinique pour commencer",
+    "stepAccount": "Compte administrateur",
+    "stepClinic": "Informations de la clinique",
+    "firstName": "Prénom",
+    "lastName": "Nom",
+    "email": "Email",
+    "password": "Mot de passe",
+    "passwordConfirm": "Confirmer le mot de passe",
+    "passwordHint": "Au moins 8 caractères, avec des lettres et des chiffres",
+    "clinicName": "Nom de la clinique",
+    "taxId": "Identifiant fiscal",
+    "next": "Suivant",
+    "back": "Retour",
+    "submit": "Créer et démarrer",
+    "success": "Tout est prêt ! Bienvenue sur DentalPin",
+    "firstNameRequired": "Saisissez le prénom",
+    "lastNameRequired": "Saisissez le nom",
+    "emailRequired": "Saisissez l'email",
+    "emailInvalid": "L'email n'est pas valide",
+    "passwordRequired": "Saisissez un mot de passe",
+    "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères",
+    "passwordWeak": "Le mot de passe doit contenir des lettres et des chiffres",
+    "passwordMismatch": "Les mots de passe ne correspondent pas",
+    "clinicNameRequired": "Saisissez le nom de la clinique",
+    "taxIdRequired": "Saisissez l'identifiant fiscal",
+    "alreadyInitialized": "Le système est déjà configuré. Veuillez vous connecter.",
+    "error": "La configuration n'a pas pu être terminée. Veuillez réessayer"
+  },
+  "actions": {
+    "edit": "Modifier",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "create": "Créer",
+    "delete": "Supprimer",
+    "close": "Fermer",
+    "remove": "Retirer"
+  },
+  "patients": {
+    "title": "Patients",
+    "create": "Nouveau patient",
+    "edit": "Modifier le patient",
+    "search": "Rechercher un patient...",
+    "searchPlaceholder": "Nom ou téléphone",
+    "noResults": "Aucun patient trouvé",
+    "empty": "Aucun patient enregistré",
+    "emptyAction": "Créer le premier patient",
+    "name": "Nom",
+    "firstName": "Prénom",
+    "lastName": "Nom",
+    "phone": "Téléphone",
+    "email": "Email",
+    "dateOfBirth": "Date de naissance",
+    "notes": "Notes",
+    "created": "Patient créé",
+    "updated": "Patient mis à jour",
+    "archived": "Patient archivé",
+    "notFound": "Patient introuvable",
+    "archiveConfirm": "Archiver le patient {name} ?",
+    "archiveDescription": "Cette action masquera le patient des recherches. Les rendez-vous existants ne seront pas supprimés.",
+    "cancel": "Annuler",
+    "archive": "Archiver",
+    "dangerZone": {
+      "title": "Zone de danger",
+      "archiveHelp": "Archiver le patient pour le masquer des recherches. Les rendez-vous et l'historique sont conservés."
+    },
+    "billingSection": "Informations de facturation",
+    "billingSectionHint": "Ces données seront automatiquement utilisées lors de la création de factures pour ce patient.",
+    "editingBillingForInvoice": "Modification des données de facturation. Les changements seront reflétés dans la facture.",
+    "returnToInvoice": "Retour à la facture",
+    "billingName": "Nom de facturation",
+    "billingNamePlaceholder": "Nom ou société pour les factures",
+    "billingTaxId": "Identifiant fiscal",
+    "billingEmail": "Email de facturation",
+    "billingAddress": "Adresse de facturation",
+    "billingComplete": "Complet",
+    "billingIncomplete": "Incomplet",
+    "demographics": "Données démographiques",
+    "nationalId": "Pièce d'identité",
+    "nationalIdType": "Type de document",
+    "passport": "Passeport",
+    "profession": "Profession",
+    "workplace": "Lieu de travail",
+    "years": "ans",
+    "status": {
+      "active": "Actif",
+      "archived": "Archivé"
+    },
+    "filters": {
+      "status": "Statut",
+      "city": "Ville",
+      "withDebt": "Avec solde débiteur",
+      "doNotContact": "Ne pas contacter",
+      "doNotContactOnly": "Uniquement ne-pas-contacter",
+      "doNotContactOnlyContactable": "Uniquement joignables"
+    },
+    "columns": {
+      "city": "Ville",
+      "contact": "Contact",
+      "debt": "Solde débiteur"
+    },
+    "sort": {
+      "lastVisit": "Dernière visite",
+      "lastName": "Nom",
+      "firstName": "Prénom",
+      "createdAt": "Inscrit le",
+      "updatedAt": "Récemment modifié"
+    },
+    "doNotContact": {
+      "label": "Ne pas contacter",
+      "hint": "Le patient sera exclu de la liste d'appels et des communications automatisées",
+      "badge": "Ne pas contacter"
+    },
+    "gender": {
+      "label": "Genre",
+      "select": "Sélectionner le genre",
+      "male": "Homme",
+      "female": "Femme",
+      "other": "Autre",
+      "preferNotSay": "Préfère ne pas préciser"
+    },
+    "emergencyContact": {
+      "title": "Contact d'urgence",
+      "hasContact": "A un contact d'urgence",
+      "noContact": "Aucun contact d'urgence enregistré",
+      "name": "Nom complet",
+      "namePlaceholder": "Nom du contact",
+      "relationship": "Lien de parenté",
+      "relationshipPlaceholder": "Sélectionner le lien",
+      "phone": "Téléphone",
+      "phonePlaceholder": "Téléphone du contact",
+      "email": "Email",
+      "emailPlaceholder": "Email du contact",
+      "isLegalGuardian": "Est tuteur légal",
+      "remove": "Supprimer le contact",
+      "relationships": {
+        "spouse": "Conjoint",
+        "parent": "Parent",
+        "child": "Enfant",
+        "sibling": "Frère/Sœur",
+        "friend": "Ami",
+        "other": "Autre"
+      }
+    },
+    "medicalHistory": {
+      "title": "Antécédents médicaux",
+      "save": "Enregistrer l'historique",
+      "fetchError": "Erreur lors du chargement des antécédents médicaux",
+      "saveSuccess": "Antécédents médicaux enregistrés",
+      "saveError": "Erreur lors de l'enregistrement des antécédents médicaux",
+      "allergies": "Allergies",
+      "allergiesCount": "{n} allergie | {n} allergies",
+      "onAnticoagulants": "Sous traitement anticoagulant",
+      "allergyName": "Nom de l'allergie",
+      "type": "Type",
+      "allergyTypes": {
+        "drug": "Médicamenteuse",
+        "food": "Alimentaire",
+        "material": "Matériau",
+        "environmental": "Environnementale"
+      },
+      "severity": {
+        "low": "Faible",
+        "medium": "Modérée",
+        "high": "Élevée",
+        "critical": "Critique"
+      },
+      "medications": "Médicaments",
+      "medicationName": "Nom du médicament",
+      "dosage": "Dosage",
+      "frequency": "Fréquence",
+      "systemicDiseases": "Maladies systémiques",
+      "diseaseName": "Nom de la maladie",
+      "diseaseTypes": {
+        "cardiovascular": "Cardiovasculaire",
+        "respiratory": "Respiratoire",
+        "endocrine": "Endocrine",
+        "neurological": "Neurologique",
+        "autoimmune": "Autoimmune",
+        "other": "Autre"
+      },
+      "critical": "Critique",
+      "controlled": "Contrôlée",
+      "notControlled": "Non contrôlée",
+      "specialConditions": "Conditions particulières",
+      "pregnant": "Enceinte",
+      "pregnancyWeek": "Semaine de grossesse",
+      "lactating": "Allaitante",
+      "anticoagulants": "Anticoagulants",
+      "anticoagulantMedication": "Médicament anticoagulant",
+      "inrValue": "Valeur de l'INR",
+      "anesthesiaReaction": "Réaction à l'anesthésie",
+      "anesthesiaReactionDetails": "Détails de la réaction",
+      "bruxism": "Bruxisme",
+      "lifestyle": "Mode de vie",
+      "smoker": "Fumeur",
+      "smokingFrequency": "Cigarettes/jour",
+      "alcoholConsumption": "Consommation d'alcool",
+      "alcohol": {
+        "none": "Aucune",
+        "occasional": "Occasionnelle",
+        "moderate": "Modérée",
+        "heavy": "Importante"
+      },
+      "surgicalHistory": "Antécédents chirurgicaux",
+      "procedure": "Acte"
+    },
+    "timeline": {
+      "empty": "Aucune activité enregistrée pour le moment",
+      "emptyFiltered": "Aucun événement dans cette catégorie",
+      "clearFilter": "Afficher toute l'activité",
+      "endOfTimeline": "Fin de la chronologie",
+      "totalEntries": "{count} entrée | {count} entrées",
+      "groups": {
+        "today": "Aujourd'hui",
+        "yesterday": "Hier",
+        "thisWeek": "Cette semaine",
+        "thisMonth": "Ce mois-ci",
+        "earlier": "Plus tôt"
+      },
+      "author": "par {name}",
+      "meta": {
+        "cabinet": "Cabinet {name}",
+        "teeth": "Dents : {list}",
+        "total": "Total : {amount}",
+        "number": "N° {value}",
+        "via": "Via {channel}",
+        "template": "Modèle : {key}",
+        "docType": "Type : {type}"
+      },
+      "categories": {
+        "all": "Tout",
+        "visit": "Visites",
+        "treatment": "Traitements",
+        "financial": "Financier",
+        "communication": "Communications",
+        "medical": "Antécédents médicaux",
+        "document": "Documents",
+        "note": "Notes cliniques"
+      }
+    },
+    "alerts": {
+      "title": "{count} alerte | {count} alertes",
+      "label": "Alertes cliniques"
+    },
+    "editDemographics": "Modifier les données démographiques",
+    "editEmergencyContact": "Modifier le contact d'urgence",
+    "editBilling": "Modifier les informations de facturation",
+    "editMedicalHistory": "Modifier les antécédents médicaux",
+    "medicalSnapshot": {
+      "title": "Informations médicales",
+      "allergiesLabel": "Allergies",
+      "allergiesEmpty": "Aucune allergie connue",
+      "allergiesNotReviewed": "Antécédents médicaux non enregistrés",
+      "completeHistory": "Historique complet",
+      "reviewedOn": "Revu le {date}",
+      "conditions": {
+        "pregnantWeek": "Enceinte · s. {week}",
+        "anticoagulantInr": "Anticoagulant · INR {inr}",
+        "smokerFreq": "Fumeur · {freq}/jour"
+      }
+    },
+    "visitSummary": {
+      "title": "Résumé de la visite",
+      "lastVisit": "Dernière visite",
+      "nextAppointment": "Prochain rendez-vous",
+      "noLastVisit": "Aucune visite précédente",
+      "noNextAppointment": "Aucun rendez-vous programmé"
+    },
+    "personalInfo": {
+      "title": "Informations personnelles",
+      "ageLabel": "{age} ans",
+      "birthWithAge": "{date} ({age} ans)"
+    },
+    "contactInfo": {
+      "title": "Contact",
+      "copyPhone": "Copier le téléphone",
+      "copyEmail": "Copier l'email",
+      "address": "Adresse",
+      "addEmergency": "Ajouter un contact d'urgence",
+      "addGuardian": "Ajouter un tuteur légal",
+      "guardianRequired": "Tuteur légal requis"
+    },
+    "administrative": {
+      "title": "Administratif"
+    },
+    "header": {
+      "ariaLabel": "En-tête du patient"
+    },
+    "quickActions": {
+      "ariaLabel": "Actions rapides du patient"
+    }
+  },
+  "patientDetail": {
+    "tabs": {
+      "summary": "Résumé",
+      "info": "Infos",
+      "clinical": "Clinique",
+      "odontogram": "Odontogramme",
+      "administration": "Administration",
+      "history": "Historique",
+      "timeline": "Activité",
+      "appointments": "Rendez-vous",
+      "budgets": "Devis",
+      "billing": "Facturation",
+      "payments": "Paiements",
+      "documents": "Documents",
+      "gallery": "Galerie"
+    },
+    "historyPlaceholder": "Notes cliniques disponibles dans une future version",
+    "noAppointments": "Ce patient n'a aucun rendez-vous",
+    "scheduleAppointment": "Programmer un rendez-vous",
+    "noBudgets": "Ce patient n'a aucun devis",
+    "createBudget": "Créer un devis",
+    "viewAllBudgets": "Voir tous les devis",
+    "activePlan": "Plan actif",
+    "noActivePlan": "Aucun plan actif",
+    "viewPlan": "Ouvrir le plan",
+    "createPlan": "Créer un plan",
+    "nextAppointment": "Prochain rendez-vous",
+    "noUpcomingAppointments": "Aucun rendez-vous à venir",
+    "openAppointment": "Ouvrir le rendez-vous",
+    "reschedule": "Reporter",
+    "balance": "Solde",
+    "collect": "Encaisser",
+    "viewLedger": "Ouvrir le grand livre",
+    "noPayments": "Aucun mouvement",
+    "diagnoses": "Diagnostiques",
+    "pending": "non traité",
+    "noDiagnoses": "Aucune anomalie en attente",
+    "openOdontogram": "Ouvrir l'odontogramme",
+    "medicalHistory": "Antécédents médicaux",
+    "completeMedicalHistory": "Aucun antécédent médical. Complétez-les pour enregistrer les allergies, les conditions et les médicaments.",
+    "editMedicalHistory": "Modifier les antécédents médicaux",
+    "quickActions": "Actions rapides",
+    "edit": "Modifier",
+    "editPatient": "Modifier le patient",
+    "noSummaryCards": "Aucun module enregistré dans le résumé.",
+    "actions": {
+      "label": "Actions",
+      "newAppointment": "Rendez-vous",
+      "collect": "Encaisser",
+      "newNote": "Note",
+      "newBudget": "Devis",
+      "uploadDocument": "Document"
+    }
+  },
+  "patientBilling": {
+    "totalBudgeted": "Total estimé",
+    "workInProgress": "Travaux en cours",
+    "workCompleted": "Travaux terminés",
+    "totalInvoiced": "Total facturé",
+    "totalPaid": "Total payé",
+    "balancePending": "Solde en attente",
+    "invoices": "Factures",
+    "createInvoice": "Créer une facture",
+    "noInvoices": "Ce patient n'a aucune facture",
+    "pending": "En attente"
+  },
+  "odontogram": {
+    "title": "Odontogramme",
+    "tooth": "Dent",
+    "globals": {
+      "category": "Bouche complète",
+      "applied": "{name} ajouté au plan",
+      "archPickerTitle": "Quelle arcade pour « {name} » ?",
+      "upperArch": "Arcade supérieure",
+      "lowerArch": "Arcade inférieure"
+    },
+    "selectCondition": "Sélectionner l'état",
+    "readOnly": "Lecture seule",
+    "legend": "Légende",
+    "statusLegend": "Statut du traitement",
+    "toothPosition": "Position dentaire",
+    "displaced": "Déplacée",
+    "rotated": "Tournée",
+    "dentition": {
+      "permanent": "Permanentes",
+      "deciduous": "Temporaires",
+      "toggle": "Basculer la dentition"
+    },
+    "quadrants": {
+      "upper": "Arcade supérieure",
+      "lower": "Arcade inférieure",
+      "upperRight": "Supérieur droit",
+      "upperLeft": "Supérieur gauche",
+      "lowerRight": "Inférieur droit",
+      "lowerLeft": "Inférieur gauche"
+    },
+    "surfaces": {
+      "M": "Mésiale",
+      "D": "Distale",
+      "O": "Occlusale",
+      "V": "Vestibulaire",
+      "L": "Linguale"
+    },
+    "conditions": {
+      "healthy": "Saine",
+      "caries": "Carie",
+      "filling": "Obturation",
+      "crown": "Couronne",
+      "missing": "Absente",
+      "root_canal": "Traitement canalaire",
+      "implant": "Implant",
+      "bridge_pontic": "Pont de bridge",
+      "bridge_abutment": "Pilier de bridge",
+      "extraction_indicated": "Extraction indiquée",
+      "sealant": "Scellant",
+      "fracture": "Fracture"
+    },
+    "history": {
+      "title": "Historique des modifications",
+      "noChanges": "Aucune modification enregistrée",
+      "changedBy": "Modifié par",
+      "changeTypes": {
+        "created": "Créé",
+        "general_condition": "État général",
+        "surface_update": "Mise à jour de surface",
+        "note": "Note"
+      }
+    },
+    "messages": {
+      "updated": "Odontogramme mis à jour",
+      "error": "Erreur lors de la mise à jour de l'odontogramme",
+      "loadError": "Impossible de charger l'odontogramme"
+    },
+    "actions": {
+      "save": "Enregistrer",
+      "reset": "Réinitialiser",
+      "print": "Imprimer"
+    },
+    "status": {
+      "existing": "Existant",
+      "planned": "Planifié"
+    },
+    "treatments": {
+      "title": "Traitements",
+      "addTreatment": "Ajouter un traitement",
+      "selectStatus": "Sélectionner le statut",
+      "noTreatments": "Aucun traitement enregistré",
+      "markPerformed": "Marquer comme réalisé",
+      "categories": {
+        "common": "Courant",
+        "restorative": "Restauratrice",
+        "diagnostic": "Diagnostique",
+        "orthodontic": "Orthodontie",
+        "periodontic": "Parodontie",
+        "position": "Position",
+        "other": "Autre",
+        "diagnostico": "Diagnostique",
+        "restauradora": "Restauratrice",
+        "cirugia": "Chirurgie",
+        "endodoncia": "Endodontie",
+        "ortodoncia": "Orthodontie"
+      },
+      "types": {
+        "pulpitis": "Pulpite",
+        "caries": "Carie",
+        "incipient_caries": "Carie naissante",
+        "pigmentation": "Pigmentation",
+        "fracture": "Fracture",
+        "missing": "Absente",
+        "periapical_small": "Péricimentaire <2mm",
+        "periapical_medium": "Péricimentaire 2-4mm",
+        "periapical_large": "Péricimentaire >4mm",
+        "rotated": "Tournée",
+        "displaced": "Déplacée",
+        "unerupted": "Non éruptée",
+        "filling": "Obturation",
+        "filling_composite": "Obturation en composite",
+        "filling_amalgam": "Obturation en amalgame",
+        "filling_temporary": "Obturation provisoire",
+        "sealant": "Scellant",
+        "veneer": "Facette",
+        "inlay": "Inlay",
+        "overlay": "Onlay",
+        "crown": "Couronne",
+        "crown_on_implant": "Couronne sur implant",
+        "provisional_crown_on_implant": "Couronne provisoire sur implant",
+        "pontic": "Pont",
+        "bridge_pontic": "Pont de bridge",
+        "bridge_abutment": "Pilier de bridge",
+        "extraction": "Extraction",
+        "implant": "Implant",
+        "apicoectomy": "Apicectomie",
+        "root_canal": "Traitement canalaire",
+        "root_canal_full": "Dépulpage complet",
+        "root_canal_two_thirds": "Traitement canalaire 2/3",
+        "root_canal_half": "Traitement canalaire 1/2",
+        "root_canal_overfill": "Surcharge de traitement canalaire",
+        "post": "Dentine",
+        "bracket": "Bracket",
+        "tube": "Tube",
+        "band": "Bague",
+        "attachment": "Attachement",
+        "retainer": "Contention",
+        "rotate": "Tournée",
+        "displace": "Déplacée",
+        "splint": "Attelle",
+        "migrated": "Traitement général"
+      },
+      "treatmentAdded": "Traitement ajouté",
+      "treatmentPerformed": "Traitement marqué comme réalisé",
+      "treatmentDeleted": "Traitement supprimé",
+      "status": {
+        "existing": "Existant",
+        "planned": "Planifié"
+      }
+    },
+    "position": {
+      "displaced": "Déplacée",
+      "rotated": "Tournée",
+      "normal": "Normale"
+    },
+    "views": {
+      "occlusal": "Vue occlusale",
+      "lateral": "Vue latérale",
+      "dual": "Vue double"
+    },
+    "selectSurfaces": "Sélectionner les surfaces",
+    "selectedSurfaces": "Surfaces sélectionnées",
+    "surfacesSelected": "surface(s) sélectionnée(s)",
+    "instructions": {
+      "selectTreatment": "Sélectionnez un traitement à appliquer",
+      "clickTooth": "Cliquez sur la dent pour appliquer"
+    },
+    "addToPlan": "Ajouter au plan",
+    "noPlan": "Aucun plan",
+    "createNewPlan": "Créer un nouveau plan...",
+    "applyTo": "Appliquer à",
+    "oneTooth": "1 dent",
+    "multipleTeeth": "Plusieurs dents",
+    "surfacePricingHint": "Prix par surface : {range}",
+    "toothNames": {
+      "centralIncisor": "Incisive centrale",
+      "lateralIncisor": "Incisive latérale",
+      "canine": "Canine",
+      "firstPremolar": "Première prémolaire",
+      "secondPremolar": "Deuxième prémolaire",
+      "firstMolar": "Première molaire",
+      "secondMolar": "Deuxième molaire",
+      "thirdMolar": "Troisième molaire"
+    },
+    "positions": {
+      "upper": "supérieure",
+      "lower": "inférieure",
+      "left": "gauche",
+      "right": "droite"
+    },
+    "tooltip": {
+      "clickToEdit": "Cliquer pour modifier"
+    },
+    "planning": "Planification",
+    "diagnosisMode": "Diagnostique",
+    "treatmentList": {
+      "title": "Liste des traitements",
+      "noTreatments": "Aucun traitement enregistré"
+    },
+    "changeHistory": {
+      "title": "Historique des modifications",
+      "noChanges": "Aucune modification enregistrée",
+      "treatmentAdded": "Traitement"
+    },
+    "timeline": {
+      "title": "Chronologie",
+      "viewingDate": "Affichage : {date}",
+      "viewingHistory": "Vous consultez l'état historique de l'odontogramme",
+      "returnToNow": "Revenir à l'état actuel",
+      "noHistory": "Aucun historique antérieur"
+    },
+    "multiTooth": {
+      "bridge": {
+        "label": "Bridge fixe"
+      },
+      "splint": {
+        "label": "Attelle"
+      },
+      "veneers": {
+        "label": "Facettes multiples"
+      },
+      "crowns": {
+        "label": "Couronnes multiples"
+      },
+      "pillar": "pilier",
+      "pontic": "pont",
+      "roleHint": "Cliquez sur une dent pour basculer pilier / pont.",
+      "needPillar": "Le bridge nécessite au moins une dent pilier.",
+      "confirmHint": "Vous êtes sur le point de créer un groupe de traitement avec {n} dents.",
+      "willBePlanned": "Le groupe sera marqué comme planifié.",
+      "willBeExisting": "Le groupe sera enregistré comme existant.",
+      "hints": {
+        "range": "Cliquez sur la première dent, puis sur la dernière",
+        "free": "Cliquez pour ajouter ou retirer des dents"
+      },
+      "errors": {
+        "tooFew": "Au moins {n} dents requises",
+        "tooMany": "Maximum {n} dents autorisées",
+        "sameArchRequired": "Les dents doivent être dans la même arcade"
+      },
+      "sectionLabel": "Traitements multi-dents"
+    }
+  },
+  "clinical": {
+    "modes": {
+      "history": "Historique",
+      "diagnosis": "Diagnostique",
+      "plans": "Plans de traitement",
+      "appointments": "Rendez-vous"
+    },
+    "history": {
+      "stateAt": "État au",
+      "changesOnDate": "Modifications à cette date",
+      "noChanges": "Aucune modification enregistrée"
+    },
+    "diagnosis": {
+      "registeredConditions": "Conditions diagnostiquées",
+      "registerConditions": "Enregistrer les conditions",
+      "noConditions": "Aucune condition enregistrée",
+      "startDiagnosis": "Sélectionnez une dent et ajoutez les conditions existantes",
+      "generalConditions": "Conditions générales",
+      "readyToCreatePlan": "Diagnostique terminé ?",
+      "createPlan": "Créer un plan de traitement",
+      "continuePlan": "Continuer le plan « {name} »",
+      "selectPlan": "Sélectionner un plan",
+      "continue": "Continuer",
+      "odontogramTab": "Odontogramme"
+    },
+    "plans": {
+      "title": "Plans de traitement",
+      "create": "Nouveau plan",
+      "backToList": "Retour aux plans",
+      "treatments": "Traitements du plan",
+      "addTreatment": "Ajouter un traitement",
+      "total": "Total",
+      "activate": "Activer le plan",
+      "generateBudget": "Générer le devis",
+      "empty": "Aucun plan de traitement",
+      "emptyDescription": "Créez un plan pour organiser les traitements du patient",
+      "createFirst": "Créer le premier plan",
+      "active": "Plans actifs",
+      "drafts": "Brouillons",
+      "completed": "Terminés",
+      "closed": "Fermés",
+      "other": "Autres",
+      "noItems": "Aucun traitement dans le plan",
+      "markComplete": "Marquer comme terminé",
+      "removeItem": "Retirer du plan",
+      "sessions": {
+        "progress": "{done}/{total} séances",
+        "markDone": "Marquer la séance comme terminée",
+        "cancel": "Annuler la séance",
+        "markedDone": "Séance marquée comme terminée",
+        "cancelled": "Séance annulée",
+        "untitled": "Séance {n}"
+      },
+      "unknownTreatment": "Traitement",
+      "odontogram": "Odontogramme",
+      "pending": "en attente",
+      "dragToReorder": "Glisser pour réordonner",
+      "reorderHint": "Utilisez Alt + touches fléchées pour déplacer",
+      "emptyDraft": {
+        "title": "Planifiez les traitements",
+        "step1": "Choisissez un traitement dans la barre ci-dessous",
+        "step2": "Cliquez sur une dent dans l'odontogramme",
+        "step3": "Confirmez le plan pour générer le devis et les rendez-vous"
+      },
+      "steps": {
+        "plan": "Planifier",
+        "confirm": "Confirmer",
+        "inProgress": "En cours"
+      },
+      "confirmCta": {
+        "titleWithItems": "Confirmer le plan",
+        "subtitleWithItems": "La confirmation débloque la génération du devis et la planification des rendez-vous.",
+        "empty": "Ajoutez au moins un traitement pour confirmer le plan"
+      },
+      "ghostHint": "Disponible après confirmation du plan",
+      "addedToPlan": "Ajouté au plan",
+      "addingToPlan": "Ajout à ce plan",
+      "cancelPlan": "Annuler le plan",
+      "locked": {
+        "title": "Plan verrouillé",
+        "subtitle": "Le devis {number} a été émis. Pour modifier les traitements, utilisez Rouvrir (si en attente) ou Renégocier le devis.",
+        "viewBudget": "Voir le devis"
+      }
+    },
+    "tooth": "Dent"
+  },
+  "appointments": {
+    "title": "Agenda",
+    "create": "Nouveau rendez-vous",
+    "edit": "Modifier le rendez-vous",
+    "today": "Aujourd'hui",
+    "tomorrow": "Demain",
+    "week": "Semaine",
+    "prevWeek": "Semaine précédente",
+    "nextWeek": "Semaine suivante",
+    "selectPatient": "Sélectionner un patient",
+    "selectProfessional": "Sélectionner un professionnel",
+    "openPatientFile": "Ouvrir le dossier patient",
+    "patient": "Patient",
+    "professional": "Professionnel",
+    "cabinet": "Cabinet",
+    "date": "Date",
+    "time": "Heure",
+    "startTime": "Heure de début",
+    "duration": "Durée",
+    "treatmentType": "Type de traitement",
+    "treatments": "Traitements",
+    "addTreatment": "Ajouter un traitement",
+    "selectTreatment": "Sélectionner un traitement",
+    "estimatedDuration": "Durée estimée",
+    "notes": "Notes",
+    "hasNotes": "A des notes",
+    "status": {
+      "label": "Statut",
+      "scheduled": "Planifié",
+      "confirmed": "Confirmé",
+      "checked_in": "En salle d'attente",
+      "in_treatment": "En fauteuil",
+      "completed": "Terminé",
+      "cancelled": "Annulé",
+      "no_show": "Absence"
+    },
+    "scheduled": "Planifié",
+    "confirmed": "Confirmé",
+    "inProgress": "En cours",
+    "in_progress": "En cours",
+    "completed": "Terminé",
+    "cancelled": "Annulé",
+    "noShow": "Absence",
+    "no_show": "Absence",
+    "transitions": {
+      "confirmed": "Marquer comme confirmé",
+      "checked_in": "Enregistrer l'arrivée",
+      "in_treatment": "Placer en fauteuil",
+      "completed": "Terminer le rendez-vous",
+      "cancelled": "Annuler le rendez-vous",
+      "no_show": "Marquer comme absence"
+    },
+    "timer": {
+      "startsIn": "commence dans {minutes} min",
+      "startsInOverdue": "{minutes} min de retard",
+      "waiting": "attente {minutes} min",
+      "inTreatment": "{elapsed}/{planned} min",
+      "completedAt": "terminé à {time}",
+      "cancelledAt": "annulé",
+      "noShowAt": "absence"
+    },
+    "confirmTransitionTitle": "Confirmer le changement de statut",
+    "confirmCancelMessage": "Annuler ce rendez-vous ? Le changement sera enregistré.",
+    "confirmNoShowMessage": "Marquer ce patient comme absent ? Le changement sera enregistré.",
+    "noteLabel": "Note (facultatif)",
+    "transitionFailed": "Impossible de modifier le statut du rendez-vous",
+    "when": "Quand",
+    "whereWho": "Cabinet et professionnel",
+    "followup": {
+      "title": "Actions post-rendez-vous"
+    },
+    "created": "Rendez-vous créé",
+    "saved": "Rendez-vous enregistré",
+    "updated": "Rendez-vous mis à jour",
+    "conflict": "Ce créneau est déjà occupé",
+    "cancel": "Annuler le rendez-vous",
+    "markCompleted": "Marquer comme terminé",
+    "markNoShow": "Absence",
+    "dailyView": "Jour",
+    "weeklyView": "Semaine",
+    "kanbanView": "Kanban",
+    "kanban": {
+      "upcoming": "À venir",
+      "waiting": "Salle d'attente",
+      "inChair": "En fauteuil",
+      "done": "Terminés",
+      "missed": "Absence / Annulé",
+      "free": "Libre",
+      "inactive": "Inactif",
+      "empty": "Aucun rendez-vous",
+      "nextIn": "Prochain à {time}",
+      "subtitleCount": "{count} rendez-vous",
+      "subtitleEmpty": "Aucun rendez-vous",
+      "subtitleWaiting": "{count} en attente · moy {avg} min",
+      "subtitleInChair": "{busy} occupé(s) · {free} libre(s)"
+    },
+    "cabinetAssignment": {
+      "assignLater": "Attribuer plus tard",
+      "unassigned": "Non attribué",
+      "assign": "Attribuer un cabinet",
+      "reassign": "Réattribuer le cabinet",
+      "unassign": "Retirer l'attribution du cabinet",
+      "requiredForTreatment": "Attribuez un cabinet avant de passer au traitement"
+    },
+    "professionals": {
+      "strip": "Professionnels",
+      "state": {
+        "free": "Libre",
+        "in_treatment": "En fauteuil",
+        "on_break": "En pause",
+        "off": "Absent"
+      }
+    },
+    "noProfessionals": "Aucun professionnel configuré",
+    "overlapWarning": "Chevauchements détectés",
+    "overlapProfessional": "Le professionnel a {count} rendez-vous(s) à cet horaire",
+    "overlapCabinet": "Le cabinet a {count} rendez-vous(s) à cet horaire",
+    "selectDuration": "Sélectionner la durée...",
+    "sendEmail": "Envoyer un email",
+    "sendConfirmationEmail": "Envoyer la confirmation",
+    "resendConfirmation": "Renvoyer la confirmation",
+    "sendReminderEmail": "Envoyer un rappel",
+    "emailSent": "Email envoyé avec succès",
+    "automatic": "automatique",
+    "selectPatientFirst": "Sélectionnez un patient pour voir les traitements en attente",
+    "noPendingTreatments": "Aucun traitement en attente",
+    "createPlanFirst": "Créez un plan de traitement pour ce patient",
+    "addTreatmentFromPlan": "Ajouter un traitement du plan",
+    "selectPendingTreatment": "Sélectionner un traitement en attente",
+    "emptyDay": "Aucun rendez-vous pour ce jour",
+    "noPatient": "Aucun patient",
+    "freeSlots": {
+      "byProfessional": "Professionnel",
+      "byCabinet": "Cabinet",
+      "freeSuffix": "libre",
+      "freeShort": "libre",
+      "noFreeTime": "Aucun créneau libre",
+      "tapToBook": "Appuyez pour réserver",
+      "tapToBookAria": "Créneau libre de {duration} à {time}",
+      "nextFreeAt": "Prochain à {time}",
+      "gapsAtLeast": "{count} créneaux ≥ {min} min",
+      "minDuration": "Minimum",
+      "noFreeSlots": "Aucun créneau libre aujourd'hui",
+      "clinicClosed": "Clinique fermée",
+      "professionalOff": "Absent",
+      "onBreak": "En pause"
+    }
+  },
+  "dashboard": {
+    "greetings": {
+      "morning": "Bonjour",
+      "afternoon": "Bon après-midi",
+      "evening": "Bonsoir"
+    },
+    "welcome": "Bienvenue sur DentalPin",
+    "welcomeMessage": "Commencez par créer votre premier patient.",
+    "quickActions": {
+      "newAppointment": "Nouveau rendez-vous",
+      "newPatient": "Nouveau patient",
+      "search": "Rechercher un patient",
+      "searchPlaceholder": "Rechercher par nom, téléphone ou email"
+    },
+    "timeline": {
+      "title": "Aujourd'hui",
+      "empty": "Aucun rendez-vous prévu aujourd'hui",
+      "now": "Maintenant",
+      "openSchedule": "Ouvrir l'agenda"
+    },
+    "todayKpi": {
+      "title": "Rendez-vous du jour",
+      "completed": "terminés",
+      "inProgress": "en cours",
+      "upcoming": "à venir",
+      "cancelled": "annulés",
+      "noShow": "absences",
+      "empty": "Aucun rendez-vous aujourd'hui"
+    },
+    "inClinic": {
+      "title": "En clinique maintenant",
+      "inTreatment": "{n} en fauteuil",
+      "waiting": "{n} en attente",
+      "empty": "Personne en clinique"
+    },
+    "unconfirmed": {
+      "title": "Non confirmés pour demain",
+      "empty": "Tous les rendez-vous de demain sont confirmés",
+      "confirm": "Confirmer",
+      "confirmError": "Impossible de confirmer"
+    },
+    "overdue": {
+      "title": "Paiements en retard",
+      "daysOverdue": "{n} jour de retard | {n} jours de retard",
+      "viewAll": "Voir tout",
+      "empty": "Aucune facture en retard"
+    },
+    "recent": {
+      "title": "Patients récents",
+      "empty": "Aucun patient pour le moment"
+    },
+    "weekGlance": {
+      "title": "Résumé de la semaine",
+      "subtitle": "7 derniers jours vs 7 jours précédents",
+      "appointments": "Rendez-vous",
+      "completed": "Terminés",
+      "invoiced": "Facturés",
+      "empty": "Aucune donnée cette semaine"
+    }
+  },
+  "settings": {
+    "title": "Paramètres",
+    "subtitle": "Gérez votre clinique, équipe et modules.",
+    "allCategories": "Toutes les catégories",
+    "navLabel": "Catégories des paramètres",
+    "attentionRequired": "Attention requise",
+    "categories": {
+      "general": {
+        "label": "Général",
+        "description": "Profil de la clinique, image de marque et fuseau horaire."
+      },
+      "workspace": {
+        "label": "Espace de travail",
+        "description": "Cabinets, horaires d'ouverture et disponibilité."
+      },
+      "people": {
+        "label": "Personnel",
+        "description": "Utilisateurs, rôles et invitations."
+      },
+      "clinical": {
+        "label": "Clinique",
+        "description": "Catalogue, paramètres par défaut et modèles de traitements."
+      },
+      "billing": {
+        "label": "Facturation & fiscalité",
+        "description": "Séries de factures, TVA et conformité fiscale."
+      },
+      "communications": {
+        "label": "Communications",
+        "description": "Notifications, SMTP et modèles."
+      },
+      "integrations": {
+        "label": "Intégrations",
+        "description": "Services et fournisseurs externes."
+      },
+      "modules": {
+        "label": "Modules",
+        "description": "Installer, mettre à jour et désinstaller des modules."
+      },
+      "account": {
+        "label": "Compte",
+        "description": "Votre profil, mot de passe et langue."
+      }
+    },
+    "search": {
+      "placeholder": "Rechercher dans les paramètres…",
+      "empty": "Aucun résultat pour cette recherche.",
+      "navigate": "naviguer",
+      "open": "ouvrir"
+    },
+    "locked": {
+      "title": "Vous n'avez pas accès à cette section",
+      "description": "Demandez à un administrateur de la clinique de vous accorder les permissions requises."
+    },
+    "emptyCategory": {
+      "title": "Aucune option disponible",
+      "description": "Lorsque des modules compatibles sont activés, leurs paramètres apparaîtront ici."
+    },
+    "loadError": {
+      "description": "Impossible de charger cet éditeur. Réessayez dans quelques secondes."
+    },
+    "comingSoon": {
+      "title": "Bientôt disponible",
+      "subtitle": "Nous travaillons sur cette section. En attendant, vous pouvez gérer cela via l'API."
+    },
+    "onboarding": {
+      "title": "Terminez la configuration de votre clinique",
+      "subtitle": "Vous avez {count} étape(s) en attente pour finaliser la configuration initiale.",
+      "dismiss": "Fermer",
+      "items": {
+        "clinicInfo": {
+          "label": "Complétez le profil de la clinique",
+          "description": "Nom, identifiant fiscal et adresse apparaissent sur les devis et factures."
+        },
+        "cabinets": {
+          "label": "Créez au moins un cabinet",
+          "description": "Sans cabinets, vous ne pouvez pas planifier de rendez-vous."
+        }
+      }
+    },
+    "cabinetsDescription": "Salles ou boxes où les patients sont traités.",
+    "usersDescription": "Comptes ayant accès à cette clinique et leurs rôles.",
+    "profileDescription": "Vos informations personnelles dans cette clinique.",
+    "clinic": "Clinique",
+    "profile": "Profil",
+    "clinicName": "Nom de la clinique",
+    "clinicInfo": "Informations de la clinique",
+    "clinicInfoDescription": "Ces données apparaîtront sur les devis et documents",
+    "taxId": "Identifiant fiscal",
+    "legalName": "Raison sociale",
+    "legalNameHelp": "Raison sociale de l'entité pour la facturation. Laissez vide pour utiliser le nom de la clinique.",
+    "street": "Adresse",
+    "city": "Ville",
+    "postalCode": "Code postal",
+    "country": "Pays",
+    "countryPlaceholder": "Sélectionner un pays",
+    "countrySearchPlaceholder": "Rechercher un pays…",
+    "phone": "Téléphone",
+    "timezone": "Fuseau horaire",
+    "timezoneHelp": "Tous les horaires et rendez-vous sont interprétés dans ce fuseau horaire.",
+    "currency": "Devise",
+    "currencyHelp": "Devise utilisée dans toute la clinique pour les devis, factures et le catalogue.",
+    "editClinicInfo": "Modifier les informations",
+    "clinicUpdated": "Informations de la clinique mises à jour",
+    "clinicUpdateError": "Erreur lors de la mise à jour des informations",
+    "cabinets": "Cabinets",
+    "language": "Langue",
+    "languageDescription": "Sélectionnez votre langue préférée",
+    "users": "Utilisateurs de la clinique",
+    "newUser": "Nouvel utilisateur",
+    "createUser": "Créer un utilisateur",
+    "editUser": "Modifier l'utilisateur",
+    "deleteUser": "Supprimer l'utilisateur",
+    "deleteUserConfirm": "Êtes-vous sûr de vouloir retirer",
+    "deleteUserNote": "L'utilisateur perdra l'accès à cette clinique mais son compte ne sera pas supprimé.",
+    "noUsers": "Aucun utilisateur enregistré",
+    "youTag": "(vous)",
+    "userActive": "Utilisateur actif",
+    "userInactiveNote": "(Ne peut pas se connecter)",
+    "saveChanges": "Enregistrer les modifications",
+    "noCabinets": "Aucun cabinet configuré",
+    "addCabinet": "Ajouter",
+    "newCabinet": "Nouveau cabinet",
+    "editCabinet": "Modifier le cabinet",
+    "deleteCabinet": "Supprimer le cabinet",
+    "deleteCabinetConfirm": "Êtes-vous sûr de vouloir supprimer le cabinet",
+    "deleteCabinetNote": "Les rendez-vous existants dans ce cabinet ne seront pas affectés.",
+    "createCabinet": "Créer le cabinet",
+    "roles": {
+      "admin": "Administrateur",
+      "dentist": "Dentiste",
+      "hygienist": "Hygiéniste",
+      "assistant": "Assistant(e)",
+      "receptionist": "Réceptionniste"
+    },
+    "errors": {
+      "loadUsers": "Erreur lors du chargement des utilisateurs",
+      "createUser": "Erreur lors de la création de l'utilisateur",
+      "updateUser": "Erreur lors de la mise à jour de l'utilisateur",
+      "deleteUser": "Erreur lors de la suppression de l'utilisateur",
+      "emailExists": "L'email existe déjà",
+      "userNotFound": "Utilisateur introuvable",
+      "operationNotAllowed": "Opération non autorisée",
+      "invalidData": "Données invalides"
+    },
+    "messages": {
+      "userCreated": "Utilisateur créé avec succès",
+      "userUpdated": "Utilisateur mis à jour avec succès",
+      "userDeleted": "Utilisateur retiré de la clinique"
+    },
+    "modules": {
+      "title": "Modules",
+      "subtitle": "Installer, désinstaller et mettre à jour les modules de la clinique.",
+      "description": "Gérez les modules actifs dans votre clinique.",
+      "deps": "Dépendances",
+      "noDeps": "Aucune dépendance",
+      "state": {
+        "installed": "Installé",
+        "uninstalled": "Non installé",
+        "toInstall": "Installation en attente",
+        "toUpgrade": "Mise à jour en attente",
+        "toRemove": "Suppression en attente",
+        "disabled": "Désactivé",
+        "error": "Erreur"
+      },
+      "category": {
+        "official": "Officiel",
+        "community": "Communauté"
+      },
+      "actions": {
+        "install": "Installer",
+        "uninstall": "Désinstaller",
+        "upgrade": "Mettre à jour",
+        "apply": "Appliquer les modifications",
+        "viewDetails": "Détails",
+        "force": "Forcer la désinstallation"
+      },
+      "confirmInstall": {
+        "title": "Installer {name} ?",
+        "message": "Le module sera programmé pour installation et deviendra actif après application des modifications.",
+        "scheduled": "Ces dépendances seront également installées :"
+      },
+      "confirmUninstall": {
+        "title": "Désinstaller {name} ?",
+        "warning": "Les tables du module seront supprimées. Une sauvegarde pg_dump est créée d'abord pour pouvoir récupérer les données.",
+        "forceHint": "Ignore les modules dépendants. À utiliser uniquement si vous savez ce que vous faites."
+      },
+      "confirmUpgrade": {
+        "title": "Mettre à jour {name} ?",
+        "message": "Le module sera mis à jour vers la version du manifest sur disque lorsque les modifications seront appliquées."
+      },
+      "confirmApply": {
+        "title": "Appliquer les modifications",
+        "message": "Le backend redémarrera. La session peut être brièvement interrompue pendant l'exécution des opérations en attente."
+      },
+      "pending": {
+        "banner": "Modifications en attente :",
+        "apply": "Appliquer les modifications"
+      },
+      "doctor": {
+        "banner": "Problèmes détectés dans le système de modules.",
+        "orphans": "modules orphelins",
+        "missingDeps": "dépendances manquantes",
+        "manifestErrors": "erreurs de manifest",
+        "errored": "modules en erreur"
+      },
+      "detail": {
+        "state": "État",
+        "category": "Catégorie",
+        "installedAt": "Installé le",
+        "lastChange": "Dernière modification",
+        "baseRevision": "Révision de base",
+        "appliedRevision": "Révision appliquée",
+        "manifest": "Manifest complet",
+        "errorMessage": "Message d'erreur",
+        "operationLog": "Journal d'opérations",
+        "noOperations": "Aucune opération enregistrée."
+      },
+      "restart": {
+        "inProgress": "Redémarrage du backend…",
+        "done": "Modifications appliquées",
+        "failed": "Échec de l'application des modifications",
+        "timeout": "Délai d'attente dépassé en attendant le backend"
+      },
+      "toasts": {
+        "scheduled": "Opération programmée. Appliquez les modifications pour finaliser.",
+        "applied": "Modifications appliquées avec succès."
+      }
+    }
+  },
+  "selector": {
+    "recentPatients": "Patients récents",
+    "commonTreatments": "Traitements courants",
+    "noRecentPatients": "Aucun patient récent",
+    "noCommonTreatments": "Aucun traitement courant",
+    "noMatches": "Aucune correspondance",
+    "typeToSearch": "Tapez pour rechercher..."
+  },
+  "density": {
+    "switchToCompact": "Vue compacte",
+    "switchToComfortable": "Vue confortable"
+  },
+  "patientSelector": {
+    "createOption": "Créer le patient « {query} »",
+    "createOptionEmpty": "Créer un nouveau patient",
+    "newBadge": "Nouveau",
+    "duplicateWarning": "{name} existe déjà avec ce téléphone",
+    "useExisting": "Utiliser ce patient",
+    "createForm": {
+      "title": "Nouveau patient",
+      "back": "Retour à la recherche",
+      "firstName": "Prénom",
+      "lastName": "Nom",
+      "phone": "Téléphone",
+      "phoneHint": "Vous pouvez l'ajouter plus tard sur le dossier patient.",
+      "submit": "Créer et sélectionner",
+      "cancel": "Annuler",
+      "errorGeneric": "Impossible de créer le patient. Réessayez."
+    }
+  },
+  "common": {
+    "save": "Enregistrer",
+    "add": "Ajouter",
+    "cancel": "Annuler",
+    "clear": "Effacer",
+    "close": "Fermer",
+    "delete": "Supprimer",
+    "comingSoon": "Bientôt disponible",
+    "edit": "Modifier",
+    "change": "modification | modifications",
+    "back": "Retour",
+    "loading": "Chargement...",
+    "error": "Erreur",
+    "success": "Succès",
+    "completed": "Terminé",
+    "retry": "Réessayer",
+    "refresh": "Actualiser",
+    "hide": "Masquer",
+    "forbidden": "Accès refusé",
+    "confirm": "Confirmer",
+    "yes": "Oui",
+    "no": "Non",
+    "actions": "Actions",
+    "viewDetails": "Voir les détails",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "previousYear": "Année précédente",
+    "nextYear": "Année suivante",
+    "undo": "Annuler",
+    "undone": "Annulé",
+    "added": "Ajouté",
+    "removed": "Retiré",
+    "page": "Page {current} sur {total}",
+    "noData": "Aucune donnée",
+    "noValue": "pas de valeur",
+    "noResults": "Aucun résultat",
+    "search": "Rechercher...",
+    "selectAll": "Tout",
+    "deselectAll": "Aucun",
+    "all": "Tout",
+    "required": "Ce champ est obligatoire",
+    "invalidEmail": "Email invalide",
+    "networkError": "Erreur de connexion",
+    "serverError": "Erreur serveur",
+    "notFound": "Introuvable",
+    "offline": "Hors ligne — les données peuvent ne pas être à jour",
+    "inactive": "Inactif",
+    "name": "Nom",
+    "color": "Couleur",
+    "firstName": "Prénom",
+    "lastName": "Nom",
+    "email": "Email",
+    "password": "Mot de passe",
+    "passwordPlaceholder": "Minimum 8 caractères",
+    "role": "Rôle",
+    "readOnly": "Lecture seule",
+    "createdBy": "Créé par",
+    "date": "Date",
+    "upload": "Envoyer",
+    "uploading": "Envoi…",
+    "maxFileSize": "jusqu'à 10 Mo",
+    "durationMinutes": "{value} min",
+    "days": {
+      "sunday": "Dimanche",
+      "monday": "Lundi",
+      "tuesday": "Mardi",
+      "wednesday": "Mercredi",
+      "thursday": "Jeudi",
+      "friday": "Vendredi",
+      "saturday": "Samedi"
+    },
+    "now": "Maintenant",
+    "today": "Aujourd'hui",
+    "tomorrow": "Demain",
+    "yesterday": "Hier",
+    "copied": "Copié dans le presse-papiers",
+    "copy": "Copier",
+    "copyFailed": "Impossible de copier"
+  },
+  "cabinet": {
+    "toast": {
+      "created": "Cabinet créé",
+      "updated": "Cabinet mis à jour",
+      "deleted": "Cabinet supprimé",
+      "duplicateName": "Un cabinet avec ce nom existe déjà",
+      "notFound": "Cabinet introuvable",
+      "createFailed": "Échec de la création du cabinet",
+      "updateFailed": "Échec de la mise à jour du cabinet",
+      "deleteFailed": "Échec de la suppression du cabinet"
+    }
+  },
+  "professionals": {
+    "toast": {
+      "loadFailed": "Échec du chargement des professionnels"
+    }
+  },
+  "lists": {
+    "empty": {
+      "title": "Aucun résultat",
+      "description": "Ajustez les filtres ou effacez-les pour voir tous les enregistrements."
+    },
+    "resultCount": "{shown} sur {total}",
+    "filter": {
+      "title": "Filtres",
+      "more": "Filtres",
+      "moreCount": "Filtres ({count})",
+      "clear": "Effacer",
+      "apply": "Appliquer",
+      "date": "Dates",
+      "dateFrom": "Du",
+      "dateTo": "Au",
+      "searchPlaceholder": "Rechercher...",
+      "noResults": "Aucune correspondance",
+      "all": "Tout"
+    },
+    "sort": {
+      "label": "Trier",
+      "asc": "Croissant",
+      "desc": "Décroissant"
+    },
+    "datePreset": {
+      "today": "Aujourd'hui",
+      "last7": "7 derniers jours",
+      "last30": "30 derniers jours",
+      "thisMonth": "Ce mois-ci",
+      "thisQuarter": "Trimestre",
+      "thisYear": "Année",
+      "custom": "Personnalisé"
+    },
+    "truncatedWarning": "Résultats tronqués (>1000). Affinez les filtres."
+  },
+  "shared": {
+    "totals": "Totaux",
+    "info": "Détails",
+    "moreActions": "Plus d'actions",
+    "criticalBanner": {
+      "dismiss": "Fermer l'alerte"
+    },
+    "collect": {
+      "amountLabel": "Montant à encaisser",
+      "methodLabel": "Mode de paiement",
+      "dateLabel": "Date de paiement",
+      "today": "Aujourd'hui",
+      "quickFull": "Intégral",
+      "optionalDetails": "Ajouter une référence ou des notes (facultatif)",
+      "referenceLabel": "Référence",
+      "referencePlaceholder": "ex. numéro de transaction POS",
+      "notesLabel": "Notes internes",
+      "submit": "Encaisser",
+      "cancel": "Annuler"
+    }
+  },
+  "validation": {
+    "required": "Ce champ est obligatoire",
+    "email": "Saisissez un email valide",
+    "minLength": "Minimum {min} caractères",
+    "maxLength": "Maximum {max} caractères",
+    "phone": "Saisissez un numéro de téléphone valide"
+  },
+  "time": {
+    "minutes": "{n} min",
+    "hours": "{n} heure | {n} heures"
+  },
+  "calendar": {
+    "today": "Aujourd'hui",
+    "prevWeek": "Semaine précédente",
+    "nextWeek": "Semaine suivante",
+    "monday": "Lundi",
+    "tuesday": "Mardi",
+    "wednesday": "Mercredi",
+    "thursday": "Jeudi",
+    "friday": "Vendredi",
+    "saturday": "Samedi",
+    "sunday": "Dimanche"
+  },
+  "catalog": {
+    "title": "Catalogue de traitements",
+    "description": "Gérer les traitements, la tarification et la configuration de la TVA",
+    "items": "Traitements",
+    "categories": "Catégories",
+    "noItems": "Aucun traitement dans le catalogue",
+    "searchPlaceholder": "Rechercher par code ou nom...",
+    "code": "Code",
+    "name": "Nom",
+    "category": "Catégorie",
+    "price": "Prix",
+    "defaultPrice": "Prix de base",
+    "costPrice": "Prix de revient",
+    "currency": "Devise",
+    "vatType": "Type de TVA",
+    "vatRate": "TVA %",
+    "duration": "Durée",
+    "system": "Système",
+    "newItem": "Nouveau traitement",
+    "editItem": "Modifier le traitement",
+    "deleteItem": "Supprimer le traitement",
+    "deleteItemConfirm": "Êtes-vous sûr de vouloir supprimer le traitement « {name} » ?",
+    "deleteItemNote": "Cette action est irréversible.",
+    "pricing": "Tarification",
+    "scheduling": "Planification",
+    "characteristics": "Caractéristiques",
+    "scope": "Périmètre",
+    "requiresAppointment": "Nécessite un rendez-vous",
+    "isDiagnostic": "Est diagnostique",
+    "requiresSurfaces": "Nécessite des surfaces",
+    "materialNotes": "Notes sur le matériel",
+    "materialNotesPlaceholder": "Matériaux ou fournitures requis...",
+    "active": "Actif",
+    "vatTypes": {
+      "exempt": "Exonéré",
+      "reduced": "Réduit",
+      "standard": "Normal"
+    },
+    "scopeTypes": {
+      "tooth": "Dent",
+      "multi_tooth": "Multi-dents",
+      "global_mouth": "Bouche complète",
+      "global_arch": "Par arcade"
+    },
+    "pricingStrategy": {
+      "label": "Stratégie de tarification",
+      "help": "Comment le prix du traitement est calculé lorsqu'il est appliqué",
+      "flat": "Forfait (prix unique)",
+      "per_tooth": "Par dent (× nombre de dents)",
+      "per_surface": "Par surface (paliers)",
+      "per_role": "Par rôle (bridge : pilier/pont)"
+    },
+    "surfacePrices": {
+      "title": "Prix par nombre de surfaces",
+      "help": "Définissez le prix pour 1 à 5 surfaces. Lorsque des surfaces sont sélectionnées sur une dent, le palier correspondant est utilisé. Les paliers manquants reviennent au palier inférieur rempli le plus proche.",
+      "tier": "{n} surf."
+    },
+    "sessions": {
+      "title": "Séances (facturation fractionnée)",
+      "help": "Définissez les étapes nommées du traitement et de la facturation (ex. couronne : « Empreintes » + « Pose »). La somme doit être égale au prix de base.",
+      "label": "Libellé",
+      "labelPlaceholder": "ex. Empreintes",
+      "price": "Montant",
+      "add": "Ajouter une séance",
+      "sumStatus": "Somme {sum} € · Total {total} €"
+    },
+    "categoryCreated": "Catégorie créée",
+    "categoryUpdated": "Catégorie mise à jour",
+    "categoryDeleted": "Catégorie supprimée",
+    "categoryKeyExists": "Une catégorie avec cette clé existe déjà",
+    "categoryCreateFailed": "Erreur lors de la création de la catégorie",
+    "categoryUpdateFailed": "Erreur lors de la mise à jour de la catégorie",
+    "categoryDeleteFailed": "Erreur lors de la suppression de la catégorie",
+    "cannotModifySystemCategory": "Impossible de modifier une catégorie système",
+    "cannotDeleteSystemCategory": "Impossible de supprimer une catégorie système",
+    "itemCreated": "Traitement créé",
+    "itemUpdated": "Traitement mis à jour",
+    "itemDeleted": "Traitement supprimé",
+    "itemCodeExists": "Un traitement avec ce code existe déjà",
+    "categoryNotFound": "Catégorie introuvable",
+    "itemCreateFailed": "Erreur lors de la création du traitement",
+    "itemUpdateFailed": "Erreur lors de la mise à jour du traitement",
+    "itemDeleteFailed": "Erreur lors de la suppression du traitement",
+    "cannotModifySystemItem": "Impossible de modifier un traitement système",
+    "cannotDeleteSystemItem": "Impossible de supprimer un traitement système",
+    "odontogramMapping": "Visualisation odontogramme",
+    "odontogramMappingDescription": "Associez ce traitement à un type de visualisation odontogramme pour qu'il apparaisse dans le dossier patient.",
+    "odontogramType": "Type de traitement",
+    "clinicalCategory": "Catégorie clinique",
+    "noOdontogramMapping": "Aucune association",
+    "odontogramMappingHint": "Les caractéristiques du traitement seront automatiquement ajustées en fonction du type sélectionné.",
+    "selectCategory": "Sélectionner une catégorie...",
+    "selectVatType": "Sélectionner un type de TVA...",
+    "selectScope": "Sélectionner un périmètre...",
+    "selectOdontogramType": "Sélectionner un type...",
+    "selectClinicalCategory": "Sélectionner une catégorie...",
+    "expandAll": "Tout développer",
+    "collapseAll": "Tout réduire",
+    "unnamed": "Sans titre",
+    "activeHint": "Disponible pour les devis et plans",
+    "tabs": {
+      "general": "Général",
+      "pricing": "Tarification",
+      "scheduling": "Planification",
+      "clinical": "Clinique"
+    }
+  },
+  "placeholders": {
+    "selectRole": "Sélectionner un rôle..."
+  },
+  "vatTypes": {
+    "title": "Types de TVA",
+    "description": "Gérer les types de TVA disponibles pour les traitements",
+    "name": "Nom",
+    "rate": "Taux",
+    "default": "Par défaut",
+    "system": "Système",
+    "active": "Actif",
+    "new": "Nouveau type de TVA",
+    "edit": "Modifier le type de TVA",
+    "delete": "Supprimer le type de TVA",
+    "setAsDefault": "Définir par défaut",
+    "showInactive": "Afficher les inactifs",
+    "noItems": "Aucun type de TVA configuré",
+    "namePlaceholder": "Ex. : Réduit (10%)",
+    "systemNote": "Les types de TVA système ne peuvent changer que leur statut par défaut.",
+    "deleteConfirm": "Êtes-vous sûr de vouloir supprimer le type de TVA",
+    "deleteNote": "Les traitements utilisant ce type de TVA ne seront pas affectés.",
+    "created": "Type de TVA créé",
+    "updated": "Type de TVA mis à jour",
+    "deleted": "Type de TVA supprimé",
+    "loadError": "Erreur lors du chargement des types de TVA",
+    "createError": "Erreur lors de la création du type de TVA",
+    "updateError": "Erreur lors de la mise à jour du type de TVA",
+    "deleteError": "Erreur lors de la suppression du type de TVA"
+  },
+  "treatmentPlans": {
+    "title": "Plans de traitement",
+    "description": "Gérer les plans de traitement des patients",
+    "new": "Nouveau plan",
+    "create": "Créer un plan de traitement",
+    "edit": "Modifier le plan",
+    "view": "Voir le plan",
+    "delete": "Supprimer le plan",
+    "noItems": "Ce plan n'a aucun traitement",
+    "noPlans": "Ce patient n'a aucun plan de traitement",
+    "noPlansHint": "Marquez des traitements sur l'odontogramme et créez un plan pour les organiser",
+    "createFirst": "Créer le premier plan",
+    "empty": "Aucun plan de traitement enregistré",
+    "emptyAction": "Créer le premier plan",
+    "searchPlaceholder": "Rechercher par numéro, patient ou titre...",
+    "planNumber": "Numéro",
+    "patient": "Patient",
+    "untitled": "Sans titre",
+    "untitledPlan": "Plan sans titre",
+    "itemCount": "{count} traitement | {count} traitements",
+    "treatments": "traitements",
+    "progress": "Progression",
+    "pendingTreatments": "Traitements en attente",
+    "completedTreatments": "Traitements terminés",
+    "linkedBudget": "Devis lié",
+    "unknownTreatment": "Traitement inconnu",
+    "globalTreatment": "Traitement général",
+    "activePlan": "Plan actif",
+    "otherPlans": "Autres plans",
+    "viewAllPlans": "Voir l'historique des plans",
+    "activate": "Activer",
+    "generateBudget": "Générer le devis",
+    "scheduleAppointment": "Programmer un rendez-vous",
+    "status": {
+      "draft": "Brouillon",
+      "pending": "En attente",
+      "active": "Actif",
+      "completed": "Terminé",
+      "closed": "Fermé",
+      "archived": "Archivé"
+    },
+    "fields": {
+      "title": "Titre",
+      "titlePlaceholder": "Ex. : Réhabilitation orale complète",
+      "assignedProfessional": "Professionnel assigné",
+      "selectProfessional": "Sélectionner un professionnel",
+      "diagnosisNotes": "Notes de diagnostique",
+      "diagnosisNotesPlaceholder": "Diagnostique et observations cliniques...",
+      "internalNotes": "Notes internes",
+      "internalNotesPlaceholder": "Notes visibles uniquement par le personnel..."
+    },
+    "modal": {
+      "subtitle": "Organiser les traitements du patient",
+      "titleHint": "Facultatif — aide à identifier le plan",
+      "additionalNotes": "Notes supplémentaires",
+      "quickTip": "Après la création du plan, vous pouvez ajouter des traitements depuis l'odontogramme ou le catalogue.",
+      "createButton": "Créer le plan"
+    },
+    "actions": {
+      "activate": "Activer le plan",
+      "confirm": "Confirmer le plan",
+      "complete": "Marquer comme terminé",
+      "generateBudget": "Générer le devis",
+      "linkBudget": "Lier un devis",
+      "syncBudget": "Synchroniser le devis",
+      "cancelPlan": "Annuler le plan",
+      "reopen": "Rouvrir",
+      "close": "Fermer le plan",
+      "reactivate": "Réactiver le plan",
+      "logContact": "Enregistrer le contact"
+    },
+    "items": {
+      "title": "Traitements",
+      "add": "Ajouter un traitement",
+      "addSelected": "Ajouter {count} traitement | Ajouter {count} traitements",
+      "remove": "Retirer le traitement",
+      "empty": "Aucun traitement dans ce plan",
+      "assignedProfessional": "Dentiste assigné",
+      "assignedProfessionalAriaLabel": "Changer le dentiste assigné pour ce traitement",
+      "useUsersPlanDoctor": "Utiliser le dentiste du plan",
+      "noProfessional": "Aucun dentiste assigné",
+      "inactiveProfessional": "Professionnel inactif",
+      "cascadeReassign": {
+        "title": "Réattribuer les traitements en attente ?",
+        "body": "Vous avez changé le dentiste du plan. {count} traitement(s) en attente étaient assignés à {previousName}. Les réattribuer au nouveau dentiste également ?",
+        "confirm": "Oui, réattribuer les en attente",
+        "cancel": "Non, conserver tels quels"
+      }
+    },
+    "filters": {
+      "allStatuses": "Tous les statuts"
+    },
+    "confirmations": {
+      "delete": "Supprimer ce plan de traitement ?",
+      "completeItem": "Marquer le traitement comme terminé ?",
+      "completeItemDescription": "Cette action est irréversible.",
+      "activateTitle": "Confirmer le plan de traitement ?",
+      "activateDescription": "La confirmation débloque la génération de devis et la planification de rendez-vous. Vous pouvez continuer à ajouter ou terminer des traitements après.",
+      "unlockTitle": "Modifier le plan ?",
+      "unlockIntro": "Ce plan a déjà le devis {number} émis. Pour le modifier, le devis actuel doit être annulé.",
+      "unlockConsequence1": "Le devis {number} sera annulé et ne sera plus valide pour le patient.",
+      "unlockConsequence2": "Vous pourrez ajouter, modifier ou retirer des traitements du plan.",
+      "unlockConsequence3": "Vous devrez générer un nouveau devis une fois les modifications terminées.",
+      "unlockConsequence4": "Le devis annulé est conservé dans l'historique pour traçabilité.",
+      "cancelTitle": "Annuler le plan de traitement ?",
+      "cancelDescription": "Le plan passera à l'état annulé et les traitements planifiés non réalisés seront retirés de l'odontogramme. L'historique du plan est conservé."
+    },
+    "messages": {
+      "created": "Plan de traitement créé",
+      "updated": "Plan de traitement mis à jour",
+      "deleted": "Plan de traitement supprimé",
+      "itemsAdded": "Traitements ajoutés au plan"
+    },
+    "itemCompleted": "Traitement terminé",
+    "budgetGenerated": "Devis généré",
+    "created": "Plan de traitement créé",
+    "updated": "Plan de traitement mis à jour",
+    "statusUpdated": "Statut du plan mis à jour",
+    "deleted": "Plan de traitement supprimé",
+    "budgetLinked": "Devis lié au plan",
+    "budgetSynced": "Devis synchronisé",
+    "errors": {
+      "load": "Erreur lors du chargement des plans de traitement",
+      "create": "Erreur lors de la création du plan de traitement",
+      "update": "Erreur lors de la mise à jour du plan de traitement",
+      "delete": "Erreur lors de la suppression du plan de traitement"
+    },
+    "notes": {
+      "title": "Notes cliniques",
+      "empty": "Aucune note clinique pour le moment",
+      "addNote": "Ajouter une note",
+      "edit": "Modifier la note",
+      "delete": "Supprimer la note",
+      "attachments": "Pièces jointes",
+      "author": "Auteur",
+      "createdAt": "Créé le",
+      "templatePicker": "Modèles",
+      "bodyPlaceholder": "Rédigez la note clinique…",
+      "saved": "Note enregistrée",
+      "deleted": "Note supprimée"
+    },
+    "completionNudge": {
+      "title": "Terminer le traitement",
+      "description": "Ajoutez une note clinique décrivant ce qui s'est passé lors de cette visite avant de le marquer comme terminé.",
+      "completeWithNote": "Terminer avec une note",
+      "skip": "Passer la note",
+      "skipConfirm": "Terminer sans note clinique ?"
+    },
+    "visitNote": {
+      "title": "Note clinique de visite",
+      "save": "Enregistrer la note",
+      "empty": "Aucune note de visite pour le moment",
+      "saved": "Note enregistrée"
+    },
+    "clinicalNotesTab": "Notes cliniques",
+    "filterBy": {
+      "plan": "Plan",
+      "item": "Traitement",
+      "visit": "Visite",
+      "all": "Tout"
+    },
+    "byPlan": {
+      "empty": "Ce patient n'a aucune note clinique dans un plan de traitement",
+      "planNotesLabel": "Notes du plan",
+      "noNotesForTreatment": "Aucune note pour ce traitement",
+      "noNotesForPlan": "Aucune note dans ce plan"
+    },
+    "noteTemplates": {
+      "endo": {
+        "singleVisit": "Endodontie — séance unique",
+        "multiVisit": "Endodontie — multi-séances"
+      },
+      "perio": {
+        "scaling": "Détartrage / surfaçage radiculaire"
+      },
+      "implant": {
+        "placement": "Pose d'implant"
+      },
+      "general": {
+        "followUp": "Suivi général"
+      }
+    },
+    "closureReason": {
+      "rejected_by_patient": "Refusé par le patient",
+      "expired": "Expiré",
+      "cancelled_by_clinic": "Annulé par la clinique",
+      "patient_abandoned": "Abandon par le patient",
+      "other": "Autre raison"
+    },
+    "confirmed": "Plan confirmé",
+    "reopened": "Plan rouvert",
+    "closed": "Plan fermé",
+    "reactivated": "Plan réactivé",
+    "contactLogged": "Contact enregistré",
+    "modals": {
+      "confirm": {
+        "title": "Confirmer le plan",
+        "description": "Le plan passera à l'état En attente et un devis brouillon sera automatiquement créé. Les traitements deviennent en lecture seule une fois confirmés.",
+        "submit": "Confirmer le plan"
+      },
+      "reopen": {
+        "title": "Rouvrir le plan pour modification",
+        "description": "Cela annulera le devis actuel. Le plan reviendra en Brouillon pour que vous puissiez modifier les traitements.",
+        "submit": "Rouvrir"
+      },
+      "close": {
+        "title": "Fermer le plan",
+        "description": "Choisissez la raison de la fermeture. Les traitements en attente seront archivés.",
+        "reasonLabel": "Raison",
+        "noteLabel": "Note (facultatif)",
+        "submit": "Fermer le plan"
+      },
+      "reactivate": {
+        "title": "Réactiver un plan fermé",
+        "description": "Cela réactivera un plan fermé le {date} pour « {reason} ». Continuer ?",
+        "submit": "Réactiver"
+      },
+      "contactLog": {
+        "title": "Enregistrer le contact",
+        "description": "Enregistre le point de contact sans modifier le statut du plan.",
+        "channelLabel": "Canal",
+        "noteLabel": "Note (facultatif)",
+        "submit": "Enregistrer"
+      }
+    }
+  },
+  "pipeline": {
+    "title": "Pipeline des plans",
+    "description": "Gérer le pipeline des traitements.",
+    "tabs": {
+      "por_presupuestar": "À deviser",
+      "esperando_paciente": "En attente patient",
+      "sin_cita": "Sans rendez-vous",
+      "sin_proxima_cita": "Sans prochain rendez-vous",
+      "cerrados": "Fermés",
+      "listado": "Liste"
+    },
+    "row": {
+      "patient": "Patient",
+      "plan": "Plan",
+      "budget": "Devis",
+      "items": "Traitements",
+      "daysIn": "{n} jour(s) dans ce statut",
+      "nextAppt": "Prochain rdv",
+      "noNextAppt": "Aucun rendez-vous",
+      "noBudget": "Aucun devis"
+    },
+    "actions": {
+      "open": "Ouvrir",
+      "send": "Envoyer",
+      "remind": "Renvoyer",
+      "schedule": "Planifier",
+      "scheduleNext": "Planifier le suivant",
+      "reactivate": "Réactiver",
+      "call": "Appeler",
+      "whatsapp": "WhatsApp",
+      "markContacted": "Marquer comme contacté",
+      "acceptInClinic": "Accepter en clinique"
+    },
+    "search": "Rechercher par nom ou numéro…",
+    "empty": "Aucune ligne dans cet onglet.",
+    "loading": "Chargement…"
+  },
+  "budget": {
+    "title": "Devis",
+    "description": "Gérer les devis de traitements pour les patients",
+    "new": "Nouveau devis",
+    "edit": "Modifier le devis",
+    "view": "Voir le devis",
+    "delete": "Supprimer le devis",
+    "duplicate": "Créer une nouvelle version",
+    "noItems": "Aucun devis",
+    "empty": "Aucun devis enregistré",
+    "emptyAction": "Créer le premier devis",
+    "linkedToPlan": "Lié au plan",
+    "searchPlaceholder": "Rechercher par numéro ou patient...",
+    "budgetNumber": "Numéro",
+    "version": "Version",
+    "treatmentPlan": "Plan de traitement",
+    "patient": "Patient",
+    "selectPatient": "Sélectionner un patient",
+    "selectPatientHint": "Recherchez et sélectionnez le patient pour ce devis",
+    "professional": "Professionnel",
+    "validFrom": "Valable à partir du",
+    "validUntil": "Valable jusqu'au",
+    "validUntilHint": "Laissez vide pour un devis sans date d'expiration",
+    "noExpiry": "Aucune date d'expiration",
+    "createAndAddItems": "Créer et ajouter les traitements",
+    "subtotal": "Sous-total",
+    "totalDiscount": "Remise totale",
+    "totalTax": "TVA totale",
+    "total": "Total",
+    "globalDiscount": "Remise globale",
+    "discountType": "Type de remise",
+    "discountValue": "Valeur de la remise",
+    "percentage": "Pourcentage",
+    "absolute": "Montant fixe",
+    "internalNotes": "Notes internes",
+    "internalNotesPlaceholder": "Notes visibles uniquement par le personnel...",
+    "patientNotes": "Notes patient",
+    "patientNotesPlaceholder": "Notes visibles sur le devis...",
+    "status": {
+      "title": "Statut",
+      "draft": "Brouillon",
+      "sent": "Envoyé",
+      "partially_accepted": "Partiellement accepté",
+      "accepted": "Accepté",
+      "in_progress": "En cours",
+      "completed": "Terminé",
+      "invoiced": "Facturé",
+      "rejected": "Refusé",
+      "expired": "Expiré",
+      "cancelled": "Annulé"
+    },
+    "itemStatus": {
+      "pending": "En attente",
+      "accepted": "Accepté",
+      "rejected": "Refusé",
+      "in_progress": "En cours",
+      "completed": "Terminé"
+    },
+    "actions": {
+      "send": "Envoyer au patient",
+      "accept": "Accepter le devis",
+      "acceptPartial": "Accepter la sélection",
+      "reject": "Refuser",
+      "cancel": "Annuler le devis",
+      "duplicate": "Créer une nouvelle version",
+      "downloadPdf": "Télécharger le PDF",
+      "previewPdf": "Aperçu du PDF",
+      "startTreatment": "Commencer le traitement",
+      "completeTreatment": "Terminer le traitement",
+      "renegotiate": "Renégocier",
+      "acceptInClinic": "Accepter en clinique",
+      "resend": "Renvoyer",
+      "sendReminder": "Envoyer un rappel",
+      "setPublicCode": "Définir le code d'accès",
+      "unlockPublic": "Déverrouiller l'accès"
+    },
+    "items": {
+      "title": "Traitements",
+      "add": "Ajouter un traitement",
+      "remove": "Retirer le traitement",
+      "edit": "Modifier le traitement",
+      "empty": "Aucun traitement dans ce devis",
+      "singular": "traitement",
+      "plural": "traitements",
+      "addFromCatalog": "Ajouter depuis le catalogue",
+      "addFromOdontogram": "Ajouter depuis l'odontogramme",
+      "treatment": "Traitement",
+      "searchCatalog": "Rechercher dans le catalogue de traitements...",
+      "unitPrice": "Prix unitaire",
+      "quantity": "Quantité",
+      "discount": "Remise",
+      "lineTotal": "Total ligne",
+      "tooth": "Dent",
+      "toothNumber": "Numéro de dent",
+      "toothNumberPlaceholder": "Ex. : 11, 21, 36...",
+      "surfaces": "Surfaces",
+      "notes": "Notes",
+      "notesPlaceholder": "Notes sur ce traitement..."
+    },
+    "signature": {
+      "title": "Signature numérique",
+      "viewAction": "Voir la signature",
+      "signedBy": "Signé par",
+      "signedAt": "Signé le",
+      "methodLabel": "Méthode",
+      "relationshipLabel": "Lien de parenté",
+      "documentHash": "Hash du document (SHA-256)",
+      "hashHint": "Hash {short} — lie la signature à ce PDF exact. Toute modification l'invaliderait.",
+      "downloadSignedPdf": "Télécharger le PDF signé",
+      "downloadError": "Impossible de télécharger le PDF signé.",
+      "notSigned": "Aucune signature n'a encore été capturée pour ce devis.",
+      "method": {
+        "drawn": "Signature manuscrite",
+        "clickAccept": "Clic pour accepter",
+        "external": "Fournisseur externe"
+      },
+      "email": "Email",
+      "relationship": "Lien avec le patient",
+      "patient": "Patient",
+      "guardian": "Tuteur légal",
+      "representative": "Représentant",
+      "accept": "J'accepte les termes du devis",
+      "signHere": "Signez ici",
+      "clear": "Effacer la signature"
+    },
+    "history": {
+      "title": "Historique des modifications",
+      "noChanges": "Aucune modification enregistrée",
+      "actions": {
+        "created": "Devis créé",
+        "updated": "Devis mis à jour",
+        "status_changed": "Statut modifié",
+        "item_added": "Traitement ajouté",
+        "item_removed": "Traitement retiré",
+        "signed": "Devis signé",
+        "sent": "Devis envoyé",
+        "duplicated": "Nouvelle version créée",
+        "deleted": "Devis supprimé",
+        "item_treatment_started": "Traitement commencé",
+        "item_treatment_completed": "Traitement terminé"
+      }
+    },
+    "versions": {
+      "title": "Versions",
+      "current": "Actuelle",
+      "viewVersion": "Voir la version"
+    },
+    "confirmations": {
+      "send": "Envoyer le devis au patient ?",
+      "sendDescription": "Le devis sera marqué comme envoyé.",
+      "reject": "Refuser le devis ?",
+      "rejectDescription": "Cette action est irréversible.",
+      "cancel": "Annuler le devis ?",
+      "cancelDescription": "Cette action est irréversible.",
+      "delete": "Supprimer le devis ?",
+      "deleteDescription": "Cette action est irréversible."
+    },
+    "send": {
+      "description": "Vous pouvez envoyer le devis par email ou le marquer comme envoyé manuellement (imprimé ou remis en main propre).",
+      "sendByEmail": "Envoyer par email",
+      "willSendTo": "Sera envoyé à",
+      "noPatientEmail": "Le patient n'a pas d'email enregistré",
+      "customMessage": "Message personnalisé (facultatif)",
+      "customMessagePlaceholder": "Ajoutez un message pour le patient...",
+      "manualNote": "Le devis sera marqué comme envoyé sans envoyer d'email.",
+      "sendEmail": "Envoyer l'email",
+      "markAsSent": "Marquer comme envoyé"
+    },
+    "messages": {
+      "created": "Devis créé",
+      "updated": "Devis mis à jour",
+      "deleted": "Devis supprimé",
+      "sent": "Devis envoyé",
+      "sentByEmail": "Devis envoyé par email",
+      "sentManually": "Devis marqué comme envoyé",
+      "accepted": "Devis accepté",
+      "rejected": "Devis refusé",
+      "cancelled": "Devis annulé",
+      "duplicated": "Nouvelle version créée",
+      "itemAdded": "Traitement ajouté",
+      "itemUpdated": "Traitement mis à jour",
+      "itemRemoved": "Traitement retiré",
+      "treatmentStarted": "Traitement commencé",
+      "treatmentCompleted": "Traitement terminé"
+    },
+    "errors": {
+      "load": "Erreur lors du chargement des devis",
+      "create": "Erreur lors de la création du devis",
+      "update": "Erreur lors de la mise à jour du devis",
+      "delete": "Erreur lors de la suppression du devis",
+      "send": "Erreur lors de l'envoi du devis",
+      "accept": "Erreur lors de l'acceptation du devis",
+      "reject": "Erreur lors du refus du devis",
+      "notFound": "Devis introuvable",
+      "onlyDraft": "Seuls les devis en brouillon peuvent être modifiés"
+    },
+    "filters": {
+      "allStatuses": "Tous les statuts",
+      "status": "Statut",
+      "paymentStatus": "Statut",
+      "professional": "Professionnel",
+      "validity": "Validité",
+      "validityValid": "Valide",
+      "validityExpiringSoon": "Expire dans 7 jours",
+      "validityExpired": "Expiré",
+      "dateFrom": "Du",
+      "dateTo": "Au",
+      "showExpired": "Afficher les expirés",
+      "advanced": "Filtres avancés",
+      "clear": "Effacer les filtres"
+    },
+    "sortFields": {
+      "createdAt": "Créé le",
+      "validUntil": "Valable jusqu'au",
+      "total": "Total",
+      "status": "Statut",
+      "budgetNumber": "Numéro"
+    },
+    "validity": {
+      "expired": "Expiré",
+      "expiresIn": "Expire dans {days}j"
+    },
+    "pdf": {
+      "generating": "Génération du PDF...",
+      "downloadError": "Erreur lors du téléchargement du PDF"
+    },
+    "modals": {
+      "renegotiate": {
+        "title": "Renégocier le devis",
+        "description": "Cela annulera le devis actuel et rouvrira le plan en Brouillon pour que vous puissiez ajuster les traitements.",
+        "submit": "Renégocier"
+      },
+      "acceptInClinic": {
+        "title": "Accepter le devis en clinique",
+        "description": "Capturez l'acceptation du patient. Vous pouvez collecter une signature sur tablette (facultatif).",
+        "signerLabel": "Nom complet du signataire",
+        "captureSignature": "Capturer la signature",
+        "submit": "Marquer comme accepté"
+      },
+      "setPublicCode": {
+        "title": "Définir le code d'accès",
+        "description": "Ce patient n'a ni téléphone ni date de naissance dans le dossier. Définissez un code à 4-6 chiffres et partagez-le oralement avec le patient. N'INCLUEZ PAS le code dans l'email.",
+        "codeLabel": "Code (4-6 chiffres)",
+        "submit": "Enregistrer le code"
+      }
+    },
+    "publicLink": {
+      "action": "Partager le lien",
+      "title": "Lien patient",
+      "help": "Copiez ce lien et partagez-le avec le patient via WhatsApp, SMS ou email. Une vérification sera demandée avant de consulter le devis.",
+      "copy": "Copier le lien",
+      "copied": "Copié !",
+      "whatsapp": "Envoyer via WhatsApp",
+      "whatsappNoPhone": "Le patient n'a pas de téléphone enregistré",
+      "whatsappGreeting": "Bonjour {name}, voici votre devis :",
+      "whatsappGreetingFallback": "Bonjour, voici votre devis :",
+      "preview": "Aperçu",
+      "statusSent": "Envoyé",
+      "statusAccepted": "Accepté",
+      "statusRejected": "Refusé",
+      "statusExpired": "Expiré"
+    },
+    "public": {
+      "title": "Votre devis",
+      "intro": "{clinic} vous a envoyé ce devis. Examinez les traitements et choisissez une option.",
+      "greeting": "Bonjour, {name}",
+      "subtitle": "Votre plan de traitement personnalisé",
+      "budgetNumber": "Devis",
+      "issuedOn": "Émis le {date}",
+      "items": "Traitements inclus",
+      "tooth": "Dent {number}",
+      "subtotal": "Sous-total",
+      "discount": "Remise",
+      "tax": "TVA",
+      "total": "Total",
+      "validUntil": "Valable jusqu'au {date}",
+      "trustSecure": "Connexion sécurisée",
+      "trustEncrypted": "Données chiffrées",
+      "trustSignature": "Signature légalement contraignante",
+      "needHelp": "Besoin d'aide ? Appelez la clinique",
+      "noteFromClinic": "Message de la clinique",
+      "callClinic": "Appeler la clinique",
+      "emailClinic": "Envoyer un email",
+      "cta_accept": "Accepter et signer",
+      "cta_reject": "Pas intéressé",
+      "expired": "Ce devis a expiré. Veuillez contacter la clinique.",
+      "locked": "Accès verrouillé après trop de tentatives. Veuillez appeler la clinique.",
+      "already_accepted": "Vous avez déjà accepté ce devis. La clinique vous contactera pour planifier votre premier rendez-vous.",
+      "already_rejected": "Vous avez refusé ce devis. Si vous changez d'avis, veuillez appeler la clinique.",
+      "download": {
+        "signedPdf": "Télécharger le PDF signé",
+        "notSigned": "Ce devis n'a pas encore de signature jointe.",
+        "error": "Impossible de télécharger le PDF. Veuillez réessayer.",
+        "reauthIntro": "Pour des raisons de sécurité, veuillez vérifier votre identité à nouveau pour télécharger le PDF signé."
+      },
+      "verify": {
+        "title": "Vérifiez votre identité",
+        "intro": "Pour protéger vos informations, confirmez un détail avant de consulter votre devis.",
+        "phone_last4_label": "4 derniers chiffres de votre téléphone",
+        "dob_label": "Votre date de naissance",
+        "manual_code_label": "Code communiqué par la clinique",
+        "submit": "Continuer",
+        "invalid": "Détail incorrect. Veuillez réessayer.",
+        "locked": "Accès verrouillé après trop de tentatives. Veuillez appeler la clinique.",
+        "rate_limited": "Trop de tentatives. Attendez 15 minutes."
+      },
+      "accept": {
+        "title": "Accepter et signer",
+        "signerLabel": "Votre nom complet",
+        "signatureLabel": "Signez ici (facultatif)",
+        "signatureClear": "Effacer",
+        "consent": "J'accepte ce devis et autorise le traitement décrit.",
+        "submit": "Confirmer l'acceptation",
+        "success": "Terminé ! La clinique vous contactera pour planifier votre premier rendez-vous."
+      },
+      "reject": {
+        "title": "Pas intéressé",
+        "intro": "Pourquoi ce devis ne vous convient-il pas ?",
+        "reasonLabel": "Raison",
+        "noteLabel": "Commentaire (facultatif)",
+        "submit": "Confirmer le refus",
+        "success": "Nous avons informé la clinique.",
+        "reasons": {
+          "price": "Prix",
+          "time": "Manque de temps",
+          "second_opinion": "Deuxième avis",
+          "other": "Autre raison"
+        }
+      }
+    },
+    "settings": {
+      "title": "Paramètres des devis",
+      "description": "Configurer l'expiration, les rappels et la vérification du lien public.",
+      "cards": {
+        "expiry": {
+          "title": "Expiration et fermeture automatique",
+          "description": "Durée de validité d'un devis avant expiration et délai de fermeture automatique des plans en attente."
+        },
+        "reminders": {
+          "title": "Rappels automatiques",
+          "description": "Activez les rappels par email à 7j et 14j pour les patients sans réponse."
+        },
+        "publicLink": {
+          "title": "Lien public et vérification",
+          "description": "Configurez la protection du lien devis accessible au patient."
+        }
+      },
+      "expiry": {
+        "validityDays": "Validité du devis (jours)",
+        "validityHelp": "Après ce nombre de jours sans réponse, le devis passe en Expiré (plage 7-180).",
+        "autoCloseDays": "Jours avant fermeture automatique du plan",
+        "autoCloseHelp": "Les plans avec un devis expiré et sans action pendant ce nombre de jours passent à Fermé (plage 7-180).",
+        "save": "Enregistrer"
+      },
+      "reminders": {
+        "enabled": "Envoyer des rappels automatiques à 7j et 14j",
+        "enabledHelp": "Lorsqu'activé, le système envoie un email au patient concernant les devis en attente. Lorsque désactivé, la réception suit manuellement.",
+        "save": "Enregistrer"
+      },
+      "publicLink": {
+        "authDisabled": "Désactiver la vérification du lien public",
+        "authDisabledHelp": "Lorsqu'activé, le patient voit le devis avec le lien uniquement — sans vérification téléphone ou date de naissance. Acceptez le risque si le lien est partagé.",
+        "save": "Enregistrer"
+      },
+      "saved": "Paramètres enregistrés"
+    }
+  },
+  "notifications": {
+    "communications": {
+      "language": {
+        "cardTitle": "Langue des communications",
+        "cardDescription": "Langue utilisée dans la vue devis patient, les emails et SMS.",
+        "title": "Langue des communications patient",
+        "label": "Langue",
+        "help": "S'applique à la vue devis accessible au patient et aux modèles email/SMS automatisés. L'interface du personnel conserve la préférence linguistique de chaque utilisateur.",
+        "save": "Enregistrer",
+        "saved": "Langue enregistrée"
+      }
+    },
+    "title": "Notifications",
+    "description": "Configurer les notifications email de la clinique",
+    "pageDescription": "Configurez quelles notifications sont envoyées automatiquement et lesquelles nécessitent un envoi manuel.",
+    "autoVsManual": "Notifications automatiques vs manuelles",
+    "autoVsManualDescription": "Définissez quelles notifications sont envoyées automatiquement lorsqu'un événement se produit et lesquelles nécessitent que l'utilisateur les envoie manuellement.",
+    "notificationType": "Type de notification",
+    "enabled": "Activé",
+    "autoSend": "Envoi automatique",
+    "options": "Options",
+    "hoursBefore": "h avant",
+    "testConnection": "Tester la connexion",
+    "testEmailTitle": "Envoyer un email de test",
+    "testEmailDescription": "Nous enverrons un email de test pour vérifier que la configuration fonctionne correctement.",
+    "sendTestEmail": "Envoyer un test",
+    "test_email_sent": "Email de test envoyé avec succès",
+    "settings_saved": "Paramètres enregistrés",
+    "emailProvider": "Fournisseur d'email",
+    "providerConfigured": "Fournisseur d'email configuré",
+    "providerNote": "La configuration du serveur email se fait dans les variables d'environnement du serveur.",
+    "infoTitle": "Information",
+    "infoAutoSend": "Envoi automatique : La notification est envoyée lorsque l'événement se produit (ex. lors de la création d'un rendez-vous).",
+    "infoManualSend": "Envoi manuel : Un bouton apparaîtra pour envoyer la notification quand vous le souhaitez.",
+    "infoDisabled": "Désactivé : La notification ne sera pas envoyée et l'option d'envoi n'apparaîtra pas.",
+    "types": {
+      "appointment_confirmation": "Confirmation de rendez-vous",
+      "appointment_confirmation_desc": "Email de confirmation lorsqu'un rendez-vous est planifié",
+      "appointment_cancelled": "Annulation de rendez-vous",
+      "appointment_cancelled_desc": "Email de notification lorsqu'un rendez-vous est annulé",
+      "appointment_reminder": "Rappel de rendez-vous",
+      "appointment_reminder_desc": "Email de rappel avant le rendez-vous",
+      "budget_sent": "Envoi de devis",
+      "budget_sent_desc": "Email avec les détails du devis",
+      "budget_accepted": "Devis accepté",
+      "budget_accepted_desc": "Email de confirmation lorsqu'un devis est accepté",
+      "welcome": "Bienvenue",
+      "welcome_desc": "Email de bienvenue pour les nouveaux patients"
+    },
+    "sendConfirmation": "Envoyer la confirmation",
+    "sendReminder": "Envoyer le rappel",
+    "sendCancellation": "Envoyer l'annulation",
+    "sendBudget": "Envoyer par email",
+    "sendAcceptance": "Envoyer la confirmation",
+    "sendWelcome": "Envoyer la bienvenue",
+    "sendEmail": "Envoyer l'email",
+    "errors": {
+      "fetch_failed": "Erreur lors du chargement des paramètres",
+      "save_failed": "Erreur lors de l'enregistrement des paramètres",
+      "test_failed": "Erreur lors de l'envoi de l'email de test",
+      "send_failed": "Erreur lors de l'envoi de la notification"
+    },
+    "smtp": {
+      "title": "Configuration du serveur email",
+      "description": "Configurez le serveur SMTP pour envoyer les emails depuis votre clinique. Chaque clinique peut avoir sa propre configuration.",
+      "configure": "Configurer",
+      "provider": "Fournisseur",
+      "host": "Serveur",
+      "port": "Port",
+      "username": "Nom d'utilisateur",
+      "password": "Mot de passe",
+      "passwordHint": "Laissez vide pour conserver le mot de passe actuel",
+      "useTls": "Utiliser TLS",
+      "useSsl": "Utiliser SSL",
+      "fromEmail": "Email d'expédition",
+      "fromName": "Nom d'expédition",
+      "security": "Sécurité",
+      "testConnection": "Tester la connexion",
+      "testConnectionTitle": "Tester la configuration avant d'enregistrer",
+      "testEmailPlaceholder": "Adresse email de test",
+      "test_success": "Connexion SMTP réussie. Email de test envoyé.",
+      "test_failed": "Erreur de connexion SMTP",
+      "settings_saved": "Paramètres SMTP enregistrés",
+      "consoleNote": "En mode console, les emails sont affichés dans la console serveur au lieu d'être envoyés. Utile pour le développement.",
+      "disabledNote": "Avec l'email désactivé, aucune notification email ne sera envoyée depuis cette clinique.",
+      "status": {
+        "not_configured": "Non configuré",
+        "verified": "Vérifié et fonctionnel",
+        "not_verified": "Configuré mais non vérifié",
+        "disabled": "Email désactivé",
+        "console": "Mode console (développement)"
+      },
+      "errors": {
+        "fetch_failed": "Erreur lors du chargement des paramètres SMTP",
+        "save_failed": "Erreur lors de l'enregistrement des paramètres SMTP",
+        "test_failed": "Erreur lors du test de connexion SMTP"
+      }
+    }
+  },
+  "invoice": {
+    "title": "Factures",
+    "description": "Gérer les factures et la facturation",
+    "new": "Nouvelle facture",
+    "edit": "Modifier la facture",
+    "view": "Voir la facture",
+    "delete": "Supprimer la facture",
+    "noItems": "Aucune facture",
+    "empty": "Aucune facture enregistrée",
+    "emptyAction": "Créer la première facture",
+    "searchPlaceholder": "Rechercher par numéro ou patient...",
+    "notFound": "Facture introuvable",
+    "draftNoNumber": "Brouillon",
+    "details": "Détails",
+    "invoiceNumber": "Numéro de facture",
+    "patient": "Patient",
+    "searchPatient": "Rechercher un patient",
+    "searchPatientPlaceholder": "Rechercher par nom...",
+    "professional": "Professionnel",
+    "billingData": "Données de facturation",
+    "billingName": "Nom de facturation",
+    "taxId": "Identifiant fiscal",
+    "billingEmail": "Email de facturation",
+    "billingAddress": "Adresse de facturation",
+    "billingDataComplete": "Complet",
+    "billingDataIncomplete": "Incomplet",
+    "billingDataIncompleteHint": "Il manque des informations de facturation au patient.",
+    "editPatientBilling": "Modifier les données du patient",
+    "fromPatient": "Depuis le patient",
+    "editInPatient": "Modifier dans le profil",
+    "billingFromPatientHint": "Ces données proviennent du dossier du patient. Pour les modifier, modifiez les informations de facturation du patient.",
+    "paymentTerms": "Conditions de paiement",
+    "linkedToBudget": "Lié au devis",
+    "selectPatient": "Sélectionner un patient",
+    "noBillingData": "Aucune donnée de facturation",
+    "street": "Rue",
+    "city": "Ville",
+    "postalCode": "Code postal",
+    "province": "Province",
+    "country": "Pays",
+    "linkedBudget": "Devis lié",
+    "creditNoteFor": "Avoir pour",
+    "paymentTermDays": "Délai de paiement (jours)",
+    "dueDate": "Date d'échéance",
+    "issueDate": "Date d'émission",
+    "subtotal": "Sous-total",
+    "discount": "Remise",
+    "totalDiscount": "Remise totale",
+    "tax": "Taxe",
+    "total": "Total",
+    "paid": "Payé",
+    "totalPaid": "Total payé",
+    "balance": "Solde",
+    "balanceDue": "Montant dû",
+    "overdue": "En retard",
+    "overdueDays": "En retard de {n}j",
+    "info": {
+      "issueDate": "Date d'émission",
+      "dueDate": "Date d'échéance",
+      "issuedBy": "Émis par",
+      "createdBy": "Créé par",
+      "createdAt": "Créé le",
+      "budget": "Devis",
+      "creditNoteFor": "Avoir pour"
+    },
+    "criticalBanner": {
+      "aeatRejected": {
+        "title": "L'AEAT a rejeté cette facture",
+        "cta": "Corriger et soumettre à nouveau"
+      },
+      "billingIncomplete": {
+        "title": "Données de facturation incomplètes",
+        "cta": "Compléter les données"
+      }
+    },
+    "collect": {
+      "title": "Encaisser la facture",
+      "submit": "Encaisser",
+      "noteAppliedToInvoice": "appliqué à cette facture.",
+      "notePendingAfter": "Solde restant",
+      "noteFullySettled": "Ce paiement règle intégralement la facture.",
+      "noteToInvoice": "appliqué à cette facture et",
+      "noteExcessToOnAccount": "crédité au compte du patient.",
+      "noteInvoiceSettled": "Cette facture est déjà payée.",
+      "noteToOnAccount": "sera créditée au compte du patient."
+    },
+    "tooth": "Dent",
+    "vat": "TVA",
+    "currency": "Devise",
+    "internalNotes": "Notes internes",
+    "internalNotesPlaceholder": "Notes visibles uniquement par le personnel...",
+    "publicNotes": "Notes publiques",
+    "publicNotesPlaceholder": "Notes visibles sur la facture...",
+    "items": "Lignes",
+    "addItem": "Ajouter une ligne",
+    "editItem": "Modifier la ligne",
+    "selectTreatment": "Traitement",
+    "searchCatalog": "Rechercher un traitement dans le catalogue...",
+    "itemDescription": "Description",
+    "itemPrice": "Prix unitaire",
+    "itemQuantity": "Quantité",
+    "selectVatType": "Sélectionner le type de TVA",
+    "summary": "Récapitulatif",
+    "createDraft": "Créer un brouillon",
+    "createFromBudget": "Créer une facture depuis un devis",
+    "notes": "Notes",
+    "status": {
+      "draft": "Brouillon",
+      "issued": "Émise",
+      "partial": "Partiellement payée",
+      "paid": "Payée",
+      "cancelled": "Annulée",
+      "voided": "Annulée"
+    },
+    "actions": {
+      "issue": "Émettre la facture",
+      "void": "Annuler",
+      "recordPayment": "Enregistrer le paiement",
+      "createCreditNote": "Créer un avoir",
+      "downloadPdf": "Télécharger le PDF",
+      "previewPdf": "Aperçu du PDF",
+      "sendEmail": "Envoyer par email"
+    },
+    "recordPayment": "Enregistrer le paiement",
+    "paymentAmount": "Montant",
+    "paymentMethod": "Mode de paiement",
+    "paymentDate": "Date de paiement",
+    "paymentReference": "Référence",
+    "paymentReferencePlaceholder": "Numéro de transaction, reçu...",
+    "paymentNotes": "Notes de paiement",
+    "paymentVoided": "Paiement annulé",
+    "createCreditNote": "Créer un avoir",
+    "creditNoteReason": "Raison de l'avoir",
+    "creditNoteReasonPlaceholder": "Décrivez la raison de l'avoir...",
+    "creditNoteInfo": "Un avoir sera créé pour le montant total de la facture.",
+    "prompts": {
+      "voidPaymentReason": "Saisissez la raison de l'annulation de ce paiement"
+    },
+    "payments": {
+      "title": "Paiements",
+      "record": "Enregistrer un paiement",
+      "void": "Annuler le paiement",
+      "amount": "Montant",
+      "method": "Mode de paiement",
+      "date": "Date",
+      "reference": "Référence",
+      "notes": "Notes",
+      "noPayments": "Aucun paiement enregistré",
+      "recorded": "Paiement enregistré",
+      "voided": "Paiement annulé",
+      "voidReason": "Raison de l'annulation",
+      "voidReasonPlaceholder": "Raison de l'annulation de ce paiement...",
+      "methods": {
+        "cash": "Espèces",
+        "card": "Carte",
+        "bank_transfer": "Virement bancaire",
+        "direct_debit": "Prélèvement",
+        "insurance": "Assurance",
+        "other": "Autre"
+      }
+    },
+    "creditNote": {
+      "title": "Avoir",
+      "create": "Créer un avoir",
+      "reason": "Raison",
+      "reasonPlaceholder": "Raison de l'avoir...",
+      "selectItems": "Sélectionner les lignes à rectifier",
+      "fullCreditNote": "Avoir complet (toutes les lignes)",
+      "partialCreditNote": "Avoir partiel (lignes sélectionnées)",
+      "originalInvoice": "Facture originale",
+      "created": "Avoir créé"
+    },
+    "history": {
+      "title": "Historique",
+      "noChanges": "Aucune modification enregistrée",
+      "actions": {
+        "created": "Facture créée",
+        "updated": "Facture mise à jour",
+        "issued": "Facture émise",
+        "voided": "Facture annulée",
+        "payment_recorded": "Paiement enregistré",
+        "payment_voided": "Paiement annulé",
+        "credit_note_created": "Avoir créé"
+      }
+    },
+    "fromBudget": "Créer une facture depuis un devis",
+    "selectItems": "Sélectionner les lignes à facturer",
+    "selectItemsHint": "Sélectionnez les lignes du devis que vous souhaitez facturer",
+    "availableQuantity": "Disponible",
+    "quantityToInvoice": "Qté à facturer",
+    "alreadyInvoiced": "Déjà facturé",
+    "remaining": "Restant",
+    "noItemsAvailable": "Aucune ligne disponible à facturer",
+    "allItemsInvoiced": "Toutes les lignes ont été facturées",
+    "series": {
+      "title": "Série de factures",
+      "prefix": "Préfixe",
+      "type": "Type",
+      "currentNumber": "Numéro actuel",
+      "resetYearly": "Réinitialiser annuellement",
+      "default": "Par défaut",
+      "active": "Actif",
+      "invoice": "Facture",
+      "credit_note": "Avoir"
+    },
+    "filters": {
+      "allStatuses": "Statut",
+      "overdueOnly": "En retard",
+      "dateFrom": "Du",
+      "dateTo": "Au"
+    },
+    "sortFields": {
+      "created": "Créé le",
+      "issueDate": "Date d'émission",
+      "dueDate": "Date d'échéance",
+      "total": "Total"
+    },
+    "overdueByDays": "En retard de {days}j",
+    "pdf": {
+      "generating": "Génération du PDF...",
+      "downloadError": "Erreur lors du téléchargement du PDF"
+    },
+    "reports": {
+      "title": "Rapports de facturation",
+      "summary": "Résumé",
+      "overdue": "En retard",
+      "overdueInvoices": "Factures en retard",
+      "byPaymentMethod": "Par mode de paiement",
+      "byProfessional": "Par professionnel",
+      "vatSummary": "Résumé de la TVA",
+      "gaps": "Lacunes de numérotation",
+      "period": "Période",
+      "from": "Du",
+      "to": "Au",
+      "refresh": "Actualiser",
+      "totalInvoiced": "Total facturé",
+      "totalCollected": "Total encaissé",
+      "totalPaid": "Total payé",
+      "totalPending": "Total en attente",
+      "pending": "Solde en attente",
+      "invoices": "factures",
+      "paid": "payées",
+      "payments": "paiements",
+      "noGaps": "Aucune lacune dans la numérotation",
+      "gapsFound": "{count} lacune(s) trouvée(s) dans la numérotation",
+      "gapsDetected": "Lacunes détectées dans la numérotation",
+      "missingNumbers": "Numéros manquants :",
+      "noData": "Aucune donnée pour la période sélectionnée",
+      "noOverdue": "Aucune facture en retard",
+      "daysOverdue": "jours de retard",
+      "vatType": "Type de TVA",
+      "base": "Base",
+      "tax": "Taxe",
+      "thisMonth": "Ce mois-ci",
+      "thisQuarter": "Ce trimestre",
+      "thisYear": "Cette année",
+      "lastMonth": "Le mois dernier",
+      "lastQuarter": "Le trimestre dernier",
+      "lastYear": "L'année dernière"
+    },
+    "confirmations": {
+      "issue": "Émettre la facture ?",
+      "issueDescription": "Une fois émise, la facture ne peut plus être modifiée. Seuls les paiements peuvent être enregistrés ou des avoirs créés.",
+      "void": "Annuler la facture ?",
+      "voidDescription": "Cette action est irréversible.",
+      "delete": "Supprimer la facture ?",
+      "deleteDescription": "Cette action est irréversible."
+    },
+    "messages": {
+      "created": "Facture créée",
+      "updated": "Facture mise à jour",
+      "deleted": "Facture supprimée",
+      "issued": "Facture émise",
+      "voided": "Facture annulée",
+      "itemAdded": "Ligne ajoutée",
+      "itemUpdated": "Ligne mise à jour",
+      "sentByEmail": "Facture envoyée par email",
+      "sentManually": "Facture marquée comme envoyée"
+    },
+    "send": {
+      "title": "Envoyer la facture",
+      "description": "Vous pouvez envoyer la facture par email ou la marquer comme envoyée manuellement (imprimée ou remise en main propre).",
+      "sendByEmail": "Envoyer par email",
+      "willSendTo": "Sera envoyée à",
+      "noPatientEmail": "Le patient n'a pas d'adresse email",
+      "customMessage": "Message personnalisé (facultatif)",
+      "customMessagePlaceholder": "Ajoutez un message pour le patient...",
+      "manualNote": "La facture sera marquée comme envoyée sans envoyer d'email.",
+      "sendEmail": "Envoyer l'email",
+      "markAsSent": "Marquer comme envoyée"
+    },
+    "errors": {
+      "load": "Erreur lors du chargement des factures",
+      "create": "Erreur lors de la création de la facture",
+      "update": "Erreur lors de la mise à jour de la facture",
+      "delete": "Erreur lors de la suppression de la facture",
+      "issue": "Erreur lors de l'émission de la facture",
+      "void": "Erreur lors de l'annulation de la facture",
+      "recordPayment": "Erreur lors de l'enregistrement du paiement",
+      "voidPayment": "Erreur lors de l'annulation du paiement",
+      "createCreditNote": "Erreur lors de la création de l'avoir",
+      "send": "Erreur lors de l'envoi de la facture",
+      "creditNoteReasonRequired": "La raison de l'avoir est requise",
+      "notFound": "Facture introuvable",
+      "onlyDraft": "Seules les factures en brouillon peuvent être modifiées",
+      "canOnlyDeleteDraft": "Seules les factures en brouillon peuvent être supprimées",
+      "patientRequired": "Le patient est requis",
+      "itemsRequired": "Au moins une ligne est requise",
+      "itemRequired": "La description et le prix sont requis",
+      "selectCatalogItem": "Veuillez sélectionner un traitement dans le catalogue",
+      "cannotEdit": "Seules les factures en brouillon peuvent être modifiées",
+      "billingIncomplete": "La facture ne peut pas être émise car les données de facturation sont incomplètes. Veuillez compléter les informations de facturation du patient pour continuer."
+    },
+    "newItemsPending": "Nouvelles lignes en attente d'enregistrement"
+  },
+  "reports": {
+    "title": "Rapports",
+    "subtitle": "Analyses et statistiques de la clinique",
+    "viewReports": "Voir les rapports",
+    "noAccess": "Vous n'avez accès à aucun rapport",
+    "dashboard": {
+      "title": "Tableau de bord",
+      "subtitle": "Votre clinique en un coup d'œil",
+      "period": "Période",
+      "snapshotBadge": "Aujourd'hui",
+      "snapshotTooltip": "Non affecté par la plage de dates",
+      "vsPrev": "vs. période précédente",
+      "empty": {
+        "noData": "Aucune donnée dans cette plage"
+      },
+      "drilldown": {
+        "title": "Détails",
+        "payments": "Paiements"
+      },
+      "kpi": {
+        "cashCollected": "Encaissements",
+        "cashCollectedHint": "{count} paiements",
+        "patientAdvance": "Crédit patient",
+        "patientAdvanceHint": "Avances non affectées",
+        "production": "Production",
+        "productionHint": "{count} traitements",
+        "byMethod": "Par mode de paiement",
+        "methodCount": "{count} paiements",
+        "total": "Total",
+        "newPatients": "Nouveaux patients",
+        "newPatientsHint": "{rate}% des rendez-vous totaux",
+        "appointmentFunnel": "Taux d'absence",
+        "funnelHint": "{completed}% terminés",
+        "avgCollectedTicket": "Ticket moyen encaissé",
+        "avgTicketHint": "Sur {count} paiements",
+        "aging": "Créances vieillissantes"
+      },
+      "charts": {
+        "cashOverTime": "Encaissements dans le temps",
+        "productionByDoctor": "Production par médecin",
+        "refunded": "Remboursements"
+      },
+      "production": {
+        "unassigned": "Non attribué",
+        "others": "Autres",
+        "treatmentCount": "{count} traitements"
+      },
+      "aging": {
+        "bucket0_30": "0-30 jours",
+        "bucket31_60": "31-60 jours",
+        "bucket61_90": "61-90 jours",
+        "bucket90plus": "90+ jours",
+        "empty": "Aucune créance en attente",
+        "patientCount": "{count} patients"
+      }
+    },
+    "billing": {
+      "title": "Facturation",
+      "description": "Revenus, paiements, TVA et factures en retard",
+      "summary": "Résumé",
+      "overdue": "En retard",
+      "overdueInvoices": "Factures en retard",
+      "byPaymentMethod": "Par mode de paiement",
+      "byProfessional": "Par professionnel",
+      "vatSummary": "Résumé de la TVA",
+      "gaps": "Lacunes de numérotation",
+      "period": "Période",
+      "from": "Du",
+      "to": "Au",
+      "refresh": "Actualiser",
+      "totalInvoiced": "Total facturé",
+      "totalCollected": "Total encaissé",
+      "pending": "Solde en attente",
+      "invoices": "factures",
+      "paid": "payées",
+      "payments": "paiements",
+      "gapsDetected": "Lacunes détectées dans la numérotation",
+      "missingNumbers": "Numéros manquants :",
+      "noData": "Aucune donnée pour la période sélectionnée",
+      "noOverdue": "Aucune facture en retard",
+      "daysOverdue": "jours de retard",
+      "vatType": "Type de TVA",
+      "base": "Base",
+      "tax": "Taxe",
+      "thisMonth": "Ce mois-ci",
+      "thisQuarter": "Ce trimestre",
+      "thisYear": "Cette année",
+      "lastMonth": "Le mois dernier",
+      "lastQuarter": "Le trimestre dernier",
+      "lastYear": "L'année dernière"
+    },
+    "budgets": {
+      "title": "Devis",
+      "description": "Taux d'acceptation, analyse par professionnel et traitements",
+      "comingSoonDescription": "Les rapports de devis seront bientôt disponibles. Vous pourrez analyser les taux d'acceptation, les devis par professionnel et les traitements les plus demandés.",
+      "features": {
+        "acceptanceRate": "Taux d'acceptation",
+        "acceptanceRateDesc": "Pourcentage de devis acceptés vs refusés",
+        "byProfessional": "Par professionnel",
+        "byProfessionalDesc": "Devis créés par chaque professionnel",
+        "byTreatment": "Par traitement",
+        "byTreatmentDesc": "Traitements les plus devisés",
+        "averageValue": "Valeur moyenne",
+        "averageValueDesc": "Montant moyen des devis"
+      },
+      "labels": {
+        "totalCreated": "Total créés",
+        "accepted": "Acceptés",
+        "rejected": "refusés",
+        "pending": "en attente",
+        "completed": "Terminés",
+        "acceptanceRate": "Taux d'acceptation",
+        "averageValue": "Valeur moyenne",
+        "byStatus": "Par statut",
+        "topTreatments": "Traitements les plus devisés",
+        "treatment": "Traitement",
+        "occurrences": "Occurrences",
+        "quantity": "Quantité"
+      }
+    },
+    "scheduling": {
+      "title": "Agenda",
+      "description": "Premières visites, heures travaillées et occupation",
+      "comingSoonDescription": "Les rapports d'agenda seront bientôt disponibles. Vous pourrez analyser les premières visites, les heures par professionnel et les taux d'annulation.",
+      "features": {
+        "firstVisits": "Premières visites",
+        "firstVisitsDesc": "Nouveaux patients par période",
+        "hoursWorked": "Heures travaillées",
+        "hoursWorkedDesc": "Temps par professionnel",
+        "cancellations": "Annulations",
+        "cancellationsDesc": "Taux d'annulation et d'absence",
+        "cabinetUtilization": "Occupation des cabinets",
+        "cabinetUtilizationDesc": "Utilisation de chaque cabinet"
+      },
+      "labels": {
+        "totalAppointments": "Total des rendez-vous",
+        "completionRate": "Taux de complétion",
+        "completed": "terminés",
+        "cancellationRate": "Taux d'annulation",
+        "cancelled": "annulés",
+        "noShowRate": "Taux d'absence",
+        "noShows": "absences",
+        "newPatients": "nouveaux patients",
+        "firstVisitRate": "Taux de première visite",
+        "ofTotalAppointments": "des rendez-vous totaux",
+        "appointmentsInPeriod": "Rendez-vous dans la période",
+        "excludingCancelled": "hors annulés",
+        "appointments": "rendez-vous",
+        "byDayOfWeek": "Par jour de la semaine",
+        "statusBreakdown": "Répartition par statut",
+        "pending": "en attente"
+      },
+      "analytics": {
+        "funnel": "Entonnoir de statuts",
+        "funnelDesc": "Répartition des rendez-vous par statut dans la période",
+        "waitingTimes": "Temps d'attente",
+        "waitingTimesDesc": "Minutes entre l'arrivée du patient et l'entrée en fauteuil",
+        "punctuality": "Ponctualité des patients",
+        "punctualityDesc": "Écart entre l'heure prévue et l'arrivée réelle",
+        "durationVariance": "Durée prévue vs réelle",
+        "durationVarianceDesc": "Comparaison entre la durée prévue et le temps réel en fauteuil",
+        "samples": "Échantillons",
+        "average": "Moyenne",
+        "median": "Médiane",
+        "p90": "P90",
+        "avgDelta": "Delta moyen",
+        "medianDelta": "Delta médian",
+        "onTime": "% à l'heure",
+        "avgOverrun": "Dépassement moyen",
+        "overrunCount": "Nombre de dépassements",
+        "underCount": "Nombre de sous-temps",
+        "completionRate": "Complétion",
+        "noShowRate": "Absence",
+        "cancellationRate": "Annulation",
+        "punctuality_early": "En avance (<-5)",
+        "punctuality_on_time": "À l'heure (±5)",
+        "punctuality_late_short": "En retard (5-15)",
+        "punctuality_late_long": "En retard (>15)"
+      },
+      "tabs": {
+        "overview": "Vue d'ensemble",
+        "activity": "Activité",
+        "quality": "Qualité"
+      },
+      "hero": {
+        "inPeriod": "dans la période"
+      },
+      "filters": {
+        "cabinet": "Cabinet",
+        "professional": "Professionnel",
+        "custom": "Plage personnalisée",
+        "all": "Tous",
+        "clear": "Effacer les filtres"
+      },
+      "empty": {
+        "title": "Aucune donnée pour cette période",
+        "desc": "Essayez une plage de dates plus large ou supprimez les filtres."
+      }
+    }
+  },
+  "invoiceSeries": {
+    "title": "Séries de facturation",
+    "description": "Configurer les préfixes et la numérotation des factures",
+    "regularInvoices": "Factures",
+    "creditNotes": "Avoirs",
+    "new": "Nouvelle série",
+    "newTitle": "Nouvelle série de {type}",
+    "editTitle": "Modifier la série",
+    "prefix": "Préfixe",
+    "prefixHint": "ex. FAC, AVO. L'année sera ajoutée automatiquement.",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Description optionnelle de la série...",
+    "nextNumber": "Numéro suivant",
+    "preview": "Aperçu",
+    "resetYearly": "Réinitialisation annuelle",
+    "resetYearlyLabel": "Réinitialiser la numérotation chaque année",
+    "setAsDefault": "Définir par défaut",
+    "activeLabel": "Série active",
+    "showInactive": "Afficher les inactives",
+    "noItems": "Aucune série configurée",
+    "resetCounter": "Réinitialiser le compteur",
+    "currentNumber": "Numéro actuel",
+    "seriesPrefix": "Préfixe de la série",
+    "newNumber": "Nouveau numéro",
+    "newNumberHint": "Le numéro doit être supérieur au plus grand numéro existant dans cette série.",
+    "resetWarningTitle": "Attention",
+    "resetWarning": "Cette action sera enregistrée dans le journal d'audit et ne peut pas être annulée.",
+    "confirmReset": "Réinitialiser le compteur",
+    "created": "Série créée avec succès",
+    "saved": "Série mise à jour avec succès",
+    "resetSuccess": "Compteur réinitialisé avec succès"
+  },
+  "documents": {
+    "title": "Documents",
+    "add": "Ajouter",
+    "edit": "Modifier le document",
+    "upload": "Télécharger un document",
+    "uploading": "Téléchargement...",
+    "empty": "Aucun document pour le moment",
+    "uploadFirst": "Télécharger le premier document",
+    "types": {
+      "consent": "Consentement",
+      "id_scan": "Pièce d'identité",
+      "insurance": "Assurance",
+      "report": "Rapport",
+      "referral": "Orientation",
+      "other": "Autre"
+    },
+    "fields": {
+      "type": "Type",
+      "title": "Titre",
+      "titlePlaceholder": "Titre du document",
+      "description": "Description",
+      "descriptionPlaceholder": "Notes facultatives"
+    },
+    "dropzone": {
+      "hint": "Glissez-déposez un fichier ici, ou cliquez pour sélectionner"
+    },
+    "filter": {
+      "allTypes": "Tous les types"
+    },
+    "deleteConfirm": {
+      "title": "Supprimer le document",
+      "message": "Êtes-vous sûr de vouloir supprimer ce document ? Cette action est irréversible."
+    },
+    "fetchError": "Erreur lors du chargement des documents",
+    "uploadSuccess": "Document téléchargé avec succès",
+    "uploadError": "Erreur lors du téléchargement du document",
+    "downloadError": "Erreur lors du téléchargement du document",
+    "deleteSuccess": "Document supprimé",
+    "deleteError": "Erreur lors de la suppression du document",
+    "updateSuccess": "Document mis à jour",
+    "updateError": "Erreur lors de la mise à jour du document",
+    "viewer": {
+      "loading": "Chargement du document...",
+      "error": "Impossible de charger le document",
+      "downloadInstead": "Télécharger à la place",
+      "unsupported": "Aperçu non disponible pour ce type de fichier",
+      "zoomOut": "Zoom arrière",
+      "zoomIn": "Zoom avant",
+      "resetZoom": "Réinitialiser à 100%",
+      "zoomHint": "Ctrl + molette pour zoomer"
+    },
+    "typeDesc": {
+      "consent": "Document signé",
+      "id_scan": "DNI / passeport",
+      "insurance": "Police ou carte",
+      "report": "Rapport clinique",
+      "referral": "Lettre d'orientation",
+      "other": "Non classifié"
+    },
+    "errors": {
+      "mime": "Type de fichier non autorisé. Seuls PDF, JPG ou PNG sont acceptés.",
+      "size": "Le fichier dépasse 10 Mo."
+    },
+    "pdfPreviewHint": "Aperçu disponible après l'envoi",
+    "uploadHelp": "Classez le fichier pour qu'il apparaisse dans la bonne catégorie."
+  },
+  "photoGallery": {
+    "title": "Galerie du patient",
+    "add": "Ajouter une photo",
+    "empty": "Aucune photo pour le moment",
+    "uploadFirst": "Envoyer la première",
+    "showingOf": "{count} sur {total} photos",
+    "upload": "Envoyer une photo",
+    "uploadHelp": "Classez pour qu'elle apparaisse dans la bonne catégorie",
+    "dropHere": "Glissez une photo ici ou cliquez",
+    "category": "Type",
+    "subtype": "Vue",
+    "titlePlaceholder": "Frontal intraoral — 02/05",
+    "capturedAt": "Date",
+    "exifHint": "Automatique depuis l'EXIF",
+    "cat": {
+      "all": "Toutes",
+      "intraoral": "Intraorale",
+      "extraoral": "Extraorale",
+      "xray": "Radiographie",
+      "clinical": "Avant/Après",
+      "other": "Autre"
+    },
+    "catDesc": {
+      "intraoral": "À l'intérieur de la bouche",
+      "extraoral": "Visage et profil",
+      "xray": "Image radiologique",
+      "clinical": "Comparaison de traitement",
+      "other": "Non classifié"
+    },
+    "sub": {
+      "frontal": "Frontal",
+      "lateral_left": "Latéral gauche",
+      "lateral_right": "Latéral droit",
+      "occlusal_upper": "Occlusale supérieure",
+      "occlusal_lower": "Occlusale inférieure",
+      "palatal": "Palatin",
+      "lingual": "Lingual",
+      "smile": "Sourire",
+      "rest": "Repos",
+      "frontal_face": "Frontal",
+      "profile_left": "Profil gauche",
+      "profile_right": "Profil droit",
+      "three_quarter_left": "3/4 gauche",
+      "three_quarter_right": "3/4 droit",
+      "panoramic": "Panoramique",
+      "periapical": "Périapicale",
+      "bitewing": "Bitewing",
+      "ceph_lat": "Céphalo latéral",
+      "ceph_pa": "Céphalo PA",
+      "cbct": "CBCT",
+      "occlusal_xray": "Occlusale Rx",
+      "before": "Avant",
+      "after": "Après",
+      "progress": "Progrès",
+      "reference": "Référence",
+      "portrait": "Portrait",
+      "document_scan": "Document",
+      "model_photo": "Modèle"
+    },
+    "compare": {
+      "before": "Avant",
+      "after": "Après"
+    },
+    "pair": {
+      "pickHint": "Choisissez la photo à apparier :",
+      "noCandidates": "Aucune photo disponible. Envoyez-en une autre d'abord.",
+      "paired": "Appariée",
+      "exitCompare": "Quitter la comparaison",
+      "compare": "Comparer",
+      "unpair": "Retirer",
+      "pair": "Apparier avant/après"
+    }
+  },
+  "help": {
+    "label": "Aide",
+    "openHelp": "Ouvrir l'aide",
+    "drawerTitle": "Aide pour cette page",
+    "unavailable": "Aucune aide contextuelle disponible pour cette page pour le moment.",
+    "openFullManual": "Ouvrir le manuel complet"
+  },
+  "charts": {
+    "trend": {
+      "ariaLabel": "Tendance sur {count} points"
+    },
+    "donut": {
+      "ariaLabel": "Diagramme circulaire, {count} segments"
+    }
+  }
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -115,7 +115,8 @@ export default defineNuxtConfig({
   i18n: {
     locales: [
       { code: 'en', name: 'English', file: 'en.json' },
-      { code: 'es', name: 'Español', file: 'es.json' }
+      { code: 'es', name: 'Español', file: 'es.json' },
+      { code: 'fr', name: 'Français', file: 'fr.json' }
     ],
     defaultLocale: 'en',
     lazy: true,


### PR DESCRIPTION
## Summary

- Closes #5: add complete French translation to support clinics in France and French-speaking countries
- Created `frontend/i18n/locales/fr.json` (2912 lines) translating all keys from `es.json`
- Created `fr.json` for 11 backend module layers and registered the locale in each module's `nuxt.config.ts`
- Fixed ~30 hardcoded Spanish/English strings in Vue components across 6 modules, replacing them with `$t()` i18n calls
- Fixed Nuxt UI locale injection so "Switch to dark mode" / "Switch to light mode" translates correctly in FR
- Added 30 missing `invoiceSeries.*` i18n keys to `en.json` and `fr.json` — settings/billing and settings/invoice-series pages no longer show raw keys
- Added `"fr"` keys to all backend seed data: 10 catalog categories, 129 treatment items, 16 session labels, clinical note templates, recall scenarios, and timeline events — verified via `seed_demo.py --lang fr`
- Fixed communications language dropdown: added French to backend validation pattern (`^(es|en)$` → `^(es|en|fr)$`) and frontend options in `ClinicLanguagePage.vue`
- Fixed copilot settings "Most-used tools" displaying raw tool names: added `toolNames` i18n map in all 3 copilot locale files and `toolDisplayName()` helper in `CopilotSettingsPanel.vue`
- Fixed recall settings "Traitement → motif" section: category labels now resolve via catalog categories (`useCatalog`) with fallback to treatment constants

## Modules touched

patients, payments, periodontogram, recalls, copilot, schedules, notifications, clinical_notes, media, catalog, billing, verifactu, migration_import, whatsapp_kapso, accounting_export

## Checklist

### Always

- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
- [x] `cd backend && ruff check . && ruff format --check .` passes
- [x] `cd frontend && npm run lint` passes
- [x] Tests added or updated when behaviour changed *(no behaviour changes — translation only)*
- [x] No cross-module imports outside `manifest.depends`

### If a touched module already exists

- [x] Its `backend/app/modules/<name>/CHANGELOG.md` updated under `## Unreleased`

### Backend — seed data
- Add full French support to `demo_data.py`: clinic (Clinique Dentaire Démo, Paris), 5 users with French names, 15 patients with French names/phones/medical data, all appointment types and invoice series
- `seed_demo.py` accepts `--lang fr` flag (default: `en`)
- `scaffold_module_docs.py` generates `fr/` doc stubs for new modules
- `catalog/seed.py`: add `"fr"` keys to all 10 treatment categories, 129 treatment items, and 16 session labels
- `catalog/service.py`: add `"fr"` keys to DEFAULT_VAT_TYPES
- `clinical_notes/seed.py`: convert admin/diagnosis/treatment/plan note bodies to `t()` i18n dicts (es/en/fr)
- `patient_timeline/seed.py`: convert timeline event titles to `t()` i18n dicts (es/en/fr); fix name resolution chain to include `"fr"`
- `recalls/seed.py`: convert scenario notes and attempt notes to `t()` i18n dicts (es/en/fr)
- `config.py`: add `extra="ignore"` to SettingsConfigDict to tolerate Docker-only env vars

### Billing module i18n
- Add 30 `invoiceSeries.*` keys to `en.json` and `fr.json` — `es.json` already had them; settings/billing and settings/invoice-series pages now render correctly in all three locales

### Email templates
- Add `backend/templates/email/` for both `fr/` and `en/` — 11 translated templates (appointment confirmations, budget emails, copilot digest,
Verifactu alerts, welcome)
- Make `base.html` footer locale-aware via `footer_sent_by` variable

### Docs
- Add `README.fr.md` — full French translation of the README
- Add `README.es.md` — full Spanish translation of the README

## Test plan

1. `npm run dev` in frontend, log in.
2. Switch language to French via Settings → Idioma
3. Verify dashboard, patients list, patient detail (all tabs), periodontogram, payments, recalls all render in French
4. Verify ColorMode toggle shows "Passer en mode sombre" / "Passer en mode clair"
5. Verify Settings → Facturation (Billing) — invoice-series and vat-types pages render in French, no raw i18n keys
6. Toggle to English and Spanish — confirm no regressions
7. Run `cd backend && uv run python scripts/seed_demo.py --lang fr` — verify French seed data (clinic: "Clinique Dentaire Démo", users: "Marie Dubois Laurent", catalog: "Diagnostic", "Chirurgie", "Blanchiment en cabinet", etc.)
8. Run `seed_demo.py --lang es` and `--lang en` — confirm no regressions
