### PR TITLE
fix(release): install snippet pointed at files the tag does not have

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,14 +94,21 @@ jobs:
             echo "No CHANGELOG section for $VERSION — falling back to generated notes only."
             : > notes.md
           fi
+          # These three are pulled from main, not from $TAG: a backfilled
+          # release predates them, and they are operational files whose
+          # latest version is the one you want. DENTALPIN_VERSION in .env
+          # is what pins the release you actually run.
+          RAW="https://raw.githubusercontent.com/${{ github.repository }}/main"
           {
             echo ""
             echo "## Install"
             echo ""
             echo '```bash'
-            echo "curl -O https://raw.githubusercontent.com/${{ github.repository }}/$TAG/docker-compose.prod.yml"
-            echo "curl -o .env https://raw.githubusercontent.com/${{ github.repository }}/$TAG/.env.prod.example"
-            echo "# edit .env (DOMAIN, POSTGRES_PASSWORD, SECRET_KEY), then:"
+            echo "curl -O $RAW/docker-compose.prod.yml"
+            echo "curl -O $RAW/Caddyfile"
+            echo "curl -o .env $RAW/.env.prod.example"
+            echo "# set PUBLIC_URL, POSTGRES_PASSWORD, SECRET_KEY"
+            echo "# and DENTALPIN_VERSION=$VERSION to pin this release, then:"
             echo "docker compose -f docker-compose.prod.yml up -d"
             echo '```'
             echo ""


### PR DESCRIPTION
Caught before triggering the first release.

The generated notes fetched `docker-compose.prod.yml` and
`.env.prod.example` from the release tag. Those files only landed on main
today, so any tag cut before them — `v2.0.0`, the one worth backfilling
first as a dry run — would have shipped an install block of three 404s.

They are operational files: the latest version is the one you want, and
`DENTALPIN_VERSION` in `.env` is what pins the release you actually run.
So the snippet now reads them from `main`.

Two more in the same block:

- `Caddyfile` was missing entirely. The compose bind-mounts it, so
  following the notes verbatim failed at startup.
- The comment named `DOMAIN`; the variable is `PUBLIC_URL`.

## Then

Once this is in, the sequence is: backfill `v2.0.0` via `workflow_dispatch`
as a dry run against a release nobody is watching, flip the two ghcr
packages to public, and cut the real release after that.

Which version that should be is your call — main has the setup assistant,
the alembic squash and now the prebuilt images sitting under
`[Unreleased]`, which reads like a `v2.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4