### PR TITLE
fix(release): manifest check failed on a manifest that was correct

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      # One image failing should not cancel the other's diagnosis.
+      fail-fast: false
       matrix:
         name: [backend, frontend]
     steps:
@@ -126,9 +128,13 @@ jobs:
         run: |
           IMAGE="${REGISTRY}/${GITHUB_REPOSITORY}-${{ matrix.name }}"
           TAG="${{ inputs.tag || github.ref_name }}"
+          # Parse it — `--raw` pretty-prints, so grepping for
+          # "architecture":"amd64" misses the space after the colon and
+          # fails a manifest that is perfectly fine.
           MANIFEST=$(docker buildx imagetools inspect "${IMAGE}:${TAG#v}" --raw)
           for arch in amd64 arm64; do
-            echo "$MANIFEST" | grep -q "\"architecture\":\"$arch\"" \
+            echo "$MANIFEST" | jq -e --arg a "$arch" \
+              '[.manifests[]?.platform | select(.os == "linux" and .architecture == $a)] | length > 0' >/dev/null \
               || { echo "::error::$IMAGE is missing linux/$arch"; exit 1; }
           done
           echo "$IMAGE ships amd64 and arm64."


### PR DESCRIPTION
The multi-arch run published both images correctly and then failed itself.

`docker buildx imagetools inspect --raw` pretty-prints, so the JSON reads
`"architecture": "amd64"` — with a space. The check grepped for
`"architecture":"amd64"` without one, never matched, and errored with
"missing linux/amd64" on a manifest that had amd64 right there.

Parsed with `jq` now. Validated the expression against the live `v2.1.0`
manifests before committing.

Also `fail-fast: false` on the merge matrix: the frontend's false negative
cancelled the backend job mid-flight, so one bad grep left both images
unverified.

## v2.1.0 is genuinely multi-arch

The failure was cosmetic — the images are fine. Verified on this machine
after clearing the local cache (the first attempt silently reused the
amd64 images pulled earlier and proved nothing):

- `docker manifest inspect` → amd64 + arm64 on both images
- `docker image inspect` after a clean pull → `arm64` on an Apple Silicon Mac
- The documented install, no platform forced: all four services healthy,
  login as the demo admin, 15 seeded patients over `/api/v1/patients`

The exact case that failed an hour ago now works untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4