### PR TITLE
fix(tests,i18n): stop CI connection exhaustion; correct French dental terms

### DIFF
--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: correct French dental terminology in seed data (Contention,
+  Bracket, Scellement de sillons, Fluoration, Diagnostic, ...).
+
 - i18n: add French names/descriptions to seed data (categories,
   treatment items, session labels, VAT type names).
 

--- a/backend/app/modules/catalog/seed.py
+++ b/backend/app/modules/catalog/seed.py
@@ -63,7 +63,7 @@ VAT_TYPES: list[dict[str, Any]] = [
 CATEGORIES: list[dict[str, Any]] = [
     {
         "key": "diagnostico",
-        "names": {"es": "Diagnóstico", "en": "Diagnostic", "fr": "Diagnostique"},
+        "names": {"es": "Diagnóstico", "en": "Diagnostic", "fr": "Diagnostic"},
         "descriptions": {
             "es": "Servicios de diagnóstico y evaluación",
             "en": "Diagnostic and evaluation services",
@@ -214,7 +214,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "descriptions": {
                 "es": "Consulta inicial con exploración y diagnóstico",
                 "en": "Initial consultation with examination and diagnosis",
-                "fr": "Consulte initiale avec examen et diagnostique",
+                "fr": "Consultation initiale avec examen et diagnostique",
             },
             "treatment_scope": "global_mouth",
             "is_diagnostic": False,
@@ -352,7 +352,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "PREV-FLUOR",
-            "names": {"es": "Fluorización", "en": "Fluoride Application", "fr": "Fluoruration"},
+            "names": {"es": "Fluorización", "en": "Fluoride Application", "fr": "Fluoration"},
             "treatment_scope": "global_mouth",
             "default_price": Decimal("25.00"),
             "default_duration_minutes": 15,
@@ -378,7 +378,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Sellador de fosas y fisuras",
                 "en": "Pit and Fissure Sealant",
-                "fr": "Sillonnage des fissures",
+                "fr": "Scellement de sillons et fissures",
             },
             "treatment_scope": "tooth",
             "requires_surfaces": True,
@@ -1028,7 +1028,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
                     "labels": {
                         "es": "Limpieza y conformación",
                         "en": "Cleaning and shaping",
-                        "fr": "Nettoyage et évasage",
+                        "fr": "Nettoyage et mise en forme",
                     },
                     "default_price": Decimal("130.00"),
                 },
@@ -1449,7 +1449,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "SURG-FREN",
-            "names": {"es": "Frenectomía", "en": "Frenectomy", "fr": "Frenectomie"},
+            "names": {"es": "Frenectomía", "en": "Frenectomy", "fr": "Frénectomie"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 30,
@@ -1658,7 +1658,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Bracket individual (reposición)",
                 "en": "Bracket (replacement)",
-                "fr": "Baguette individuelle (remplacement)",
+                "fr": "Bracket individuel (remplacement)",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("45.00"),
@@ -1684,7 +1684,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "internal_code": "ORTO-RET-FIX",
-            "names": {"es": "Retenedor fijo", "en": "Fixed retainer", "fr": "Relieur fixe"},
+            "names": {"es": "Retenedor fijo", "en": "Fixed retainer", "fr": "Contention fixe"},
             "treatment_scope": "tooth",
             "default_price": Decimal("180.00"),
             "default_duration_minutes": 45,
@@ -1699,7 +1699,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Retenedor removible",
                 "en": "Removable retainer",
-                "fr": "Relieur amovible",
+                "fr": "Contention amovible",
             },
             "treatment_scope": "global_arch",
             "default_price": Decimal("120.00"),
@@ -1728,7 +1728,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Cementado de bracket",
                 "en": "Bracket bonding",
-                "fr": "Collage de baguette",
+                "fr": "Collage de bracket",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("35.00"),
@@ -1744,7 +1744,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Descementado de brackets",
                 "en": "Bracket removal",
-                "fr": "Désinstallation de bagues",
+                "fr": "Dépose des bagues",
             },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("120.00"),
@@ -1873,7 +1873,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Eliminación de pigmentación",
                 "en": "Pigmentation removal",
-                "fr": "Élimination des pigmentation",
+                "fr": "Élimination des pigmentations",
             },
             "treatment_scope": "global_mouth",
             "default_price": Decimal("90.00"),
@@ -2009,7 +2009,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Fluorización pediátrica",
                 "en": "Pediatric fluoride",
-                "fr": "Fluoruration pédiatrique",
+                "fr": "Fluoration pédiatrique",
             },
             "treatment_scope": "tooth",
             "default_price": Decimal("25.00"),
