### PR TITLE
fix(release): publish arm64 images alongside amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Release
 
 # Tag -> publish images to ghcr.io -> publish the GitHub Release.
 #
-# ponytail: amd64 only. Covers the x86 VPS every self-hoster actually
-# rents (Hetzner/DO/Vultr/OVH). Add `linux/arm64` to `platforms` when
-# someone opens an issue asking for it — native ARM runners make it
-# cheap, QEMU emulation of the Nuxt build does not.
+# Each architecture builds on its own native runner and pushes by digest;
+# a merge job then stitches them into one manifest list per image. The
+# obvious alternative — one runner, QEMU, `platforms: amd64,arm64` — puts
+# the Nuxt build under emulation, where a 4 GB heap is a coin flip.
 
 on:
   push:
@@ -24,11 +24,11 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  images:
-    runs-on: ubuntu-latest
+  build:
     strategy:
+      fail-fast: false
       matrix:
-        include:
+        image:
           - name: backend
             context: ./backend
             dockerfile: ./backend/Dockerfile
@@ -37,10 +37,61 @@ jobs:
             # out of backend/app/modules (see frontend/Dockerfile.prod).
             context: .
             dockerfile: ./frontend/Dockerfile.prod
+        platform:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || github.ref }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/${{ matrix.platform.arch }}
+          # No tags here: tagging happens once, in the merge job, so a
+          # half-finished matrix never leaves :latest pointing at one arch.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-${{ matrix.platform.arch }}
+
+      - name: Record the digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" \
+            > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name: [backend, frontend]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -55,23 +106,35 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.name }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create the manifest list
+        run: |
+          IMAGE="${REGISTRY}/${GITHUB_REPOSITORY}-${{ matrix.name }}"
+          SOURCES=""
+          for f in /tmp/digests/*; do
+            SOURCES="$SOURCES ${IMAGE}@$(cat "$f")"
+          done
+          # shellcheck disable=SC2086
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $SOURCES
+
+      - name: Check both architectures made it
+        run: |
+          IMAGE="${REGISTRY}/${GITHUB_REPOSITORY}-${{ matrix.name }}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          MANIFEST=$(docker buildx imagetools inspect "${IMAGE}:${TAG#v}" --raw)
+          for arch in amd64 arm64; do
+            echo "$MANIFEST" | grep -q "\"architecture\":\"$arch\"" \
+              || { echo "::error::$IMAGE is missing linux/$arch"; exit 1; }
+          done
+          echo "$IMAGE ships amd64 and arm64."
 
   release:
-    needs: images
+    needs: merge
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -112,7 +175,7 @@ jobs:
             echo "docker compose -f docker-compose.prod.yml up -d"
             echo '```'
             echo ""
-            echo "Images: \`ghcr.io/${{ github.repository }}-backend:$VERSION\` · \`ghcr.io/${{ github.repository }}-frontend:$VERSION\`"
+            echo "Images (amd64 + arm64): \`ghcr.io/${{ github.repository }}-backend:$VERSION\` · \`ghcr.io/${{ github.repository }}-frontend:$VERSION\`"
           } >> notes.md
 
       - name: Publish the release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ frontend as a Nuxt layer under its own Python package.
 
 ## [Unreleased]
 
+### Fixed
+
+- Published images were `amd64` only, so `docker compose up` failed at the
+  very first command on Apple Silicon and on ARM VPS instances (Hetzner's
+  CAX line, the cheapest in Europe and popular with self-hosters) with a
+  bare `no matching manifest for linux/arm64/v8`. Each architecture now
+  builds on its own native runner and a merge step publishes one manifest
+  list per image, verified to carry both before the release is cut.
+
 ## [2.1.0] - 2026-07-28
 
 First release cut through the automated pipeline. The eleven modules that


### PR DESCRIPTION
I wrote "amd64 only, add arm64 when someone asks" in #109 and then became
the first person to ask, twenty minutes later, by following the v2.1.0
install instructions on an Apple Silicon Mac:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

That is the **first command** of the documented install. The reasoning
was that self-hosters rent x86 VPS — some do, but every developer
evaluating DentalPin on a Mac hits this immediately, and Hetzner's CAX
line is the cheapest VPS in Europe and aimed squarely at this audience.
An install that dies on its first command is the exact thing #109 existed
to stop.

## What changed

- Each architecture builds on its own **native runner**
  (`ubuntu-latest` / `ubuntu-24.04-arm`) and pushes by digest.
- A **merge job** stitches the digests into one manifest list per image
  and applies the tags there. Tagging no longer happens in the build job,
  so a half-finished matrix cannot leave `:latest` pointing at one arch.
- A verification step **fails the release** if either architecture is
  missing from the published manifest.

The cheaper alternative — one runner, QEMU, `platforms: amd64,arm64` —
puts the Nuxt build under emulation, where a 4 GB heap is a coin flip.

## v2.1.0 itself is sound

Verified separately before writing this: followed the release notes
verbatim into an empty directory, forced amd64, and got a working stack
from the published images — `/health` 200, login as the demo admin, 15
seeded patients over `/api/v1/patients`, and `apiBaseUrl` carrying the
runtime value rather than the one compiled in.

So this only blocks ARM hosts. Once merged, re-running the workflow via
`workflow_dispatch` on `v2.1.0` republishes it as multi-arch without
burning a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4