### PR TITLE
chore(github): issue templates, security policy, funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://www.dentalpin.com/en/pricing"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something is broken
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Installation trouble is usually faster to sort out in
+        [Q&A](https://github.com/martinezsalmeron/dentalpin/discussions/categories/q-a)
+        or on [Telegram](https://t.me/dentalpin). Use this form when the
+        software itself misbehaves.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: And what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Log in as receptionist
+        2. Open the weekly schedule
+        3. Drag an appointment onto an occupied slot
+        4. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release tag, or `git rev-parse --short HEAD` for a source checkout.
+      placeholder: v2.0.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How are you running it
+      options:
+        - docker-compose.prod.yml (prebuilt images)
+        - docker-compose.yml (built from source)
+        - Coolify
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        `docker compose logs backend --tail 50`. Scrub patient data before
+        pasting — this is a public tracker.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Installation help and questions
+    url: https://github.com/martinezsalmeron/dentalpin/discussions/categories/q-a
+    about: Anything that starts with "how do I" — answers stay searchable here.
+  - name: Telegram channel
+    url: https://t.me/dentalpin
+    about: Live chat with other clinics and the maintainers.
+  - name: Security vulnerability
+    url: https://github.com/martinezsalmeron/dentalpin/security/advisories/new
+    about: Report privately. Never in a public issue — this software holds patient data.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Propose something DentalPin should do
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve
+      description: |
+        Describe the situation in the clinic, not the solution. What
+        happens today, how often, and what it costs whoever deals with it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you have in mind
+    validations:
+      required: true
+
+  - type: input
+    id: module
+    attributes:
+      label: Which module
+      description: |
+        Leave blank if unsure. See
+        [docs/modules-catalog.md](https://github.com/martinezsalmeron/dentalpin/blob/main/docs/modules-catalog.md).
+      placeholder: agenda
+
+  - type: input
+    id: country
+    attributes:
+      label: Country
+      description: Matters for anything touching billing, tax or regulation.
+      placeholder: ES

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+DentalPin holds patient health data. Treat anything that touches
+authentication, tenant isolation or clinical records as high severity by
+default.
+
+## Reporting a vulnerability
+
+Report privately through
+[GitHub Security Advisories](https://github.com/martinezsalmeron/dentalpin/security/advisories/new).
+Never open a public issue for a vulnerability.
+
+Expect an acknowledgement within 72 hours. We will tell you what we found,
+what we intend to do, and when — and credit you in the advisory unless you
+ask us not to.
+
+## Supported versions
+
+The latest release on `main`. There are no long-term support branches yet;
+if you run a pinned `DENTALPIN_VERSION`, upgrading is the fix path.
+
+## What we consider a vulnerability
+
+- **Cross-tenant data access.** Any query reaching a row from another
+  `clinic_id`. Every multi-tenant table filters on it — a path that skips
+  the filter is a breach, not a bug.
+- **Permission bypass.** Reaching an endpoint, or an agent tool, without
+  the RBAC permission that gates it.
+- **Copilot boundary escapes.** The agent re-checks permissions at the
+  execution chokepoint and redacts PHI before anything reaches an LLM
+  provider. Getting past either is in scope, including prompt injection
+  that induces a tool call the calling user could not make themselves.
+- Authentication and token handling, stored/reflected XSS, SQL injection,
+  SSRF, and unauthenticated access to stored media.
+
+## Out of scope
+
+Findings against `demo.dentalpin.com` that only affect seeded demo data,
+missing hardening headers with no demonstrated impact, rate-limit tuning,
+and reports from automated scanners with no working proof of concept.


### PR DESCRIPTION
Repo hygiene. Small, independent of #109.

- **Issue forms** — bug report asks for the release tag and the install
  method (prebuilt images / source / Coolify), which were the two things
  most often missing. Feature request asks for the clinic situation and
  the country, since anything touching billing or tax depends on it.
- **Blank issues off**, chooser routes installation questions to
  [Q&A](https://github.com/martinezsalmeron/dentalpin/discussions/categories/q-a)
  and chat to Telegram. A Discussions thread stays searchable; an issue
  closed with "sorted it out on Telegram" helps nobody who hits the same
  wall later.
- **SECURITY.md** — private advisories (now enabled on the repo) instead
  of public issues. Scope written for software holding patient records:
  cross-tenant reads, permission bypass, and escapes past the copilot's
  RBAC re-check or PHI redaction.
- **FUNDING.yml** pointing at the services page.

## Already applied directly to repo settings

Discussions enabled (the pricing page had been linking to them for
weeks), homepage set to dentalpin.com, private vulnerability reporting
on, and topics from 3 to 20 — `emr`, `ehr`, `practice-management`,
`healthcare`, `mcp`, `self-hosted`, `verifactu`, `spain` and the rest.
Topic pages are how this repo already gets found; it was listed under
three of them.

## Note

SECURITY.md deliberately has no email fallback — `security@dentalpin.com`
does not exist. Say the word and I will add it once the alias does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4