### PR TITLE
docs(changelog): cut 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ frontend as a Nuxt layer under its own Python package.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-28
+
+First release cut through the automated pipeline. The eleven modules that
+landed since 2.0.0 — payments, copilot, verifactu, recalls, schedules,
+notifications, periodontogram, clinical_notes, accounting_export,
+migration_import, whatsapp_kapso — are listed per-PR in the generated
+release notes and documented in their own module CHANGELOGs; the
+narrative version of that work belongs to the next major.
+
 ### Added
 
 - **Prebuilt images and a one-command install.** Tagging a release now


### PR DESCRIPTION
Dates the section so `release.yml` has something to extract. Merge, then the tag goes up.

This release is deliberately quiet: it exists to exercise the image pipeline end to end, not to announce the eleven modules that landed since 2.0.0. Those are covered per-PR in the generated notes and in their own module changelogs; the narrative version is being saved for the next major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4