### PR TITLE
fix(catalog): surface API error detail in useCatalog toasts

### DIFF
--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(frontend): error toasts in `useCatalog` now show the exact API
+  error `detail` (string or 422 validation list) instead of always
+  falling back to the generic "Error al crear/actualizar/eliminar"
+  message. Generic text remains the fallback for network errors.
+
 - i18n: correct French dental terminology in seed data (Contention,
   Bracket, Scellement de sillons, Fluoration, Diagnostic, ...).
 

--- a/backend/app/modules/catalog/frontend/composables/useCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useCatalog.ts
@@ -16,6 +16,24 @@ import type {
   TreatmentCatalogItemUpdate
 } from '~~/app/types'
 
+/**
+ * Extract the FastAPI error `detail` from a fetch error, so toasts can show
+ * the exact server message instead of a generic one. Returns null for
+ * network errors or unexpected bodies (caller falls back to generic text).
+ */
+function apiErrorDetail(e: unknown): string | null {
+  const detail = (e as { data?: { detail?: unknown } }).data?.detail
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail)) {
+    // 422 validation errors: [{loc: ["body", "field"], msg: "..."}]
+    const parts = (detail as Array<{ loc?: unknown[], msg?: string }>)
+      .map(d => [Array.isArray(d.loc) ? d.loc.slice(1).join('.') : '', d.msg].filter(Boolean).join(': '))
+      .filter(Boolean)
+    return parts.length ? parts.join('; ') : null
+  }
+  return null
+}
+
 export function useCatalog() {
   const api = useApi()
   const { t, locale } = useI18n()
@@ -94,7 +112,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.categoryCreateFailed'),
+          description: apiErrorDetail(e) || t('catalog.categoryCreateFailed'),
           color: 'error'
         })
       }
@@ -133,7 +151,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.categoryUpdateFailed'),
+          description: apiErrorDetail(e) || t('catalog.categoryUpdateFailed'),
           color: 'error'
         })
       }
@@ -166,7 +184,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.categoryDeleteFailed'),
+          description: apiErrorDetail(e) || t('catalog.categoryDeleteFailed'),
           color: 'error'
         })
       }
@@ -267,7 +285,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.itemCreateFailed'),
+          description: apiErrorDetail(e) || t('catalog.itemCreateFailed'),
           color: 'error'
         })
       }
@@ -306,7 +324,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.itemUpdateFailed'),
+          description: apiErrorDetail(e) || t('catalog.itemUpdateFailed'),
           color: 'error'
         })
       }
@@ -339,7 +357,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.itemDeleteFailed'),
+          description: apiErrorDetail(e) || t('catalog.itemDeleteFailed'),
           color: 'error'
         })
       }


### PR DESCRIPTION
## What

Error toasts in `useCatalog` always showed a generic i18n message
(`catalog.itemCreateFailed`, …), swallowing the server's actual reason —
duplicate code, category still in use, 422 field validation.

Adds an `apiErrorDetail()` helper that pulls FastAPI's `detail` off the
fetch error:

- `string` → shown as-is
- `array` (422) → flattened to `field: msg; field: msg`, dropping the
  leading `body` from `loc`
- anything else / network error → `null`, caller falls back to the
  existing generic text

Applied to the 6 toast sites (category + item × create/update/delete).

Continues the silent-failure tranche from #100.

## Notes

- No API, permission, event or schema change — frontend-only.
- `catalog/CHANGELOG.md` updated under `## Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)