### PR TITLE
feat(deploy): prebuilt images on ghcr + one-command production install

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,26 @@
+# DentalPin — production. Copy to .env next to docker-compose.prod.yml.
+
+# Public address of your install. Use https:// with a domain that already
+# points at this server and Caddy provisions TLS on first boot.
+# For a local trial, leave it as http://localhost.
+PUBLIC_URL=https://clinic.example.com
+
+# Pin a release instead of tracking latest once you are in production.
+DENTALPIN_VERSION=latest
+
+# Database
+POSTGRES_DB=dental_clinic
+POSTGRES_USER=dental
+POSTGRES_PASSWORD=
+
+# Generate each with: openssl rand -hex 32
+SECRET_KEY=
+BUDGET_PUBLIC_SECRET_KEY=
+
+# AI Copilot (optional). Without it the app runs, the assistant does not.
+OPENAI_API_KEY=
+
+# Load the demo clinic on first boot to look around before going live.
+# admin@demo.clinic / demo1234. Leave at 0 for a real clinic.
+SEED_ON_STARTUP=0
+SEED_LANG=es

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: Release
+
+# Tag -> publish images to ghcr.io -> publish the GitHub Release.
+#
+# ponytail: amd64 only. Covers the x86 VPS every self-hoster actually
+# rents (Hetzner/DO/Vultr/OVH). Add `linux/arm64` to `platforms` when
+# someone opens an issue asking for it — native ARM runners make it
+# cheap, QEMU emulation of the Nuxt build does not.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)publish, e.g. v2.0.0"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - name: frontend
+            # Needs the repo root: the Nuxt build copies module layers
+            # out of backend/app/modules (see frontend/Dockerfile.prod).
+            context: .
+            dockerfile: ./frontend/Dockerfile.prod
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    needs: images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Extract the CHANGELOG section for this version
+        id: notes
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          # Everything between "## [<version>]" and the next "## [" heading.
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { inside = 1; next }
+            inside && /^## \[/     { exit }
+            inside                 { print }
+          ' CHANGELOG.md > notes.md
+          if [ ! -s notes.md ]; then
+            echo "No CHANGELOG section for $VERSION — falling back to generated notes only."
+            : > notes.md
+          fi
+          {
+            echo ""
+            echo "## Install"
+            echo ""
+            echo '```bash'
+            echo "curl -O https://raw.githubusercontent.com/${{ github.repository }}/$TAG/docker-compose.prod.yml"
+            echo "curl -o .env https://raw.githubusercontent.com/${{ github.repository }}/$TAG/.env.prod.example"
+            echo "# edit .env (DOMAIN, POSTGRES_PASSWORD, SECRET_KEY), then:"
+            echo "docker compose -f docker-compose.prod.yml up -d"
+            echo '```'
+            echo ""
+            echo "Images: \`ghcr.io/${{ github.repository }}-backend:$VERSION\` · \`ghcr.io/${{ github.repository }}-frontend:$VERSION\`"
+          } >> notes.md
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file notes.md \
+            --generate-notes \
+            --verify-tag \
+            || gh release edit "$TAG" --notes-file notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ frontend as a Nuxt layer under its own Python package.
 
 ### Added
 