@@ -2022,7 +2022,7 @@ TREATMENTS: dict[str, list[dict[str, Any]]] = {
             "names": {
                 "es": "Sellador pediátrico",
                 "en": "Pediatric sealant",
-                "fr": "Sillonnage pédiatrique",
+                "fr": "Scellement de sillons pédiatrique",
             },
             "treatment_scope": "tooth",
             "requires_surfaces": True,

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: correct French terminology in `fr.json` (Diagnostic).
+
 - i18n: add French locale (`fr.json`); add French translations to seed
   data; add `body_i18n_key` to template responses so template bodies
   resolve in the active locale. Labels now resolve via

--- a/backend/app/modules/clinical_notes/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/clinical_notes/frontend/i18n/locales/fr.json
@@ -2,7 +2,7 @@
   "clinicalNotes": {
     "types": {
       "administrative": "Administratif",
-      "diagnosis": "Diagnostique",
+      "diagnosis": "Diagnostic",
       "treatment": "Traitement",
       "treatment_plan": "Plan",
       "appointment_clinical": "Clinique",
@@ -110,12 +110,12 @@
       }
     },
     "templateBodies": {
-      "endo_single_visit": "Diagnostique : \nAnesthésie : \nCanaux localisés : \nLongueur de travail : \nObturation : \nPost-op : ",
+      "endo_single_visit": "Diagnostic : \nAnesthésie : \nCanaux localisés : \nLongueur de travail : \nObturation : \nPost-op : ",
       "endo_multi_visit": "Séance : \nCanaux traités : \nMédicament intracanalaire : \nProchain rendez-vous : ",
       "perio_scaling": "Quadrants traités : \nProfondeur de sondage : \nSangrado au sondage : \nConsignes d'hygiène : ",
       "implant_placement": "Implant (marque / diamètre / longueur) : \nCouple final (Ncm) : \nStabilité primaire : \nGreffe : \nPost-op : ",
       "diagnosis_caries": "Observation : carie \nProfondeur : \nSymptômes : \nTest de vitalité : \nTraitement suggéré : ",
-      "diagnosis_periapical": "Lésion périapicale \nDent : \nRadiographie : \nPercussion, palpation : \nDiagnostique : ",
+      "diagnosis_periapical": "Lésion périapicale \nDent : \nRadiographie : \nPercussion, palpation : \nDiagnostic : ",
       "admin_phone_call": "Appel du patient : \nMotif : \nAction entreprise : \nSuivi : ",
       "admin_reschedule": "Demande de report : \nDate actuelle : \nNouvelle proposition : ",
       "general_follow_up": "Observations : \nProcédure réalisée : \nConsignes au patient : "

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: correct French wording in seed note (Contrôle mensuel).
+
 - i18n: add French translations to seed data; fix `t()` dict pattern.
 
 - fix(security): reject `create` when `patient_id` belongs to another

--- a/backend/app/modules/recalls/seed.py
+++ b/backend/app/modules/recalls/seed.py
@@ -108,7 +108,7 @@ _SCENARIOS = (
         "note": {
             "es": "Revisión mensual de ortodoncia.",
             "en": "Monthly orthodontic review.",
-            "fr": "Revue mensuelle d'orthodontie.",
+            "fr": "Contrôle mensuel d'orthodontie.",
         },
     },
     {

--- a/backend/app/seeds/demo_data.py
+++ b/backend/app/seeds/demo_data.py
@@ -1565,7 +1565,7 @@ _APPT_LOOK_BY_PREFIX: list[tuple[str, dict]] = [
     (
         "DX",
         {
-            "name": {"es": "Diagnóstico", "en": "Diagnosis", "fr": "Diagnostique"},
+            "name": {"es": "Diagnóstico", "en": "Diagnosis", "fr": "Diagnostic"},
             "duration": 30,
             "color": "#3B82F6",
         },

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ os.environ["TESTING"] = "true"
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from app.config import settings
 
@@ -16,6 +17,7 @@ from app.config import settings
 from app.core.auth.models import Clinic, ClinicMembership, User  # noqa: F401
 from app.core.plugins.loader import load_modules
 from app.database import Base, get_db
+from app.database import engine as app_engine
 from app.main import app
 from app.modules.agenda.models import (  # noqa: F401
     Appointment,
@@ -96,11 +98,26 @@ load_modules(app)
 TEST_DATABASE_URL = settings.DATABASE_URL
 
 
+@pytest_asyncio.fixture(autouse=True)
+async def _dispose_app_engine() -> AsyncGenerator[None, None]:
+    """Dispose the global app engine after every test.
+
+    Event handlers (e.g. patient_timeline) use the module-level
+    ``app.database.engine``; its pooled connections stay bound to the
+    test's event loop and leak once the loop closes, exhausting CI
+    Postgres near the end of the suite (TooManyConnectionsError).
+    """
+    yield
+    await app_engine.dispose()
+
+
 @pytest_asyncio.fixture
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
     """Create a fresh database session for each test."""
     # Create a new engine for each test to avoid connection conflicts
-    test_engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    # NullPool: with one engine per test, pooled idle connections pile up
+    # across ~800 tests and CI Postgres hits max_connections (100).
+    test_engine = create_async_engine(TEST_DATABASE_URL, echo=False, poolclass=NullPool)
     test_session_maker = async_sessionmaker(
         test_engine, class_=AsyncSession, expire_on_commit=False
     )

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -375,7 +375,7 @@
     "collect": "Encaisser",
     "viewLedger": "Ouvrir le grand livre",
     "noPayments": "Aucun mouvement",
-    "diagnoses": "Diagnostiques",
+    "diagnoses": "Diagnostics",
     "pending": "non traité",
     "noDiagnoses": "Aucune anomalie en attente",
     "openOdontogram": "Ouvrir l'odontogramme",
@@ -492,12 +492,12 @@
       "categories": {
         "common": "Courant",
         "restorative": "Restauratrice",
-        "diagnostic": "Diagnostique",
+        "diagnostic": "Diagnostic",
         "orthodontic": "Orthodontie",
         "periodontic": "Parodontie",
         "position": "Position",
         "other": "Autre",
-        "diagnostico": "Diagnostique",
+        "diagnostico": "Diagnostic",
         "restauradora": "Restauratrice",
         "cirugia": "Chirurgie",
         "endodoncia": "Endodontie",
@@ -601,7 +601,7 @@
       "clickToEdit": "Cliquer pour modifier"
     },
     "planning": "Planification",
-    "diagnosisMode": "Diagnostique",
+    "diagnosisMode": "Diagnostic",
     "treatmentList": {
       "title": "Liste des traitements",
       "noTreatments": "Aucun traitement enregistré"
@@ -653,7 +653,7 @@
   "clinical": {
     "modes": {
       "history": "Historique",
-      "diagnosis": "Diagnostique",
+      "diagnosis": "Diagnostic",
       "plans": "Plans de traitement",
       "appointments": "Rendez-vous"
     },
@@ -668,7 +668,7 @@
       "noConditions": "Aucune condition enregistrée",
       "startDiagnosis": "Sélectionnez une dent et ajoutez les conditions existantes",
       "generalConditions": "Conditions générales",
-      "readyToCreatePlan": "Diagnostique terminé ?",
+      "readyToCreatePlan": "Diagnostic terminé ?",
       "createPlan": "Créer un plan de traitement",
       "continuePlan": "Continuer le plan « {name} »",
       "selectPlan": "Sélectionner un plan",
@@ -1562,7 +1562,7 @@
       "assignedProfessional": "Professionnel assigné",
       "selectProfessional": "Sélectionner un professionnel",
       "diagnosisNotes": "Notes de diagnostique",
-      "diagnosisNotesPlaceholder": "Diagnostique et observations cliniques...",
+      "diagnosisNotesPlaceholder": "Diagnostic et observations cliniques...",
       "internalNotes": "Notes internes",
       "internalNotesPlaceholder": "Notes visibles uniquement par le personnel..."
     },


### PR DESCRIPTION
## Summary

Follow-up to #103.

**CI stability** — `backend-test` failed on `main` (and on 2 of the last 4 PR runs) with `asyncpg.exceptions.TooManyConnectionsError` in the four `test_patient_timeline.py` appointment tests, always at ~81% of the suite. Root cause: the `patient_timeline` event handlers use the module-level `app.database.engine`; with function-scoped event loops, its pooled connections stay bound to each test's loop and leak when the loop closes, accumulating until CI Postgres hits `max_connections` (100).

- `tests/conftest.py`: autouse fixture disposes the global app engine after every test.
- Per-test engines use `NullPool` so idle pooled connections stop piling up across ~800 tests.

**French dental terminology** — 26 corrections to the machine-translation errors that shipped in #103 (seed data + `fr.json` locales): `Diagnostique→Diagnostic`, `Relieur fixe/amovible→Contention fixe/amovible` (*relieur* = bookbinder), `Baguette→Bracket`, `Sillonnage→Scellement de sillons`, `Fluoruration→Fluoration`, `Frenectomie→Frénectomie`, `Désinstallation de bagues→Dépose des bagues`, `Consulte initiale→Consultation initiale`, `Élimination des pigmentation→pigmentations`, `Revue mensuelle→Contrôle mensuel`, `Nettoyage et évasage→mise en forme`.

## Test plan

1. CI `backend-test` green — the four `patient_timeline` tests are the regression probe for the connection leak.
2. `seed_demo.py --lang fr` shows corrected catalog names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)