### PR TITLE
fix(ci): health alert jobs could not find the repository

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -26,6 +26,10 @@ permissions:
 
 env:
   ISSUE_TITLE: "Published images are not pullable"
+  # The alert jobs deliberately skip checkout — they have nothing to build.
+  # Without a git remote `gh` cannot infer the repository and dies with
+  # "not a git repository", so name it explicitly.
+  GH_REPO: ${{ github.repository }}
 
 jobs:
   check:


### PR DESCRIPTION
Ran the new health workflow once by hand after merging #123. The manifest
check passed — and the workflow failed anyway:

```
failed to run git: fatal: not a git repository
```

`gh issue list` in the `alert` and `resolve` jobs. Those jobs skip
checkout deliberately (they have nothing to build), so `gh` has no git
remote to infer the repository from. `GH_REPO` names it explicitly;
adding a checkout just to hand the CLI a remote would be a clone per run
for nothing.

**Worth catching now.** The check itself was green, which means the
broken half was the half that only runs on a bad day — it would have
failed silently at precisely the moment it was supposed to speak up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4