+- **Prebuilt images and a one-command install.** Tagging a release now
+  builds and publishes `ghcr.io/martinezsalmeron/dentalpin-backend` and
+  `-frontend`, and publishes the GitHub Release with notes taken from
+  this file. `docker-compose.prod.yml` runs the stack straight from those
+  images with no clone and no build; a Caddy container fronts both
+  services on a single origin, so TLS is provisioned automatically from
+  `PUBLIC_URL` and there is no CORS to configure. One image serves every
+  deployment — Nuxt overrides `runtimeConfig.public.apiBaseUrl` from
+  `NUXT_PUBLIC_API_BASE_URL` at boot rather than baking the URL in.
+
 - **First-time setup assistant** (issue #85). A fresh install (no users)
   now bootstraps from the UI: `GET /api/v1/auth/setup/status` reports
   whether the system is initialized, and `POST /api/v1/auth/setup`

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,23 @@
+# Single origin for the whole app. PUBLIC_URL doubles as the site
+# address: give it an https host and Caddy provisions the certificate
+# itself; leave it at http://localhost and it serves plain HTTP.
+
+{$PUBLIC_URL:http://localhost} {
+	handle /api/* {
+		reverse_proxy backend:8000 {
+			# The copilot streams SSE; without this Caddy buffers the
+			# response and the chat appears frozen until the turn ends.
+			flush_interval -1
+		}
+	}
+
+	handle /health* {
+		reverse_proxy backend:8000
+	}
+
+	handle {
+		reverse_proxy frontend:3000
+	}
+
+	encode gzip
+}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,30 @@ Join our [**Telegram channel**](https://t.me/dentalpin) for support, installatio
 ### Settings
 ![Settings](docs/screenshots/settings.png)
 
-## Quick Start
+## Install
+
+Prebuilt images, no clone, no build. On any server with Docker:
+
+```bash
+curl -O https://raw.githubusercontent.com/martinezsalmeron/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/martinezsalmeron/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/martinezsalmeron/dentalpin/main/.env.prod.example
+
+# Set PUBLIC_URL, POSTGRES_PASSWORD and SECRET_KEY in .env, then:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Point a domain at the server, set `PUBLIC_URL=https://your-domain`, and TLS is
+provisioned on first boot — Caddy fronts both services on a single origin, so
+there is no CORS and no certificate to renew. Set `SEED_ON_STARTUP=1` to load
+the demo clinic and look around before going live.
+
+Images: [`dentalpin-backend`](https://github.com/martinezsalmeron/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/martinezsalmeron/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Quick Start (development)
+
+Builds from source with hot reload:
 
 ```bash
 # Start services

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,96 @@
+# Production stack from prebuilt images. No repo clone, no build.
+#
+#   curl -O https://raw.githubusercontent.com/martinezsalmeron/dentalpin/main/docker-compose.prod.yml
+#   curl -O https://raw.githubusercontent.com/martinezsalmeron/dentalpin/main/Caddyfile
+#   curl -o .env https://raw.githubusercontent.com/martinezsalmeron/dentalpin/main/.env.prod.example
+#   # edit .env, then:
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# Caddy fronts both services on a single origin, so the browser only ever
+# talks to PUBLIC_URL: no CORS to configure, and TLS is provisioned
+# automatically from Let's Encrypt when PUBLIC_URL is a real https host.
+
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-dental_clinic}
+      POSTGRES_USER: ${POSTGRES_USER:-dental}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dental} -d ${POSTGRES_DB:-dental_clinic}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  backend:
+    image: ghcr.io/martinezsalmeron/dentalpin-backend:${DENTALPIN_VERSION:-latest}
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-dental}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-dental_clinic}
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env}
+      BUDGET_PUBLIC_SECRET_KEY: ${BUDGET_PUBLIC_SECRET_KEY:-}
+      ENVIRONMENT: production
+      ALLOWED_ORIGINS: ${PUBLIC_URL:-http://localhost}
+      STORAGE_BACKEND: local
+      STORAGE_LOCAL_PATH: /app/storage
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      # Seeds the demo clinic on first boot. Leave at 0 for a real clinic.
+      SEED_ON_STARTUP: ${SEED_ON_STARTUP:-0}
+      SEED_LANG: ${SEED_LANG:-es}
+    volumes:
+      - storage_data:/app/storage
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=2).status == 200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+  frontend:
+    image: ghcr.io/martinezsalmeron/dentalpin-frontend:${DENTALPIN_VERSION:-latest}
+    environment:
+      # Nuxt overrides runtimeConfig.public.apiBaseUrl from this at boot,
+      # so one image serves every deployment — nothing is baked in.
+      NUXT_PUBLIC_API_BASE_URL: ${PUBLIC_URL:-http://localhost}
+      API_BASE_URL_SERVER: http://backend:8000
+      NUXT_PUBLIC_DOCS_URL: ${DOCS_URL:-https://docs.dentalpin.com}
+    depends_on:
+      backend:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      PUBLIC_URL: ${PUBLIC_URL:-http://localhost}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+      - backend
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  storage_data:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Why

112 unique clones in 14 days against 31 stars all-time. Roughly three times
more people try to install DentalPin every fortnight than have ever starred
it, and every one of them hits `git clone` + build both images. Our own FAQ
puts that at thirty minutes.

## What

- **`.github/workflows/release.yml`** — on `v*` tags: build and push
  `dentalpin-backend` / `dentalpin-frontend` to ghcr, then publish the
  GitHub Release with notes pulled from the matching `CHANGELOG.md`
  section plus GitHub's generated commit list. `workflow_dispatch` takes
  a tag so `v2.0.0` (tagged, never released) can be backfilled.
- **`docker-compose.prod.yml` + `Caddyfile`** — runs the stack from the
  published images. Caddy fronts frontend and backend on one origin:
  `/api/*` and `/health*` to the backend, everything else to Nuxt. TLS is
  provisioned from `PUBLIC_URL` on first boot.
- **`.env.prod.example`** — three values to fill in.
- README: an `## Install` section above the dev quick start.

Install goes to: download three files, edit three values, `docker compose up -d`.

## One image for every deployment

`frontend/Dockerfile.prod` takes `API_BASE_URL` as a build arg, which would
normally mean baking one deployment's URL into a public image. It doesn't:
`nuxt.config.ts` declares `runtimeConfig.public.apiBaseUrl`, so Nuxt
overrides it from `NUXT_PUBLIC_API_BASE_URL` at boot and the build arg is
only a default. No code change needed — verified below.

## Verification

Built both images locally under the ghcr names, ran the prod compose in an
isolated project, all four services healthy:

- `/health` → 200 and `/api/v1` → 200 through Caddy
- `POST /api/v1/auth/login` with the demo admin → 200 + token
- `GET /api/v1/patients` with that token → 200, 15 seeded patients
- `/login` SSR payload carries `apiBaseUrl: "http://localhost"` — the
  runtime value, not the `http://localhost:8000` compiled into the image

`docker compose config` and `caddy validate` both clean.

## Deliberately not here

- **amd64 only.** Covers the x86 VPS self-hosters actually rent. arm64 goes
  in when someone asks; QEMU-emulating the Nuxt build to pre-empt that is
  not worth the CI minutes.
- Package visibility on ghcr has to be flipped to public once by hand after
  the first run — GitHub gives no API for it before the package exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4