### PR TITLE
feat(i18n): add Portuguese translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ frontend as a Nuxt layer under its own Python package.
 
 ## [Unreleased]
 
+### Added
+
+- **Portuguese (pt-PT) translation.** The fourth UI language after
+  Spanish, English and French. Ships the ~2,340-key core locale plus a
+  `pt.json` for each of the eleven module layers, so every screen the
+  modules contribute is covered too, and the language appears in
+  Settings → Account → Language with no further configuration. Patient
+  communications can also be switched to Portuguese: the clinic-wide
+  communications language accepts `pt` and the full set of transactional
+  email templates (appointment confirmation / reminder / cancellation,
+  quote sent / accepted, welcome, morning digest, Verifactu alerts) is
+  translated. Nuxt UI's own `pt` locale is wired in so date pickers and
+  built-in component strings follow. Backend catalog-name resolution
+  gained a `pt` fallback, so treatments named in Portuguese resolve on
+  invoices, plans, the timeline and the agent tools rather than silently
+  falling back to the internal code.
+
+  Not included: the user manual and the demo seed data stay on
+  `es/en/fr`, matching how French shipped.
+
 ### Fixed
 
 - Published images were `amd64` only, so `docker compose up` failed at the

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -729,7 +729,7 @@ async def update_budget_settings(
 
 
 class _CommunicationsSettingsPatch(BaseModel):
-    language: str | None = Field(default=None, pattern="^(es|en|fr)$")
+    language: str | None = Field(default=None, pattern="^(es|en|fr|pt)$")
 
 
 class _CommunicationsSettingsResponse(BaseModel):

--- a/backend/app/modules/accounting_export/CHANGELOG.md
+++ b/backend/app/modules/accounting_export/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - Initial release. Optional, removable, model-free module that exports

--- a/backend/app/modules/accounting_export/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/accounting_export/frontend/i18n/locales/pt.json
@@ -1,0 +1,40 @@
+{
+  "nav": {
+    "accountingExport": "Exportação para o contabilista"
+  },
+  "accountingExport": {
+    "title": "Exportação para o contabilista",
+    "subtitle": "Descarregue as faturas e os pagamentos do período para entregar ao seu contabilista.",
+    "period": "Período",
+    "from": "De",
+    "to": "Até",
+    "presets": {
+      "currentMonth": "Mês atual",
+      "previousMonth": "Mês anterior",
+      "currentQuarter": "Trimestre atual",
+      "previousQuarter": "Trimestre anterior",
+      "yearToDate": "Ano até à data",
+      "custom": "Personalizado"
+    },
+    "actions": {
+      "preview": "Pré-visualizar",
+      "download": "Descarregar (.zip)"
+    },
+    "counters": {
+      "invoices": "Faturas",
+      "payments": "Pagamentos",
+      "base": "Base",
+      "total": "Total"
+    },
+    "cols": {
+      "numero": "Número",
+      "fecha_emision": "Data",
+      "cliente": "Cliente",
+      "nif": "NIF",
+      "base": "Base",
+      "cuota_iva": "IVA",
+      "total": "Total",
+      "estado": "Estado"
+    }
+  }
+}

--- a/backend/app/modules/accounting_export/frontend/nuxt.config.ts
+++ b/backend/app/modules/accounting_export/frontend/nuxt.config.ts
@@ -4,7 +4,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: add `pt` fallback to invoice description resolution in
+  service layer so Portuguese-localized treatment names appear on invoices.
+
 - i18n: add `fr` fallback to invoice description resolution in
   service layer so French-localized treatment names appear on invoices.
 

--- a/backend/app/modules/billing/service.py
+++ b/backend/app/modules/billing/service.py
@@ -1081,7 +1081,13 @@ class InvoiceService:
             internal_code = None
             if budget_item.catalog_item:
                 names = budget_item.catalog_item.names or {}
-                description = names.get("es") or names.get("en") or names.get("fr") or description
+                description = (
+                    names.get("es")
+                    or names.get("en")
+                    or names.get("fr")
+                    or names.get("pt")
+                    or description
+                )
                 internal_code = budget_item.catalog_item.internal_code
 
             # Create invoice item

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: add `pt` fallback to the agent-tool catalog name resolver so
+  Portuguese-localized treatment names resolve.
+
 - fix(frontend): error toasts in `useCatalog` now show the exact API
   error `detail` (string or 422 validation list) instead of always
   falling back to the generic "Error al crear/actualizar/eliminar"

--- a/backend/app/modules/catalog/tools.py
+++ b/backend/app/modules/catalog/tools.py
@@ -35,7 +35,13 @@ class GetCatalogItemArgs(BaseModel):
 def _name(names: dict | None) -> str | None:
     if not names:
         return None
-    return names.get("es") or names.get("en") or names.get("fr") or next(iter(names.values()), None)
+    return (
+        names.get("es")
+        or names.get("en")
+        or names.get("fr")
+        or names.get("pt")
+        or next(iter(names.values()), None)
+    )
 
 
 def _summary(item) -> dict:

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- i18n: extend the catalog label fallback chain to `es → en → fr → pt`.
+
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: correct French terminology in `fr.json` (Diagnostic).
 
 - i18n: add French locale (`fr.json`); add French translations to seed

--- a/backend/app/modules/clinical_notes/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/clinical_notes/frontend/i18n/locales/pt.json
@@ -1,0 +1,124 @@
+{
+  "clinicalNotes": {
+    "types": {
+      "administrative": "Administrativa",
+      "diagnosis": "Diagnóstico",
+      "treatment": "Tratamento",
+      "treatment_plan": "Plano",
+      "appointment_clinical": "Clínica",
+      "appointment_administrative": "Administrativa"
+    },
+    "appointment": {
+      "addByType": "Adicionar nota {label}",
+      "empty": "Ainda não há notas nesta consulta. Use os botões acima para adicionar uma."
+    },
+    "feed": {
+      "filterLabel": "Filtros",
+      "filterAll": "Todas",
+      "filterClear": "Limpar filtros",
+      "filterStatus": "A mostrar {n} de {total} tipos",
+      "addAdministrative": "Nota administrativa",
+      "loadMore": "Carregar mais",
+      "empty": {
+        "title": "Ainda não há notas",
+        "help": "As notas administrativas, de diagnóstico e de tratamento aparecerão aqui por ordem cronológica."
+      }
+    },
+    "diagnosisSidebar": {
+      "title": "Notas",
+      "addNote": "Adicionar nota",
+      "empty": "Sem notas nesta categoria."
+    },
+    "treatmentButton": {
+      "title": "Notas do tratamento",
+      "add": "Adicionar nota",
+      "empty": "Ainda não há notas neste tratamento.",
+      "aria": "Notas do tratamento ({n})"
+    },
+    "timeline": {
+      "addPlanNote": "Nota do plano",
+      "empty": "Ainda não há notas.",
+      "emptyForFilter": "Nenhuma nota corresponde ao filtro.",
+      "source": {
+        "plan": "Plano",
+        "treatment": "Tratamento",
+        "visit": "Visita"
+      }
+    },
+    "byPlan": {
+      "empty": "Este paciente ainda não tem notas clínicas associadas a planos.",
+      "planNotesLabel": "Notas do plano",
+      "unknownTreatment": "Tratamento",
+      "noNotesForTreatment": "Ainda não há notas neste tratamento."
+    },
+    "composer": {
+      "placeholder": "Escreva a nota…",
+      "templates": "Modelos",
+      "attach": "Anexar fotografia ou documento",
+      "bindToTooth": "Associar ao dente {n}"
+    },
+    "linked": {
+      "tooth": "Dente {n}",
+      "treatment": "Tratamento",
+      "treatmentOnTooth": "{label} (dente {n})",
+      "plan": "Plano",
+      "planNamed": "Plano: {label}"
+    },
+    "actions": {
+      "showMore": "Mostrar mais",
+      "showLess": "Mostrar menos",
+      "openLinked": "Abrir contexto"
+    },
+    "author": {
+      "unknown": "Autor desconhecido"
+    },
+    "time": {
+      "justNow": "agora mesmo",
+      "minutesAgo": "há {n} min",
+      "hoursAgo": "há {n} h",
+      "daysAgo": "há {n} d"
+    },
+    "toasts": {
+      "saved": "Nota guardada",
+      "deleted": "Nota eliminada",
+      "saveFailed": "Não foi possível guardar a nota"
+    },
+    "confirms": {
+      "delete": "Eliminar esta nota? A recuperação exige contactar o suporte."
+    },
+    "templates": {
+      "endo": {
+        "singleVisit": "Endodontia (sessão única)",
+        "multiVisit": "Endodontia (várias sessões)"
+      },
+      "perio": {
+        "scaling": "Destartarização / RAR"
+      },
+      "implant": {
+        "placement": "Colocação de implante"
+      },
+      "diagnosis": {
+        "caries": "Cárie",
+        "periapical": "Lesão periapical"
+      },
+      "admin": {
+        "phoneCall": "Chamada telefónica ao paciente",
+        "reschedule": "Pedido de reagendamento"
+      },
+      "general": {
+        "followUp": "Seguimento geral"
+      }
+    },
+    "templateBodies": {
+      "endo_single_visit": "Diagnóstico: \nAnestesia: \nCanais localizados: \nComprimento de trabalho: \nObturação: \nPós-operatório: ",
+      "endo_multi_visit": "Sessão: \nCanais trabalhados: \nMedicação intracanalar: \nPróxima consulta: ",
+      "perio_scaling": "Quadrantes tratados: \nProfundidade de sondagem: \nHemorragia à sondagem: \nInstruções de higiene: ",
+      "implant_placement": "Implante (marca / diâmetro / comprimento): \nTorque final (Ncm): \nEstabilidade primária: \nEnxerto: \nPós-operatório: ",
+      "diagnosis_caries": "Achado: cárie \nProfundidade: \nSintomas: \nTeste de vitalidade: \nTratamento sugerido: ",
+      "diagnosis_periapical": "Lesão periapical \nDente: \nRadiografia: \nTestes (percussão, palpação): \nDiagnóstico: ",
+      "admin_phone_call": "Chamada ao paciente: \nMotivo: \nAção tomada: \nSeguimento: ",
+      "admin_reschedule": "Pedido de reagendamento: \nData atual: \nNova proposta: ",
+      "general_follow_up": "Achados: \nProcedimento realizado: \nInstruções ao paciente: "
+    }
+  }
+}

--- a/backend/app/modules/clinical_notes/frontend/nuxt.config.ts
+++ b/backend/app/modules/clinical_notes/frontend/nuxt.config.ts
@@ -12,7 +12,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/clinical_notes/service.py
+++ b/backend/app/modules/clinical_notes/service.py
@@ -574,9 +574,9 @@ def _author_brief(author) -> dict:
 def _resolve_label(
     names: dict[str, str] | None,
 ) -> str | None:
-    """Resolve a display label from catalog names: es → en → fr."""
+    """Resolve a display label from catalog names: es → en → fr → pt."""
     names = names or {}
-    return next((names[k] for k in ("es", "en", "fr") if names.get(k)), None)
+    return next((names[k] for k in ("es", "en", "fr", "pt") if names.get(k)), None)
 
 
 def _build_linked(

--- a/backend/app/modules/copilot/CHANGELOG.md
+++ b/backend/app/modules/copilot/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - feat(pending): "Pendientes" feed (IA redesign Fase 2, ADR 0015). New

--- a/backend/app/modules/copilot/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/copilot/frontend/i18n/locales/pt.json
@@ -1,0 +1,185 @@
+{
+  "nav": {
+    "copilot": "IA"
+  },
+  "copilot": {
+    "title": "IA",
+    "open": "Abrir a IA",
+    "empty": "Pergunte-me sobre pacientes, a agenda ou peça-me para marcar uma consulta.",
+    "placeholder": "Escreva a sua mensagem…",
+    "send": "Enviar",
+    "copy": "Copiar",
+    "new": "Nova conversa",
+    "thinking": "A pensar…",
+    "you": "Você",
+    "assistant": "IA",
+    "trust": "Os seus dados estão protegidos",
+    "phase": {
+      "working": "A trabalhar…",
+      "writing": "A escrever…"
+    },
+    "tabs": {
+      "pending": "Por fazer",
+      "chat": "Conversa"
+    },
+    "pending": {
+      "empty": "Nada pendente. Está tudo em dia.",
+      "unknownPatient": "Paciente desconhecido",
+      "group": {
+        "recall": "Reconvocações a seguir",
+        "budget": "Orçamentos a aguardar resposta"
+      }
+    },
+    "nudge": {
+      "act": "Ver isto",
+      "dismiss": "Dispensar",
+      "appointmentCancelled": {
+        "text": "A consulta das {time} foi cancelada — ficou uma vaga livre.",
+        "prompt": "A consulta das {time} foi cancelada. Encontra pacientes com reconvocação que possam ocupar essa vaga."
+      }
+    },
+    "suggest": {
+      "heading": "Como posso ajudar?",
+      "cat": {
+        "workflows": "Fluxos de trabalho",
+        "patients": "Pacientes",
+        "agenda": "Agenda",
+        "recalls": "Reconvocações",
+        "money": "Cobranças e orçamentos",
+        "reports": "Relatórios"
+      },
+      "dailyBriefing": "Resumo diário",
+      "prepareVisit": "Preparar uma visita",
+      "fillGap": "Preencher uma vaga",
+      "searchPatient": "Encontrar um paciente",
+      "patientSummary": "Resumir um paciente",
+      "freeSlots": "Vagas livres hoje",
+      "bookAppointment": "Marcar uma consulta",
+      "dueRecalls": "Reconvocações a vencer",
+      "pendingBudgets": "Orçamentos sem resposta",
+      "recordPayment": "Registar um pagamento",
+      "monthCollections": "Cobranças deste mês",
+      "agendaSummary": "Visão geral da agenda",
+      "prompt": {
+        "dailyBriefing": "Dá-me o resumo diário: consultas de hoje, reconvocações em atraso e orçamentos sem resposta",
+        "prepareVisit": "Prepara-me a próxima visita de um paciente",
+        "fillGap": "Ficou uma vaga livre na agenda, a quem podemos telefonar?",
+        "searchPatient": "Encontra um paciente",
+        "patientSummary": "Dá-me um resumo de um paciente",
+        "freeSlots": "Que vagas livres há hoje?",
+        "bookAppointment": "Quero marcar uma consulta",
+        "dueRecalls": "Que reconvocações vencem este mês?",
+        "pendingBudgets": "Que orçamentos foram enviados e estão sem resposta?",
+        "recordPayment": "Quero registar um pagamento de um paciente",
+        "monthCollections": "Resumo das cobranças deste mês",
+        "agendaSummary": "Dá-me uma visão geral da agenda de hoje"
+      }
+    },
+    "settings": {
+      "title": "Copilot",
+      "description": "Assistente de IA: resumo diário e motor",
+      "saved": "Definições guardadas",
+      "digest": {
+        "title": "Email de resumo matinal",
+        "description": "Todas as manhãs: consultas de hoje, reconvocações em atraso e orçamentos sem resposta.",
+        "enabled": "Enviar resumo diário",
+        "hour": "Hora de envio",
+        "hourHelp": "Interpretada no fuso horário da clínica.",
+        "recipients": "Destinatários",
+        "recipientsHelp": "Cada destinatário recebe o seu próprio resumo, limitado ao que o seu perfil pode ver.",
+        "recipientsPlaceholder": "Selecionar membros da equipa…"
+      },
+      "engine": {
+        "title": "Motor",
+        "provider": "Fornecedor",
+        "model": "Modelo",
+        "redaction": "Ocultação de dados clínicos",
+        "redactionOn": "Ativada",
+        "redactionOff": "Desativada"
+      },
+      "metrics": {
+        "title": "Utilização",
+        "description": "Últimos {days} dias.",
+        "toolCalls": "Chamadas a ferramentas",
+        "errorRate": "Taxa de erro",
+        "avgLatency": "Latência média",
+        "conversations": "Conversas",
+        "tokenBudget": "Orçamento mensal de tokens",
+        "topTools": "Ferramentas mais usadas",
+        "toolNames": {
+          "recalls_list_due_recalls": "Reconvocações em atraso",
+          "budget_list_budgets": "Orçamentos pendentes",
+          "patients_list_patients": "Pesquisa de pacientes",
+          "appointments_list_appointments": "Consultas",
+          "invoices_list_invoices": "Faturas"
+        }
+      }
+    },
+    "tool": {
+      "running": "A executar {name}…",
+      "done": "{name} concluído",
+      "failed": "{name} falhou"
+    },
+    "card": {
+      "viewPatient": "Ver ficha",
+      "noResults": "Sem resultados",
+      "notFound": "Não encontrado",
+      "more": "+{n} mais",
+      "freeSlots": "Vagas livres",
+      "appointments": "Consultas",
+      "patients": "Pacientes"
+    },
+    "patientStatus": {
+      "active": "ativo",
+      "archived": "arquivado"
+    },
+    "apptStatus": {
+      "scheduled": "Agendada",
+      "confirmed": "Confirmada",
+      "checked_in": "Chegada registada",
+      "in_treatment": "Em tratamento",
+      "completed": "Concluída",
+      "cancelled": "Cancelada",
+      "no_show": "Faltou"
+    },
+    "confirm": {
+      "title": "Confirmar ação",
+      "body": "A IA quer executar {name}.",
+      "approve": "Confirmar",
+      "reject": "Cancelar",
+      "approved": "Confirmada",
+      "rejected": "Cancelada",
+      "destructiveNote": "Esta ação não pode ser anulada.",
+      "action": {
+        "book_appointment": "A IA quer marcar uma consulta.",
+        "cancel_appointment": "A IA quer cancelar uma consulta.",
+        "create_patient": "A IA quer criar um paciente."
+      },
+      "field": {
+        "patient_id": "Paciente",
+        "professional_id": "Profissional",
+        "appointment_id": "Consulta",
+        "cabinet_id": "Gabinete",
+        "cabinet": "Gabinete",
+        "start_time": "Data",
+        "end_time": "Fim",
+        "datetime": "Data",
+        "service": "Serviço",
+        "reason": "Motivo",
+        "duration_minutes": "Duração (min)",
+        "first_name": "Nome",
+        "last_name": "Apelido",
+        "phone": "Telefone",
+        "email": "Email",
+        "date_of_birth": "Data de nascimento",
+        "query": "Pesquisa"
+      }
+    },
+    "budgetExceeded": "Foi atingido o limite mensal de utilização da IA.",
+    "error": "Algo correu mal.",
+    "page": {
+      "title": "IA",
+      "subtitle": "O assistente da sua clínica, limitado às suas permissões."
+    }
+  }
+}

--- a/backend/app/modules/copilot/frontend/nuxt.config.ts
+++ b/backend/app/modules/copilot/frontend/nuxt.config.ts
@@ -9,7 +9,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/migration_import/CHANGELOG.md
+++ b/backend/app/modules/migration_import/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - fix(entity_mappings): widen ``source_canonical_uuid`` from

--- a/backend/app/modules/migration_import/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/migration_import/frontend/i18n/locales/pt.json
@@ -1,0 +1,90 @@
+{
+  "migrationImport": {
+    "settingsCard": {
+      "title": "Migração de dados (dental-bridge)",
+      "description": "Importe um ficheiro DPMF produzido pelo dental-bridge (pacientes, consultas, orçamentos, pagamentos, documentos)."
+    },
+    "page": {
+      "title": "Migração de dados",
+      "subtitle": "Importe para esta clínica os dados extraídos pelo dental-bridge."
+    },
+    "upload": {
+      "dropFile": "Largue aqui o ficheiro .dpm ou clique para escolher um",
+      "passphrase": "Frase-passe (apenas para ficheiros encriptados)",
+      "passphraseHelp": "Só é necessária para .dpm.enc / .dpm.zst.enc",
+      "submit": "Carregar e validar",
+      "uploading": "A carregar…",
+      "error": "Falha no carregamento"
+    },
+    "validate": {
+      "running": "A verificar o ficheiro…",
+      "ok": "O ficheiro é válido",
+      "failed": "A validação falhou"
+    },
+    "preview": {
+      "title": "Pré-visualização",
+      "entities": "Entidades",
+      "samples": "Amostras",
+      "warnings": "Avisos",
+      "files": "Ficheiros anexos",
+      "filesTotal": "Total",
+      "filesWithSha": "Com sha256",
+      "filesWithoutSha": "Sem sha256",
+      "verifactuCheckbox": "Importar dados legais Verifactu",
+      "verifactuHelp": "Preserva os hashes legais (Verifactu) nas faturas. Só está disponível quando o módulo Verifactu está instalado e o ficheiro contém esses dados.",
+      "confirm": "Confirmar e importar",
+      "warning": "Esta ação não pode ser anulada. Reveja os dados antes de confirmar."
+    },
+    "filters": {
+      "title": "Filtragem de profissionais",
+      "description": "Os profissionais filtrados são importados como inativos (mantidos para referências históricas, mas ocultos na agenda). Pode reativá-los mais tarde em Definições → Utilizadores.",
+      "totalLabel": "Total",
+      "deactivatedLabel": "Inativos na origem",
+      "orphansLabel": "Colunas só de agenda",
+      "stale24mLabel": "Sem atividade nos últimos 24 m",
+      "minActivityLabel": "Atividade mínima (meses)",
+      "minActivityHelp": "Desativa suavemente os profissionais sem registo clínico mais recente do que este número de meses. Defina 0 para desativar.",
+      "excludeOrphans": "Excluir colunas só de agenda sem registo real de colaborador",
+      "excludeInactive": "Excluir profissionais marcados como inativos na origem",
+      "excludeNonClinical": "Importar apenas médicos dentistas e higienistas (ignorar auxiliares e pessoal administrativo)"
+    },
+    "execute": {
+      "running": "A importar…",
+      "progress": "{processed} de {total} entidades",
+      "ok": "Importação concluída",
+      "failed": "A importação falhou"
+    },
+    "proposals": {
+      "title": "Rever as correspondências do catálogo",
+      "subtitle": "Associe cada tratamento do Gesdén ao catálogo do DentalPin antes de importar.",
+      "build": "Calcular propostas",
+      "building": "A calcular…",
+      "summary": "{total} propostas: {link} associadas, {fuzzy} aproximadas, {create} a criar",
+      "bulkAccept": "Aceitar todas as correspondências com confiança ≥ 0,9",
+      "accepted": "{n} propostas aceites.",
+      "columnSource": "Tratamento Gesdén",
+      "columnProposed": "Proposta",
+      "columnAction": "Ação",
+      "columnStatus": "Estado",
+      "actionLink": "Associar ao catálogo",
+      "actionFuzzy": "Correspondência aproximada",
+      "actionCreate": "Criar novo",
+      "operatorPending": "Pendente",
+      "operatorAccepted": "Aceite",
+      "operatorRelinked": "Reassociado",
+      "operatorCreated": "Criar novo",
+      "operatorIgnored": "Ignorado",
+      "acceptRow": "Aceitar",
+      "ignoreRow": "Ignorar"
+    },
+    "status": {
+      "uploaded": "Carregado",
+      "validating": "A validar",
+      "validated": "Validado",
+      "previewing": "Pré-visualização",
+      "executing": "A importar",
+      "completed": "Concluído",
+      "failed": "Falhou"
+    }
+  }
+}

--- a/backend/app/modules/migration_import/frontend/nuxt.config.ts
+++ b/backend/app/modules/migration_import/frontend/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`notifications-pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - feat(conversation): inbound replies + bidirectional WhatsApp (Phase 2A,

--- a/backend/app/modules/notifications/frontend/components/settings/ClinicLanguagePage.vue
+++ b/backend/app/modules/notifications/frontend/components/settings/ClinicLanguagePage.vue
@@ -2,10 +2,12 @@
 const { t } = useI18n()
 const { settings, loading, saving, fetch, update } = useCommunicationsSettings()
 
-const language = ref<'es' | 'en' | 'fr'>('es')
+const language = ref<'es' | 'en' | 'fr' | 'pt'>('es')
+
+const SUPPORTED = ['en', 'fr', 'pt'] as const
 
 watch(settings, (s) => {
-  if (s) language.value = (s.language === 'en' || s.language === 'fr' ? s.language : 'es')
+  if (s) language.value = (SUPPORTED.includes(s.language as typeof SUPPORTED[number]) ? s.language as typeof language.value : 'es')
 })
 
 onMounted(fetch)
@@ -14,6 +16,7 @@ const options = [
   { value: 'es', label: 'Español' },
   { value: 'en', label: 'English' },
   { value: 'fr', label: 'Français' },
+  { value: 'pt', label: 'Português' },
 ]
 
 async function save() {

--- a/backend/app/modules/notifications/frontend/i18n/locales/notifications-pt.json
+++ b/backend/app/modules/notifications/frontend/i18n/locales/notifications-pt.json
@@ -1,0 +1,11 @@
+{
+  "notifications": {
+    "conversation": {
+      "title": "Conversa de WhatsApp",
+      "empty": "Ainda não há mensagens.",
+      "placeholder": "Escreva uma resposta…",
+      "replyError": "Não foi possível enviar a resposta",
+      "windowClosed": "A janela de 24 h está fechada. Use um modelo para reabrir a conversa."
+    }
+  }
+}

--- a/backend/app/modules/notifications/frontend/nuxt.config.ts
+++ b/backend/app/modules/notifications/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'notifications-en.json' },
       { code: 'es', file: 'notifications-es.json' },
-      { code: 'fr', file: 'notifications-fr.json' }
+      { code: 'fr', file: 'notifications-fr.json' },
+      { code: 'pt', file: 'notifications-pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/patient_timeline/CHANGELOG.md
+++ b/backend/app/modules/patient_timeline/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: add `pt` fallback to treatment name resolution in the demo
+  timeline seed.
+
 - feat(agents): expose `tools.py` — `get_patient_timeline` (READ)
   wrapping `TimelineService.get_timeline`. Returns structured event
   metadata only (type/category/title/timestamp); free-text description +

--- a/backend/app/modules/patient_timeline/seed.py
+++ b/backend/app/modules/patient_timeline/seed.py
@@ -154,6 +154,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
             names.get("es")
             or names.get("en")
             or names.get("fr")
+            or names.get("pt")
             or t({"es": "tratamiento", "en": "treatment", "fr": "traitement"})
         )
         patient_id = item.treatment.patient_id if item.treatment else None
@@ -187,6 +188,7 @@ async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int
             names.get("es")
             or names.get("en")
             or names.get("fr")
+            or names.get("pt")
             or treatment.clinical_type
             or t({"es": "tratamiento", "en": "treatment", "fr": "traitement"})
         )

--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - fix(security): lock the payment row `FOR UPDATE` before the refund

--- a/backend/app/modules/payments/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/payments/frontend/i18n/locales/pt.json
@@ -1,0 +1,287 @@
+{
+  "payments": {
+    "nav": {
+      "payments": "Pagamentos",
+      "reports": "Relatórios de pagamentos"
+    },
+    "balance": {
+      "debt": "Deve",
+      "credit": "Em conta",
+      "paid": "Total pago"
+    },
+    "list": {
+      "title": "Pagamentos",
+      "subtitle": "Pagamentos de pacientes, adiantamentos de orçamentos e crédito em conta.",
+      "empty": "Nenhum pagamento registado.",
+      "new": "Novo pagamento",
+      "searchPlaceholder": "Paciente ou referência",
+      "filterDateFrom": "De",
+      "filterDateTo": "Até",
+      "filterMethod": "Método",
+      "filterPatient": "Paciente",
+      "filter": {
+        "method": "Método",
+        "hasRefunds": "Com reembolsos",
+        "hasUnallocated": "Por afetar",
+        "patient": "Paciente",
+        "withDebt": "Com dívida",
+        "paymentStatus": "Estado"
+      },
+      "sort": {
+        "paymentDate": "Data",
+        "amount": "Montante"
+      },
+      "budgetStatus": {
+        "paid": "Pago",
+        "partial": "Parcial",
+        "unpaid": "Por pagar"
+      },
+      "row": {
+        "debtTooltip": "Saldo em dívida do paciente",
+        "creditTooltip": "Saldo de crédito do paciente",
+        "allocationsLabel": "Afetação",
+        "refundedLabel": "Reembolsado",
+        "noPatient": "Sem paciente"
+      },
+      "columnDate": "Data",
+      "columnPatient": "Paciente",
+      "columnAmount": "Montante",
+      "columnMethod": "Método",
+      "columnAllocations": "Afetação",
+      "columnNet": "Líquido",
+      "columnActions": "Ações"
+    },
+    "detail": {
+      "title": "Pagamento {reference}",
+      "amount": "Montante",
+      "method": "Método",
+      "date": "Data",
+      "recordedBy": "Registado por",
+      "allocations": "Afetações",
+      "refunds": "Reembolsos",
+      "refund": "Reembolsar",
+      "refundedTotal": "Reembolsado",
+      "netAmount": "Líquido",
+      "reference": "Referência",
+      "notes": "Notas"
+    },
+    "new": {
+      "title": "Registar pagamento",
+      "patient": "Paciente",
+      "patientPlaceholder": "Procurar paciente...",
+      "unknownPatient": "Paciente desconhecido",
+      "amount": "Montante",
+      "suggestedHint": "Por cobrar: {amount}",
+      "useSuggested": "usar este montante",
+      "method": "Método",
+      "moreMethods": "Mais opções",
+      "date": "Data",
+      "today": "Hoje",
+      "advanced": "Opções avançadas",
+      "reference": "Referência",
+      "referencePlaceholder": "N.º de autorização do cartão, referência da transferência...",
+      "notes": "Notas",
+      "allocations": "Afetação",
+      "allocationsHint": "Distribua este pagamento por orçamentos ou deixe-o no crédito do paciente.",
+      "addAllocation": "Adicionar afetação",
+      "allocationToBudget": "Para orçamento",
+      "allocationOnAccount": "Em conta",
+      "sumLabel": "Soma:",
+      "sumMismatch": "não coincide com o montante",
+      "submit": "Registar",
+      "submitWithAmount": "Cobrar {amount}",
+      "cancel": "Cancelar",
+      "errPatient": "Selecione um paciente",
+      "errAmount": "Introduza um montante superior a 0",
+      "errSum": "A soma das afetações tem de ser igual ao montante",
+      "errUnknown": "Não foi possível registar o pagamento. Tente novamente."
+    },
+    "methods": {
+      "cash": "Numerário",
+      "card": "Cartão",
+      "bank_transfer": "Transferência",
+      "direct_debit": "Débito direto",
+      "insurance": "Seguro",
+      "other": "Outro"
+    },
+    "refund": {
+      "title": "Reembolsar pagamento",
+      "amount": "Montante",
+      "method": "Método",
+      "reason": "Motivo",
+      "note": "Detalhes",
+      "submit": "Reembolsar",
+      "reasonCodes": {
+        "duplicate": "Pagamento duplicado",
+        "overpaid": "Pagamento em excesso",
+        "treatment_cancelled": "Tratamento cancelado",
+        "dispute": "Litígio",
+        "other": "Outro"
+      }
+    },
+    "ledger": {
+      "title": "Conta corrente do paciente",
+      "totalPaid": "Total pago",
+      "totalEarned": "Tratamento realizado",
+      "patientCredit": "Saldo de crédito do paciente",
+      "clinicReceivable": "Valor a receber pela clínica",
+      "onAccount": "Em conta",
+      "empty": "Sem movimentos."
+    },
+    "budgetCard": {
+      "title": "Pagamentos do orçamento",
+      "budgetTotal": "Orçamentado",
+      "collected": "Cobrado",
+      "pending": "Pendente",
+      "collect": "Cobrar",
+      "empty": "Ainda não há pagamentos afetados a este orçamento.",
+      "collectedLabel": "Cobrado",
+      "pendingLabel": "Pendente",
+      "outOfTotal": "de {total} no total",
+      "settled": "Orçamento totalmente cobrado",
+      "history": "Histórico de pagamentos",
+      "payment": "Pagamento",
+      "emptyDetailed": "Ainda não foram cobrados pagamentos. Use \"Cobrar\" para registar o primeiro."
+    },
+    "budgetCollect": {
+      "title": "Cobrar orçamento",
+      "amountLabel": "Montante",
+      "methodLabel": "Método de pagamento",
+      "dateLabel": "Data do pagamento",
+      "today": "Hoje",
+      "quickFull": "Total",
+      "optionalDetails": "Adicionar referência ou notas (opcional)",
+      "referenceLabel": "Referência",
+      "referencePlaceholder": "Ex.: id da transação no TPA",
+      "notesLabel": "Notas internas",
+      "submit": "Cobrar",
+      "cancel": "Cancelar",
+      "success": "Pagamento registado",
+      "errorGeneric": "Não foi possível registar o pagamento",
+      "noteAppliedToBudget": "aplicados ao orçamento.",
+      "notePendingAfter": "Restante",
+      "noteFullySettled": "O orçamento ficará totalmente liquidado.",
+      "noteToBudget": "aplicados ao orçamento e",
+      "noteExcessToOnAccount": "para o crédito em conta do paciente.",
+      "noteBudgetSettled": "O orçamento já está totalmente pago.",
+      "noteToOnAccount": "vão para o crédito em conta do paciente."
+    },
+    "pendingCharges": {
+      "title": "Por cobrar",
+      "count": "{n} sessões",
+      "more": "+ {n} mais",
+      "collect": "Cobrar {amount}",
+      "unnamedSession": "Sessão sem título"
+    },
+    "patientPanel": {
+      "title": "Conta corrente do paciente",
+      "kpis": {
+        "totalPaid": "Total pago",
+        "debt": "Valor a receber pela clínica",
+        "onAccount": "Em conta"
+      },
+      "sidebar": {
+        "title": "Resumo",
+        "credit": "Crédito do paciente",
+        "lastPayment": "Último pagamento",
+        "noLastPayment": "Ainda não há pagamentos",
+        "totalEarned": "Tratamento realizado"
+      },
+      "banner": {
+        "debtTitle": "Deve {amount} à clínica",
+        "debtDescription": "O total pago é inferior ao tratamento realizado.",
+        "creditTitle": "Tem {amount} de crédito",
+        "creditDescription": "Pagou mais do que o tratamento realizado."
+      },
+      "cobrar": "Registar pagamento",
+      "timeline": {
+        "title": "Movimentos",
+        "empty": "Nenhum movimento registado",
+        "emptyCta": "Registar o primeiro pagamento",
+        "loadError": "Não foi possível carregar a conta corrente do paciente.",
+        "retry": "Tentar novamente",
+        "drPrefix": "Dr(a). {name}",
+        "types": {
+          "payment": "Pagamento",
+          "refund": "Reembolso",
+          "earned": "Tratamento realizado"
+        },
+        "treatmentStatus": {
+          "planned": "Planeado",
+          "performed": "Realizado",
+          "completed": "Concluído",
+          "cancelled": "Cancelado",
+          "in_progress": "Em curso"
+        },
+        "rowMenu": {
+          "detail": "Ver detalhe",
+          "refund": "Reembolsar"
+        }
+      },
+      "refundModal": {
+        "title": "Reembolsar pagamento",
+        "amount": "Montante do reembolso",
+        "method": "Método do reembolso",
+        "reason": "Motivo",
+        "note": "Detalhes (opcional)",
+        "submit": "Confirmar reembolso",
+        "cancel": "Cancelar",
+        "errorGeneric": "Não foi possível registar o reembolso"
+      }
+    },
+    "reports": {
+      "title": "Relatórios de pagamentos",
+      "subtitle": "Cobranças, reembolsos, saldos de pacientes e tendências do período.",
+      "cardDescription": "Cobrado, reembolsos, saldos de pacientes, antiguidade e tendências.",
+      "period": "Período",
+      "refresh": "Atualizar",
+      "collected": "Cobrado",
+      "refunded": "Reembolsado",
+      "net": "Líquido",
+      "patientCredit": "Total de crédito dos pacientes",
+      "patientCreditHint": "Saldos em conta ou adiantamentos.",
+      "clinicReceivable": "Valor a receber pela clínica",
+      "refundRatio": "Rácio de reembolsos",
+      "byMethod": "Por método",
+      "byProfessional": "Por profissional",
+      "byProfessionalHint": "Tratamento realizado, não cobrado.",
+      "aging": "Antiguidade dos saldos",
+      "agingHint": "Pacientes com saldo em dívida agrupados pela antiguidade da dívida.",
+      "refunds": "Reembolsos por motivo",
+      "refundsHint": "Distribuição dos reembolsos pelo motivo registado.",
+      "bucket": "{range} dias",
+      "unknownProfessional": "Sem atribuição",
+      "countShort": "{n} transações",
+      "countPatients": "{n} pacientes",
+      "granularity": {
+        "day": "Dia",
+        "week": "Semana",
+        "month": "Mês"
+      },
+      "hero": {
+        "netCollected": "Cobrado líquido",
+        "netCollectedHint": "Cobranças menos reembolsos no período.",
+        "receivable": "Saldo por receber",
+        "receivableHint": "Tratamento realizado ainda não cobrado, por antiguidade.",
+        "vsPrevious": "vs. período anterior",
+        "transactionsCount": "{n} transações no período"
+      },
+      "trend": {
+        "title": "Tendência das cobranças",
+        "subtitle": "Líquido por intervalo. A linha tracejada sobrepõe os reembolsos."
+      },
+      "empty": {
+        "noDataTitle": "Sem dados neste intervalo",
+        "noDataDescription": "Ajuste o período ou registe um pagamento para começar a ver o relatório.",
+        "noTrend": "Pontos insuficientes para traçar a tendência.",
+        "noMethods": "Sem cobranças por método no período.",
+        "noProfessionals": "Sem tratamento realizado no período.",
+        "noReceivable": "Sem pacientes com dívida por liquidar."
+      },
+      "drilldown": {
+        "viewPayments": "Ver pagamentos do período",
+        "viewPatients": "Ver pacientes com dívida"
+      }
+    }
+  }
+}

--- a/backend/app/modules/payments/frontend/nuxt.config.ts
+++ b/backend/app/modules/payments/frontend/nuxt.config.ts
@@ -12,7 +12,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - fix(frontend): call `api.del` instead of the non-existent `api.delete`

--- a/backend/app/modules/periodontogram/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/periodontogram/frontend/i18n/locales/pt.json
@@ -1,0 +1,84 @@
+{
+  "periodontogram": {
+    "tab": {
+      "label": "Periodontograma"
+    },
+    "empty": {
+      "title": "Ainda não há exames periodontais",
+      "description": "Abra uma nova sessão para registar profundidades de sondagem, hemorragia, placa e as restantes métricas SEPA.",
+      "cta": "Iniciar exame"
+    },
+    "session": {
+      "draftBadge": "Rascunho em curso",
+      "closedBadge": "Sessão fechada",
+      "recordedAt": "Registada a {date}",
+      "openDraft": "Abrir nova sessão",
+      "continueDraft": "Continuar rascunho",
+      "closeTitle": "Fechar sessão periodontal",
+      "closeDescription": "Depois de fechada, a sessão é imutável e passa a constar no histórico. Para fazer correções terá de abrir uma nova sessão.",
+      "closeButton": "Fechar sessão",
+      "discardTitle": "Descartar rascunho",
+      "discardDescription": "Todos os dados introduzidos nesta sessão serão eliminados. Esta ação não pode ser anulada.",
+      "discardButton": "Descartar",
+      "cancel": "Cancelar",
+      "closeSession": "Fechar sessão",
+      "discardDraft": "Descartar rascunho"
+    },
+    "indices": {
+      "bop": "Hemorragia",
+      "pi": "Placa",
+      "calMean": "CAL médio",
+      "deepPockets": "Bolsas ≥5 mm"
+    },
+    "saveState": {
+      "saving": "A guardar…",
+      "dirty": "Alterações por guardar",
+      "saved": "Alterações guardadas"
+    },
+    "history": {
+      "viewingSession": "A visualizar a sessão de {date} (apenas leitura).",
+      "returnToCurrent": "Voltar à atual"
+    },
+    "arch": {
+      "upper": "Superior",
+      "lower": "Inferior",
+      "palatal": "Palatina",
+      "lingual": "Lingual",
+      "vestibular": "Vestibular",
+      "probing": "Sondagem",
+      "margin": "Margem",
+      "bleeding": "Hemorragia",
+      "plaque": "Placa",
+      "probingTitle": "Sondagem de {code} (0–15 mm)",
+      "marginTitle": "Margem gengival de {code} (-5 a 10 mm)",
+      "plaqueTitle": "Placa em {code} (clique para alternar)",
+      "bleedingTitle": "Hemorragia em {code} (clique para alternar)",
+      "implant": "Implante",
+      "implantToggleOn": "Implante (clique para remover)",
+      "implantToggleOff": "Clique para marcar como implante",
+      "mobility": "Mobilidade",
+      "mobilityTitle": "Clique para alterar a mobilidade (0–3)",
+      "prognosis": "Prognóstico",
+      "prognosisTitle": "Bom / Razoável / Duvidoso / Sem prognóstico",
+      "furcaV": "Furca V",
+      "furcaVTitle": "Furca vestibular (0/I/II/III)",
+      "furcaLP": "Furca L/P",
+      "furcaLPTitle": "Furca lingual/palatina (0/I/II/III)",
+      "gingivalWidth": "Largura gengival",
+      "siteMarkerAria": "Local {code}, sondagem {depth}"
+    },
+    "chart": {
+      "ariaLabel": "Periodontograma — arcadas superior e inferior"
+    },
+    "indicesBanner": {
+      "observationsPlaceholder": "Notas do exame…",
+      "noteLabel": "Nota (opcional)"
+    },
+    "loading": "A carregar o periodontograma…",
+    "errors": {
+      "loadFailed": "Não foi possível carregar o periodontograma.",
+      "saveFailed": "Não foi possível guardar a alteração.",
+      "checkConnection": "Verifique a sua ligação e tente novamente."
+    }
+  }
+}

--- a/backend/app/modules/periodontogram/frontend/nuxt.config.ts
+++ b/backend/app/modules/periodontogram/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: correct French wording in seed note (Contrôle mensuel).
 
 - i18n: add French translations to seed data; fix `t()` dict pattern.

--- a/backend/app/modules/recalls/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/recalls/frontend/i18n/locales/pt.json
@@ -1,0 +1,129 @@
+{
+  "recalls": {
+    "title": "Reconvocações",
+    "callList": "Lista de chamadas",
+    "noRecallsThisMonth": "Sem reconvocações pendentes este mês",
+    "filters": {
+      "month": "Mês",
+      "reason": "Motivo",
+      "professional": "Profissional",
+      "status": "Estado",
+      "priority": "Prioridade",
+      "overdue": "Mostrar em atraso",
+      "any": "Qualquer",
+      "thisMonth": "Este mês"
+    },
+    "counters": {
+      "due_this_week": "A vencer esta semana",
+      "due_this_month": "A vencer este mês",
+      "overdue": "Em atraso",
+      "scheduled_this_month": "Agendadas este mês",
+      "completed_this_month": "Concluídas este mês",
+      "conversion_rate": "Conversão"
+    },
+    "setRecall": "Definir reconvocação",
+    "setRecallShort": "Reconvocação",
+    "history": "Histórico de reconvocações",
+    "viewAll": "Ver tudo",
+    "pillNext": "Próxima reconvocação: {month} · {reason}",
+    "pillNone": "Sem reconvocação ativa",
+    "reasons": {
+      "hygiene": "Higiene",
+      "checkup": "Consulta de rotina",
+      "ortho_review": "Revisão de ortodontia",
+      "implant_review": "Revisão de implante",
+      "post_op": "Pós-operatório",
+      "treatment_followup": "Seguimento de tratamento",
+      "other": "Outro"
+    },
+    "priority": {
+      "low": "Baixa",
+      "normal": "Normal",
+      "high": "Alta"
+    },
+    "status": {
+      "pending": "Pendente",
+      "contacted_no_answer": "Sem resposta",
+      "contacted_scheduled": "Agendada",
+      "contacted_declined": "Recusada",
+      "done": "Concluída",
+      "cancelled": "Cancelada",
+      "needs_review": "Precisa de revisão"
+    },
+    "actions": {
+      "call": "Telefonar",
+      "logAttempt": "Registar tentativa",
+      "noAnswer": "Sem resposta",
+      "book": "Marcar consulta",
+      "snooze": "Adiar",
+      "cancel": "Cancelar",
+      "markDone": "Marcar como concluída",
+      "exportCsv": "Exportar CSV",
+      "save": "Guardar"
+    },
+    "closeoutPrompt": {
+      "title": "Agendar uma reconvocação?",
+      "subtitle": "O paciente acabou de terminar — quando devemos voltar a contactá-lo?",
+      "skip": "Agora não"
+    },
+    "modal": {
+      "title": "Definir reconvocação",
+      "subtitle": "Sinalize o paciente para um contacto futuro",
+      "patient": "Paciente",
+      "reason": "Motivo",
+      "when": "Quando",
+      "month": "Mês alvo",
+      "targetMonth": "Mês alvo",
+      "preciseDate": "Escolher um dia específico",
+      "priority": "Prioridade",
+      "assigned": "Profissional responsável",
+      "note": "Nota interna",
+      "notePlaceholder": "Detalhe opcional (ex.: 'Rever restauração no 47')",
+      "optional": "opcional",
+      "duplicateGuard": "Já existe uma reconvocação pendente para este paciente e motivo. Será atualizada."
+    },
+    "doNotContact": {
+      "cannotSchedule": "Este paciente está assinalado como \"Não contactar\". Não é possível agendar reconvocações. Altere a preferência nos dados demográficos para voltar a permitir o contacto."
+    },
+    "activeRecallHint": "Reconvocação ativa · toque para gerir",
+    "logAttempt": {
+      "channel": "Canal",
+      "outcome": "Resultado",
+      "note": "Nota",
+      "submit": "Registar tentativa"
+    },
+    "channel": {
+      "phone": "Telefone",
+      "whatsapp": "WhatsApp",
+      "sms": "SMS",
+      "email": "Email"
+    },
+    "outcome": {
+      "no_answer": "Sem resposta",
+      "voicemail": "Correio de voz",
+      "scheduled": "Consulta agendada",
+      "declined": "Recusou",
+      "wrong_number": "Número errado"
+    },
+    "snoozePrompt": "Adiar por quantos meses?",
+    "settings": {
+      "title": "Reconvocações",
+      "description": "Intervalos predefinidos + correspondência com categorias de tratamento",
+      "intervals": "Intervalos predefinidos (meses)",
+      "categoryMap": "Tratamento → motivo",
+      "categoryKeyPlaceholder": "chave da categoria do catálogo",
+      "autoSuggest": "Sugerir uma reconvocação quando um tratamento é concluído",
+      "autoLink": "Associar uma consulta agendada a uma reconvocação pendente",
+      "saved": "Definições guardadas"
+    },
+    "dashboard": {
+      "title": "Reconvocações"
+    },
+    "suggestion": {
+      "title": "Reconvocação sugerida",
+      "body": "Após este tratamento sugerimos uma reconvocação em {month} ({reason}).",
+      "create": "Criar reconvocação",
+      "dismiss": "Dispensar"
+    }
+  }
+}

--- a/backend/app/modules/recalls/frontend/nuxt.config.ts
+++ b/backend/app/modules/recalls/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - fix(agents): `find_free_slots` now returns contiguous free **windows**

--- a/backend/app/modules/schedules/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/schedules/frontend/i18n/locales/pt.json
@@ -1,0 +1,82 @@
+{
+  "schedules": {
+    "nav": {
+      "clinicHours": "Horário da clínica",
+      "professionalSchedules": "Horários dos profissionais"
+    },
+    "settingsCards": {
+      "clinicHoursTitle": "Horário da clínica",
+      "clinicHoursDescription": "Defina o horário de funcionamento semanal da clínica e as datas especiais (feriados, horário reduzido).",
+      "professionalHoursTitle": "Horários dos profissionais",
+      "professionalHoursDescription": "Defina horários individuais para cada profissional e faça a gestão de férias ou outros períodos de indisponibilidade."
+    },
+    "clinicHours": {
+      "title": "Horário da clínica",
+      "subtitle": "Defina quando a clínica está aberta em cada dia da semana.",
+      "weeklyTemplate": "Modelo semanal",
+      "overrides": "Datas especiais",
+      "addOverride": "Adicionar data especial",
+      "editOverride": "Editar data especial",
+      "save": "Guardar alterações",
+      "saved": "Horário atualizado",
+      "savedError": "Falha ao guardar o horário"
+    },
+    "professionalHours": {
+      "title": "Horários dos profissionais",
+      "selectProfessional": "Selecione um profissional",
+      "weeklyTemplate": "Horário semanal",
+      "overrides": "Ausências e horários especiais",
+      "addOverride": "Adicionar ausência",
+      "editOverride": "Editar ausência",
+      "save": "Guardar alterações",
+      "saved": "Horário atualizado"
+    },
+    "weekday": {
+      "0": "Segunda-feira",
+      "1": "Terça-feira",
+      "2": "Quarta-feira",
+      "3": "Quinta-feira",
+      "4": "Sexta-feira",
+      "5": "Sábado",
+      "6": "Domingo",
+      "closed": "Encerrado",
+      "addShift": "Adicionar turno",
+      "removeShift": "Remover turno",
+      "start": "Início",
+      "end": "Fim"
+    },
+    "overrides": {
+      "startDate": "Data de início",
+      "endDate": "Data de fim",
+      "kind": "Tipo",
+      "reason": "Motivo",
+      "reasonPlaceholder": "Por exemplo: Natal, congresso...",
+      "closed": "Encerrado",
+      "customHours": "Horário personalizado",
+      "unavailable": "Indisponível",
+      "noOverrides": "Nenhuma data especial agendada",
+      "delete": "Eliminar",
+      "confirmDelete": "Eliminar este período?",
+      "add": "Adicionar",
+      "save": "Guardar",
+      "cancel": "Cancelar"
+    },
+    "analytics": {
+      "occupancyTitle": "Ocupação por gabinete",
+      "utilizationTitle": "Utilização por profissional",
+      "peakHoursTitle": "Horas de maior afluência",
+      "bookedMinutes": "Minutos ocupados",
+      "availableMinutes": "Minutos disponíveis",
+      "rate": "Ocupação",
+      "noData": "Sem dados no intervalo selecionado"
+    },
+    "availability": {
+      "clinicClosed": "Clínica encerrada",
+      "professionalOff": "Profissional indisponível",
+      "outsideHours": "Fora do horário configurado",
+      "confirmOutside": "Este horário está fora do horário de trabalho. Criar a consulta mesmo assim?",
+      "confirm": "Criar mesmo assim",
+      "cancel": "Cancelar"
+    }
+  }
+}

--- a/backend/app/modules/schedules/frontend/nuxt.config.ts
+++ b/backend/app/modules/schedules/frontend/nuxt.config.ts
@@ -12,7 +12,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- i18n: add `pt` fallback to plan item name resolution in service
+  layer so Portuguese-localized treatment names display correctly.
+
 - i18n: add `fr` fallback to plan item name resolution in service
   layer so French-localized treatment names display correctly.
 

--- a/backend/app/modules/treatment_plan/service.py
+++ b/backend/app/modules/treatment_plan/service.py
@@ -948,7 +948,7 @@ class TreatmentPlanService:
             patient_id_str = str(item.treatment.patient_id)
             if item.treatment.catalog_item:
                 names = item.treatment.catalog_item.names or {}
-                item_name = names.get("es") or names.get("en") or names.get("fr")
+                item_name = names.get("es") or names.get("en") or names.get("fr") or names.get("pt")
                 if item.treatment.catalog_item.category:
                     treatment_category_key = item.treatment.catalog_item.category.key
 

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - fix(frontend): the queue tabs (Pendientes/Rechazadas/Fallos) rendered

--- a/backend/app/modules/verifactu/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/verifactu/frontend/i18n/locales/pt.json
@@ -1,0 +1,351 @@
+{
+  "verifactu": {
+    "nav": { "settings": "Verifactu (AEAT)" },
+    "settingsCards": {
+      "title": "Verifactu (AEAT)",
+      "description": "Conformidade de faturação eletrónica espanhola. Faça a gestão do certificado, do produtor SIF, da fila de envio e do registo fiscal.",
+      "open": "Abrir"
+    },
+    "title": "Verifactu (AEAT)",
+    "subtitle": "Conformidade de faturação eletrónica espanhola (RRSIF / Veri*Factu).",
+    "hero": {
+      "loading": { "title": "A carregar…", "description": "" },
+      "setup": {
+        "title": "Configuração pendente",
+        "description": "Conclua os passos seguintes antes de ativar o Verifactu."
+      },
+      "inactive": {
+        "title": "Pronto a ativar",
+        "description": "Toda a configuração está concluída. Ative o Verifactu para começar a enviar faturas à AEAT."
+      },
+      "active-test": {
+        "title": "Verifactu ativo em modo de teste",
+        "description": "As faturas são enviadas para o ambiente de testes da AEAT. Útil para validar a integração antes de passar a produção."
+      },
+      "active-prod": {
+        "title": "Verifactu ativo em produção",
+        "description": "As faturas são enviadas como dados fiscais reais à AEAT. Qualquer erro fica oficialmente registado."
+      },
+      "activate": "Ativar Verifactu",
+      "deactivate": "Desativar Verifactu"
+    },
+    "setup": {
+      "clinicNif": "Configure o NIF fiscal da clínica (CIF/NIF)",
+      "clinicNifCta": "Informação da clínica",
+      "producer": "Preencha os dados do produtor SIF",
+      "producerCta": "Produtor",
+      "declaration": "Assine a declaración responsable do produtor",
+      "declarationCta": "Assinar",
+      "certificate": "Carregue o certificado digital (FNMT)",
+      "certificateCta": "Carregar"
+    },
+    "cards": {
+      "manage": "Gerir",
+      "emisor": {
+        "title": "Dados do emitente",
+        "editHint": "Estes dados provêm da informação da clínica. Para os alterar, edite-os aí.",
+        "editLink": "Informação da clínica"
+      },
+      "producer": {
+        "empty": "O produtor SIF ainda não está configurado."
+      },
+      "vatMapping": {
+        "title": "Classificação de IVA da AEAT",
+        "description": "Associe cada tipo de IVA do catálogo à respetiva classificação da AEAT (S1, E1, N1…)."
+      },
+      "activity": {
+        "title": "Atividade"
+      }
+    },
+    "modal": {
+      "confirmProdTitle": "Passar a produção?",
+      "confirmProdAction": "Sim, passar a produção"
+    },
+    "vatMapping": {
+      "title": "Classificação de IVA da AEAT",
+      "subtitle": "Defina como cada tipo de IVA do catálogo se traduz na respetiva classificação da AEAT em cada registo Verifactu.",
+      "legalIntroTitle": "Como funciona",
+      "legalIntro": "Deixar uma linha em 'Auto' usa uma heurística (taxa>0 → S1, taxa=0 → N1). Nos serviços clínicos dentários costuma fazer sentido fixar 'E1 — Isento art. 20 LIVA'. As clínicas espanholas normalmente só precisam de uma exceção no tipo de IVA 'Isento'.",
+      "empty": "Não há tipos de IVA no catálogo da clínica.",
+      "rate": "Taxa",
+      "defaultBadge": "Predefinido",
+      "autoOption": "Auto ({code}) — usar heurística",
+      "sourceAuto": "automático",
+      "sourceOverride": "exceção fixada",
+      "save": "Guardar",
+      "saved": "Classificação guardada.",
+      "saveFailed": "Não foi possível guardar a classificação.",
+      "notesPlaceholder": "Notas (ex.: 'art. 20.uno.3.º LIVA')"
+    },
+    "environment": {
+      "test": "Teste",
+      "prod": "Produção",
+      "switchToProd": "Passar a produção",
+      "switchToTest": "Passar a teste",
+      "warningProd": "Está prestes a passar a produção. A partir de agora, cada fatura emitida será enviada à AEAT como registo fiscal real.",
+      "label": "Ambiente"
+    },
+    "errors": {
+      "cannotPromoteToProd": "O seu perfil não pode promover o Verifactu a produção. Peça a um administrador que faça esta alteração."
+    },
+    "status": {
+      "enabled": "Ativado",
+      "disabled": "Desativado",
+      "noCertificate": "Sem certificado",
+      "certificateExpiringSoon": "O certificado expira dentro de {days} dias",
+      "certificateExpired": "Certificado expirado"
+    },
+    "settings": {
+      "title": "Definições do Verifactu",
+      "enable": "Ativar Verifactu",
+      "enableHint": "Quando ativo, cada fatura emitida é automaticamente enviada à AEAT.",
+      "nifEmisor": "NIF do emitente",
+      "nifEmisorHint": "O NIF da clínica. Tem de coincidir com o do certificado.",
+      "nombreRazon": "Denominação social do emitente",
+      "save": "Guardar",
+      "saved": "Definições guardadas"
+    },
+    "certificate": {
+      "title": "Certificado digital",
+      "description": "Carregue o certificado FNMT da clínica (.pfx / .p12). É guardado encriptado.",
+      "active": "Certificado ativo",
+      "healthy": "Válido",
+      "subject": "Titular",
+      "issuer": "Emissor",
+      "nif": "NIF do titular",
+      "validFrom": "Válido desde",
+      "validUntil": "Válido até",
+      "uploadFile": "Ficheiro do certificado",
+      "uploadHint": "Aceita os formatos .pfx e .p12.",
+      "password": "Palavra-passe do certificado",
+      "passwordHint": "A palavra-passe que protege o ficheiro. Nunca é guardada em texto simples.",
+      "passwordPlaceholder": "••••••••",
+      "togglePassword": "Mostrar/ocultar palavra-passe",
+      "uploadButton": "Carregar certificado",
+      "uploadTitle": "Carregar certificado",
+      "replaceTitle": "Substituir certificado",
+      "uploadSubmit": "Carregar certificado",
+      "replaceSubmit": "Substituir certificado",
+      "uploaded": "Certificado carregado e ativo",
+      "uploadFailed": "Não foi possível carregar o certificado",
+      "invalidFormat": "Formato inválido. Carregue um ficheiro .pfx ou .p12.",
+      "history": "Histórico de certificados",
+      "historyEmpty": "Ainda não foi carregado nenhum certificado.",
+      "noActive": "Sem certificado ativo",
+      "noActiveHint": "Carregue o seu certificado FNMT (.pfx / .p12) para ativar o Verifactu e assinar os envios à AEAT.",
+      "dropzoneTitle": "Largue aqui o seu certificado",
+      "dropzoneSubtitle": "ou clique para escolher um ficheiro",
+      "dropzoneFormats": "formato .pfx ou .p12",
+      "removeFile": "Remover ficheiro",
+      "encryptionNote": "O ficheiro e a palavra-passe são encriptados com a chave do servidor. Nunca são guardados em texto simples.",
+      "helpTitle": "Onde obter o certificado?",
+      "helpBody": "Para assinar os envios à AEAT precisa de um certificado digital da clínica, emitido pela FNMT. Há três tipos válidos:",
+      "helpItem1": "Certificado de Representante Legal — para sociedades (S.L., S.A.).",
+      "helpItem2": "Certificado Pessoal — para trabalhadores independentes cujo NIF coincida com o do emitente.",
+      "helpItem3": "Selo Empresarial — alternativa para entidades.",
+      "fnmtLink": "Solicitar o certificado no portal da FNMT"
+    },
+    "queue": {
+      "title": "Fila de envio",
+      "tabs": { "pending": "Pendentes", "rejected": "Recusados", "transient": "Erros transitórios" },
+      "empty": "Nenhum registo neste estado.",
+      "retry": "Tentar novamente",
+      "regenerateAndRetry": "Regenerar e reenviar",
+      "regenerateTooltip": "Recalcula o registo a partir dos dados atuais (NIF, linhas, …) e reenvia-o como Subsanación.",
+      "retryAll": "Regenerar tudo",
+      "retryAllConfirm": "Está prestes a regenerar todos os registos recusados desta clínica. Continuar?",
+      "retryAllResult": "{n} registos regenerados ({failed} falharam).",
+      "viewInvoice": "Ver fatura",
+      "viewHistory": "Histórico AEAT",
+      "errorCode": "Código",
+      "transportError": "Erro de transporte",
+      "aeatFault": "Resposta de erro da AEAT",
+      "rawError": "Mensagem original da AEAT",
+      "submissionAttempt": "Tentativa {n}",
+      "processNow": "Processar agora",
+      "processed": "{n} registos processados",
+      "regeneratedToast": "Registo regenerado e reenviado.",
+      "blockingBanner": {
+        "title": "{n} registo(s) Verifactu recusado(s)",
+        "description": "Não pode emitir novas faturas enquanto não forem resolvidos (quebraria a cadeia de hashes).",
+        "cta": "Abrir a fila",
+        "adminContact": "Contacte o administrador {email} se não tiver acesso."
+      },
+      "ctas": {
+        "edit_clinic": "Corrigir os meus dados fiscais",
+        "edit_billing_party": "Editar os dados do cliente",
+        "edit_lines": "Rever as linhas da fatura",
+        "edit_producer": "Editar o produtor SIF",
+        "retry": "Tentar novamente",
+        "contact_support": "Contactar o suporte"
+      },
+      "history": {
+        "title": "Histórico de envios à AEAT",
+        "empty": "Não há tentativas anteriores arquivadas (este é o primeiro envio).",
+        "attempt": "Tentativa n.º {n}",
+        "huella": "Hash",
+        "code": "Código AEAT"
+      }
+    },
+    "billingParty": {
+      "modalTitle": "Editar os dados do cliente",
+      "intro": "Estes dados serão enviados à AEAT como destinatário no próximo envio.",
+      "fields": {
+        "name": "Nome / denominação social",
+        "taxId": "NIF",
+        "address": "Morada"
+      },
+      "save": "Guardar e reenviar",
+      "saved": "Guardado. O Verifactu voltará a enviar o registo automaticamente.",
+      "concurrentEdit": "Outra pessoa editou esta fatura entretanto. Recarregue e tente novamente.",
+      "saveFailed": "Não foi possível guardar."
+    },
+    "invoiceBanner": {
+      "rejectedTitle": "A AEAT recusou este registo Verifactu",
+      "rejectedBody": "Corrija os dados abaixo e reenviaremos automaticamente como Subsanación.",
+      "pdfStaleTitle": "O PDF descarregado pode estar desatualizado",
+      "pdfStaleBody": "O QR muda depois de corrigir e reenviar. Volte a descarregar o PDF se já o tiver enviado ao paciente.",
+      "downloadAgain": "Descarregar o PDF atualizado"
+    },
+    "nif": {
+      "warningInvalid": "O formato do NIF não parece correto. A AEAT pode recusá-lo."
+    },
+    "globalBanner": {
+      "title": "Verifactu: {n} fatura(s) recusada(s) pela AEAT",
+      "description": "Resolva-as antes de emitir novas faturas (quebraria a cadeia de hashes).",
+      "cta": "Resolver"
+    },
+    "badge": {
+      "short": "AEAT",
+      "tooltip": {
+        "ok": "Aceite pela AEAT",
+        "warning": "Aceite com observações pela AEAT",
+        "pending": "Envio à AEAT pendente",
+        "error": "Recusada pela AEAT"
+      }
+    },
+    "filter": {
+      "label": "Verifactu",
+      "options": {
+        "ok": "Aceites",
+        "warning": "Com observações",
+        "pending": "Pendentes",
+        "error": "Recusadas"
+      },
+      "shortcut": "Apenas com problemas",
+      "empty": "Todas as faturas Verifactu estão em dia."
+    },
+    "records": {
+      "title": "Registo fiscal",
+      "subtitle": "Histórico imutável dos registos enviados à AEAT.",
+      "filterState": "Estado",
+      "filterTipo": "Tipo",
+      "columns": {
+        "createdAt": "Data",
+        "tipoFactura": "Tipo",
+        "serieNumero": "Número",
+        "importe": "Montante",
+        "state": "Estado",
+        "csv": "CSV da AEAT"
+      },
+      "viewXml": "Ver XML",
+      "verifyChain": "Verificar a cadeia"
+    },
+    "tipoFactura": {
+      "F1": "F1 — Fatura completa",
+      "F2": "F2 — Simplificada",
+      "F3": "F3 — Substituição",
+      "R1": "R1 — Retificação",
+      "R2": "R2 — Crédito incobrável",
+      "R5": "R5 — Retificação simplificada"
+    },
+    "recordState": {
+      "pending": "Pendente",
+      "sending": "A enviar",
+      "accepted": "Aceite",
+      "accepted_with_errors": "Aceite com erros",
+      "rejected": "Recusado",
+      "failed_transient": "A repetir",
+      "failed_validation": "Erro de validação"
+    },
+    "panel": {
+      "verifactuTitle": "Verifactu",
+      "huella": "Hash",
+      "csv": "CSV da AEAT",
+      "qr": "Código QR",
+      "viewRecord": "Ver o registo completo",
+      "submittedAt": "Enviado",
+      "stillPending": "Envio à AEAT pendente"
+    },
+    "producer": {
+      "title": "Produtor SIF",
+      "subtitle": "Identificação legal de quem coloca o software em produção e assina a declaración responsable.",
+      "legalIntroTitle": "Responsabilidade legal",
+      "legalIntro": "O art. 13 do RD 1007/2023 exige que o produtor do Sistema Informático de Facturación assine uma declaración responsable. Se o DentalPin for disponibilizado como SaaS gerido, o produtor é o operador do SaaS. Se uma clínica o alojar por conta própria (autodesarrollo), a própria clínica é o produtor. Se for um integrador a instalá-lo, o produtor é o integrador.",
+      "process": {
+        "title": "O que tem de fazer",
+        "s1": "Identificar quem é o produtor SIF (passo 1) — dados legais que constam da declaração e de cada registo enviado à AEAT.",
+        "s2": "Ler a declaración responsable e assiná-la eletronicamente (passo 2). O sistema sela a data e o utilizador signatário como prova.",
+        "s3": "Descarregar o PDF assinado (passo 3) para arquivo e, se operar um SaaS, para distribuir às suas clínicas.",
+        "legalNote": "A assinatura eletrónica guardada no sistema é prova suficiente numa auditoria da AEAT. O PDF é um documento informativo derivado dessa assinatura."
+      },
+      "step1": {
+        "title": "Dados do produtor",
+        "description": "Estes campos identificam legalmente o produtor SIF e são incorporados tanto na declaración responsable como no bloco SistemaInformatico de cada registo enviado à AEAT.",
+        "lockedTitle": "Dados selados",
+        "lockedDescription": "A declaração já foi assinada com estes dados, pelo que estão bloqueados. Contacte o suporte para revogar a assinatura caso precise de os alterar."
+      },
+      "step2": {
+        "title": "Assinar a declaração",
+        "description": "Leia o texto com atenção. Quando estiver de acordo, assinale a caixa e clique em Assinar eletronicamente. A assinatura é selada no sistema com a data e o utilizador."
+      },
+      "step3": {
+        "title": "Descarregar a declaração assinada",
+        "description": "Documento imprimível com os dados do produtor e o selo da assinatura eletrónica. Útil para arquivo interno, auditoria da AEAT ou distribuição às clínicas que usam o sistema.",
+        "lockedHint": "Disponível depois de a declaração ser assinada (passo 2)."
+      },
+      "fields": {
+        "name": "Denominação social do produtor",
+        "nameHint": "Denominação social da empresa ou do trabalhador independente que atua como produtor SIF.",
+        "nif": "NIF do produtor",
+        "nifHint": "NIF do produtor SIF. Consta de cada registo enviado à AEAT.",
+        "idSistema": "ID do sistema",
+        "idSistemaHint": "Identificador curto (1-2 caracteres) que o produtor atribui ao sistema. Predefinição: DP.",
+        "version": "Versão do sistema",
+        "versionHint": "Versão do software em produção (ex.: 0.1.0)."
+      },
+      "declaration": {
+        "heading": "Declaración responsable",
+        "legalRef": "Sistema Informático de Facturación — Veri*Factu (RD 1007/2023, art. 13)",
+        "preamble": "Nos termos do artigo 13 do Real Decreto 1007/2023 (RRSIF) e da Ordem HAC/1177/2024:",
+        "identity": "{name}, com NIF {nif}, na qualidade de produtor do Sistema Informático de Facturación denominado DentalPin (identificador de sistema {idSistema}, versão {version}), declara sob sua responsabilidade que:",
+        "item1": "O sistema cumpre os requisitos do artigo 29.2.j) da Lei 58/2003 (General Tributaria) e do RRSIF.",
+        "item2": "O sistema garante a integridade, conservação, acessibilidade, legibilidade, rastreabilidade e inalterabilidade dos registos de faturação.",
+        "item3": "O sistema implementa o envio contínuo de registos à AEAT em modo Veri*Factu.",
+        "item4": "O produtor compromete-se a manter o sistema atualizado à medida que a regulamentação evolui."
+      },
+      "statusSigned": "Assinada",
+      "statusUnsigned": "A aguardar assinatura",
+      "readAndAccept": "Li e aceito a declaración responsable enquanto produtor SIF.",
+      "signButton": "Assinar eletronicamente",
+      "signNote": "Ao clicar no botão, a assinatura fica registada com a data e o seu utilizador. A ação não pode ser anulada a partir da interface.",
+      "signedToast": "Declaração assinada e registada.",
+      "sealedNote": "Os dados do produtor ficam selados como prova para uma eventual auditoria da AEAT.",
+      "saveDraft": "Guardar sem assinar",
+      "draftSaved": "Rascunho guardado (assinatura pendente).",
+      "downloadPdf": "Descarregar o PDF assinado",
+      "revokeAction": "Revogar a assinatura para editar",
+      "revokeTitle": "Revogar a assinatura?",
+      "revokeBody": "Revogar a assinatura eletrónica permite voltar a editar os dados do produtor. Antes de continuar:",
+      "revokeBullet1": "A assinatura atual perde valor legal como prova perante a AEAT.",
+      "revokeBullet2": "O Verifactu é automaticamente desativado até assinar a nova declaração.",
+      "revokeBullet3": "Os registos já enviados à AEAT não são afetados — muda apenas o produtor declarado nos envios futuros.",
+      "revokeConfirm": "Revogar e editar",
+      "revokedToast": "Assinatura revogada. Já pode editar os dados do produtor.",
+      "signLabel": "Assinar a declaración responsable",
+      "alreadySigned": "Declaração assinada",
+      "signedAt": "Assinada eletronicamente a {at}",
+      "saveFailed": "Não foi possível guardar a informação do produtor."
+    }
+  }
+}

--- a/backend/app/modules/verifactu/frontend/nuxt.config.ts
+++ b/backend/app/modules/verifactu/frontend/nuxt.config.ts
@@ -11,7 +11,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/whatsapp_kapso/CHANGELOG.md
+++ b/backend/app/modules/whatsapp_kapso/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Portuguese locale (`pt.json`) with full UI coverage.
+
 - i18n: add French locale (`fr.json`) with full UI coverage.
 
 - feat: initial release. WhatsApp delivery for the notifications gateway via

--- a/backend/app/modules/whatsapp_kapso/frontend/i18n/locales/pt.json
+++ b/backend/app/modules/whatsapp_kapso/frontend/i18n/locales/pt.json
@@ -1,0 +1,38 @@
+{
+  "whatsapp_kapso": {
+    "settings": {
+      "title": "WhatsApp (Kapso)",
+      "description": "Ligue o número de WhatsApp da clínica através da Kapso para enviar e receber mensagens."
+    },
+    "connection": "Ligação",
+    "verified": "Verificado",
+    "notVerified": "Não verificado",
+    "apiKey": "Chave de API da Kapso",
+    "phoneNumberId": "ID do número de telefone",
+    "businessAccountId": "ID da conta empresarial",
+    "businessAccountHelp": "Necessário para sincronizar os modelos aprovados.",
+    "displayPhone": "Número apresentado",
+    "webhookSecret": "Segredo do webhook",
+    "secretStored": "Guardado. Deixe vazio para o manter inalterado.",
+    "webhook": "Webhook",
+    "webhookHelp": "Cole este URL nas definições de webhook da Kapso para receber estados e respostas.",
+    "copy": "Copiar",
+    "copied": "URL copiado",
+    "templates": "Modelos",
+    "sync": "Sincronizar",
+    "noTemplates": "Não há modelos aprovados. Sincronize para os obter da Kapso.",
+    "notificationType": "Tipo de notificação",
+    "template": "Modelo",
+    "map": "Associar",
+    "mapped": "Modelo associado",
+    "mapError": "Não foi possível associar o modelo",
+    "test": "Envio de teste",
+    "sendTest": "Enviar teste",
+    "testOk": "Mensagem de teste enviada",
+    "testFail": "Falha ao enviar o teste",
+    "saved": "Definições guardadas",
+    "saveError": "Não foi possível guardar",
+    "synced": "{n} modelos sincronizados",
+    "syncError": "Não foi possível sincronizar"
+  }
+}

--- a/backend/app/modules/whatsapp_kapso/frontend/nuxt.config.ts
+++ b/backend/app/modules/whatsapp_kapso/frontend/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
-      { code: 'fr', file: 'fr.json' }
+      { code: 'fr', file: 'fr.json' },
+      { code: 'pt', file: 'pt.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/templates/email/pt/appointment_cancelled.html
+++ b/backend/templates/email/pt/appointment_cancelled.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Consulta cancelada - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Olá {{ patient_name }},</h2>
+
+<p>Informamos que a sua consulta foi cancelada.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Data</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Hora</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Profissional</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+{% if cancellation_reason %}
+<div class="alert alert-warning">
+    <strong>Motivo:</strong> {{ cancellation_reason }}
+</div>
+{% endif %}
+
+<p>Se pretender remarcar a sua consulta, não hesite em contactar-nos.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Marcar nova consulta</a>
+</div>
+{% endif %}
+
+<p>Pedimos desculpa pelo incómodo causado.</p>
+{% endblock %}

--- a/backend/templates/email/pt/appointment_confirmation.html
+++ b/backend/templates/email/pt/appointment_confirmation.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}Confirmação de consulta - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Olá {{ patient_name }},</h2>
+
+<p>A sua consulta foi confirmada. Estes são os detalhes:</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Data</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Hora</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Profissional</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if cabinet_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Gabinete</div>
+            <div class="value">{{ cabinet_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if treatment_type %}
+    <div class="info-row">
+        <div>
+            <div class="label">Tratamento</div>
+            <div class="value">{{ treatment_type }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+{% if notes %}
+<div class="alert alert-info">
+    <strong>Notas:</strong> {{ notes }}
+</div>
+{% endif %}
+
+<p>Agradecemos que chegue 10 minutos antes da consulta. Se precisar de cancelar ou remarcar, avise-nos com pelo menos 24 horas de antecedência.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Telefonar à clínica</a>
+</div>
+{% endif %}
+
+<p>Até breve!</p>
+{% endblock %}

--- a/backend/templates/email/pt/appointment_reminder.html
+++ b/backend/templates/email/pt/appointment_reminder.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block title %}Lembrete de consulta - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Olá {{ patient_name }},</h2>
+
+<p>Lembramos que tem uma consulta marcada:</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">Data</div>
+            <div class="value">{{ appointment_date }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Hora</div>
+            <div class="value">{{ appointment_time }}</div>
+        </div>
+    </div>
+    {% if professional_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Profissional</div>
+            <div class="value">{{ professional_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if cabinet_name %}
+    <div class="info-row">
+        <div>
+            <div class="label">Gabinete</div>
+            <div class="value">{{ cabinet_name }}</div>
+        </div>
+    </div>
+    {% endif %}
+    {% if treatment_type %}
+    <div class="info-row">
+        <div>
+            <div class="label">Tratamento</div>
+            <div class="value">{{ treatment_type }}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<div class="alert alert-info">
+    <strong>Lembrete:</strong> agradecemos que chegue 10 minutos antes da consulta.
+</div>
+
+{% if notes %}
+<p><strong>Notas:</strong> {{ notes }}</p>
+{% endif %}
+
+<p>Se não puder comparecer, avise-nos com antecedência para podermos reatribuir o horário.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Confirmar a minha presença</a>
+</div>
+{% endif %}
+
+<p>Até breve!</p>
+{% endblock %}

--- a/backend/templates/email/pt/budget_accepted.html
+++ b/backend/templates/email/pt/budget_accepted.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Orçamento aceite - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Olá {{ patient_name }},</h2>
+
+<p>Registámos a aceitação do seu orçamento. Obrigado pela sua confiança.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">N.º do orçamento</div>
+            <div class="value">{{ budget_number }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Data de aceitação</div>
+            <div class="value">{{ accepted_date }}</div>
+        </div>
+    </div>
+    <div class="info-row">
+        <div>
+            <div class="label">Total do tratamento</div>
+            <div class="value" style="font-size: 20px; color: #3b82f6;">{{ total }} €</div>
+        </div>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <strong>Passo seguinte!</strong> Entraremos em contacto para marcar as consultas necessárias ao seu tratamento.
+</div>
+
+{% if notes %}
+<p><strong>Notas:</strong> {{ notes }}</p>
+{% endif %}
+
+<p>Se tiver dúvidas ou quiser marcar já a sua primeira consulta, contacte-nos.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Marcar consulta</a>
+</div>
+{% endif %}
+
+<p>Obrigado pela sua confiança!</p>
+{% endblock %}

--- a/backend/templates/email/pt/budget_sent.html
+++ b/backend/templates/email/pt/budget_sent.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+
+{% block title %}Orçamento - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Olá {{ patient_name }},</h2>
+
+<p>Enviamos-lhe o orçamento detalhado para o seu tratamento dentário.</p>
+
+<div class="info-box">
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">N.º do orçamento</div>
+            <div class="value">{{ budget_number }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Data</div>
+            <div class="value">{{ budget_date }}</div>
+        </div>
+    </div>
+</div>
+
+{% if treatments %}
+<table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+    <thead>
+        <tr style="border-bottom: 2px solid #e4e4e7;">
+            <th style="text-align: left; padding: 12px 0; font-size: 12px; font-weight: 600; text-transform: uppercase; color: #71717a;">Tratamento</th>
+            <th style="text-align: right; padding: 12px 0; font-size: 12px; font-weight: 600; text-transform: uppercase; color: #71717a;">Montante</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for treatment in treatments %}
+        <tr style="border-bottom: 1px solid #f4f4f5;">
+            <td style="padding: 12px 0;">
+                <div style="font-weight: 500;">{{ treatment.name }}</div>
+                {% if treatment.tooth %}
+                <div style="font-size: 14px; color: #71717a;">Dente: {{ treatment.tooth }}</div>
+                {% endif %}
+            </td>
+            <td style="text-align: right; padding: 12px 0;">{{ treatment.price }} €</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        {% if subtotal and total != subtotal %}
+        <tr>
+            <td style="padding: 12px 0; text-align: right; font-weight: 500;">Subtotal:</td>
+            <td style="padding: 12px 0; text-align: right;">{{ subtotal }} €</td>
+        </tr>
+        {% endif %}
+        {% if discount_amount %}
+        <tr>
+            <td style="padding: 12px 0; text-align: right; font-weight: 500; color: #22c55e;">Desconto:</td>
+            <td style="padding: 12px 0; text-align: right; color: #22c55e;">-{{ discount_amount }} €</td>
+        </tr>
+        {% endif %}
+        <tr style="border-top: 2px solid #18181b;">
+            <td style="padding: 16px 0; text-align: right; font-size: 18px; font-weight: 600;">Total:</td>
+            <td style="padding: 16px 0; text-align: right; font-size: 18px; font-weight: 600;">{{ total }} €</td>
+        </tr>
+    </tfoot>
+</table>
+{% endif %}
+
+{% if validity_days %}
+<div class="alert alert-info">
+    <strong>Validade:</strong> este orçamento é válido durante {{ validity_days }} dias a contar da data de emissão.
+</div>
+{% endif %}
+
+{% if notes %}
+<p><strong>Observações:</strong> {{ notes }}</p>
+{% endif %}
+
+<p>Se tiver dúvidas sobre o orçamento ou quiser agendar o seu tratamento, não hesite em contactar-nos.</p>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Contacte-nos</a>
+</div>
+{% endif %}
+
+<p>Ficamos ao seu dispor.</p>
+{% endblock %}

--- a/backend/templates/email/pt/copilot_morning_digest.html
+++ b/backend/templates/email/pt/copilot_morning_digest.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+
+{% block title %}Resumo do dia - {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Resumo de {{ today }}</h2>
+
+{% if appointments is not none %}
+<h3>Consultas de hoje ({{ appointments | length }})</h3>
+{% if appointments %}
+<div class="info-box">
+    {% for a in appointments %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">{{ a.start_time[11:16] if a.start_time else '' }}</div>
+            <div class="value">{{ a.patient_name or '—' }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Estado</div>
+            <div class="value">{{ a.status }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Não há consultas marcadas para hoje.</p>
+{% endif %}
+{% endif %}
+
+{% if recalls is not none %}
+<h3>Reconvocações em atraso ({{ recalls | length }})</h3>
+{% if recalls %}
+<div class="info-box">
+    {% for r in recalls %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">{{ r.reason }}</div>
+            <div class="value">{{ r.patient_name or '—' }}{% if r.phone %} · {{ r.phone }}{% endif %}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Prioridade</div>
+            <div class="value">{{ r.priority }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Não há reconvocações em atraso.</p>
+{% endif %}
+{% endif %}
+
+{% if budgets is not none %}
+<h3>Orçamentos a aguardar resposta ({{ budgets | length }})</h3>
+{% if budgets %}
+<div class="info-box">
+    {% for b in budgets %}
+    <div class="info-row">
+        <div style="flex: 1;">
+            <div class="label">{{ b.number }}</div>
+            <div class="value">{{ b.patient_name or '—' }}</div>
+        </div>
+        <div style="flex: 1;">
+            <div class="label">Montante</div>
+            <div class="value">{{ b.total }}</div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Não há orçamentos a aguardar resposta.</p>
+{% endif %}
+{% endif %}
+
+<p style="color: #71717a; font-size: 14px;">
+    Resumo automático gerado pelo copilot do DentalPin. Pode
+    desativá-lo ou alterar a hora em Definições → Copilot.
+</p>
+{% endblock %}

--- a/backend/templates/email/pt/verifactu_cert_expiry.html
+++ b/backend/templates/email/pt/verifactu_cert_expiry.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}{% if is_expired %}O seu certificado Verifactu expirou{% else %}O seu certificado Verifactu está prestes a expirar{% endif %}{% endblock %}
+
+{% block content %}
+<h2>Olá {{ admin_name }},</h2>
+
+{% if is_expired %}
+<div class="alert alert-error">
+    O certificado digital da clínica <strong>{{ clinic_name }}</strong> usado para assinar os envios à AEAT (Veri*Factu) <strong>expirou</strong>. Enquanto não o renovar, os registos ficam em fila de espera e a AEAT recusará qualquer envio.
+</div>
+{% else %}
+<div class="alert alert-warning">
+    O certificado digital da clínica <strong>{{ clinic_name }}</strong> usado para assinar os envios à AEAT (Veri*Factu) expira dentro de <strong>{{ days_left }} dia{% if days_left != 1 %}s{% endif %}</strong>. Recomendamos que o renove antes do prazo para evitar qualquer interrupção da faturação.
+</div>
+{% endif %}
+
+<div class="info-box">
+    <div class="label">Titular do certificado</div>
+    <div class="value">{{ subject_cn or '—' }}</div>
+</div>
+
+<div class="info-box">
+    <div class="label">Data de expiração</div>
+    <div class="value">{{ valid_until.strftime('%d/%m/%Y') }}</div>
+</div>
+
+<h3 style="margin-top: 24px; margin-bottom: 12px; font-size: 16px; font-weight: 600;">O que tem de fazer?</h3>
+
+<ol style="padding-left: 20px; color: #3f3f46;">
+    <li style="margin-bottom: 8px;">Solicite um novo certificado à FNMT (Representante de Pessoa Coletiva, Pessoa Singular ou Selo Empresarial).</li>
+    <li style="margin-bottom: 8px;">Inicie sessão no DentalPin como administrador e aceda a <em>Definições → Verifactu → Certificado</em>.</li>
+    <li style="margin-bottom: 8px;">Carregue o novo ficheiro <code>.pfx</code> e introduza a respetiva palavra-passe. O certificado anterior fica arquivado para auditoria.</li>
+</ol>
+
+<p>Se precisar de ajuda, responda a este email e orientamo-lo passo a passo.</p>
+{% endblock %}

--- a/backend/templates/email/pt/verifactu_cert_expiry.txt
+++ b/backend/templates/email/pt/verifactu_cert_expiry.txt
@@ -1,0 +1,17 @@
+Olá {{ admin_name }},
+
+{% if is_expired -%}
+O certificado digital da clínica "{{ clinic_name }}" usado para assinar os envios à AEAT (Veri*Factu) EXPIROU. Enquanto não o renovar, os registos ficam em fila de espera e a AEAT recusará qualquer envio.
+{%- else -%}
+O certificado digital da clínica "{{ clinic_name }}" usado para assinar os envios à AEAT (Veri*Factu) expira dentro de {{ days_left }} dia(s). Recomendamos que o renove antes do prazo para evitar qualquer interrupção da faturação.
+{%- endif %}
+
+Titular: {{ subject_cn or '—' }}
+Expiração: {{ valid_until.strftime('%d/%m/%Y') }}
+
+Passos:
+1. Solicite um novo certificado à FNMT.
+2. Inicie sessão no DentalPin → Definições → Verifactu → Certificado.
+3. Carregue o ficheiro .pfx e introduza a respetiva palavra-passe.
+
+Se precisar de ajuda, responda a este email.

--- a/backend/templates/email/pt/verifactu_record_rejected.html
+++ b/backend/templates/email/pt/verifactu_record_rejected.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}Fatura recusada pela AEAT — ação necessária{% endblock %}
+
+{% block content %}
+<h2>Olá {{ admin_name }},</h2>
+
+<div class="alert alert-error">
+    A AEAT <strong>recusou</strong> o registo Verifactu da fatura <strong>{{ invoice_number }}</strong> da clínica <strong>{{ clinic_name }}</strong>.
+    Enquanto não resolver este problema, <strong>não poderá emitir novas faturas</strong> (a cadeia de hashes ficaria comprometida).
+</div>
+
+<div class="info-box">
+    <div class="label">Fatura</div>
+    <div class="value">{{ invoice_number }}</div>
+</div>
+
+<div class="info-box">
+    <div class="label">Código AEAT</div>
+    <div class="value">{{ codigo_error or '—' }}</div>
+</div>
+
+<div class="info-box">
+    <div class="label">Motivo</div>
+    <div class="value">{{ friendly_message }}</div>
+</div>
+
+<h3 style="margin-top: 24px; margin-bottom: 12px; font-size: 16px; font-weight: 600;">O que fazer agora?</h3>
+
+<ol style="padding-left: 20px; color: #3f3f46;">
+    {% if suggested_cta == 'edit_clinic' %}
+    <li style="margin-bottom: 8px;">Aceda a <em>Definições → Clínica</em> e verifique o CIF/NIF da clínica.</li>
+    <li style="margin-bottom: 8px;">Volte a <em>Definições → Verifactu → Fila de envio</em> e clique em <strong>«Regenerar e reenviar»</strong>.</li>
+    {% elif suggested_cta == 'edit_billing_party' %}
+    <li style="margin-bottom: 8px;">Abra a fatura {{ invoice_number }} e clique em <strong>«Editar os dados do cliente»</strong> na faixa vermelha.</li>
+    <li style="margin-bottom: 8px;">Depois de guardar, o registo é reenviado automaticamente.</li>
+    {% elif suggested_cta == 'edit_lines' %}
+    <li style="margin-bottom: 8px;">Verifique a correspondência do IVA e os montantes da fatura {{ invoice_number }}.</li>
+    <li style="margin-bottom: 8px;">Emita uma nota de crédito se a fatura já estava paga, ou volte a emiti-la se ainda era um rascunho.</li>
+    {% else %}
+    <li style="margin-bottom: 8px;">Aceda a <em>Definições → Verifactu → Fila de envio</em> para ver os detalhes da recusa.</li>
+    <li style="margin-bottom: 8px;">Se a causa não for clara, contacte o suporte indicando o código de erro.</li>
+    {% endif %}
+</ol>
+
+{% if queue_url %}
+<p style="margin-top: 20px;">
+    <a href="{{ queue_url }}" style="display: inline-block; padding: 10px 16px; background: #18181b; color: #fff; text-decoration: none; border-radius: 6px;">Abrir a fila Verifactu</a>
+</p>
+{% endif %}
+{% endblock %}

--- a/backend/templates/email/pt/verifactu_record_rejected.txt
+++ b/backend/templates/email/pt/verifactu_record_rejected.txt
@@ -1,0 +1,27 @@
+Olá {{ admin_name }},
+
+A AEAT RECUSOU o registo Verifactu da fatura {{ invoice_number }} da clínica "{{ clinic_name }}".
+Enquanto não resolver este problema, não poderá emitir novas faturas (a cadeia de hashes ficaria comprometida).
+
+Fatura: {{ invoice_number }}
+Código AEAT: {{ codigo_error or '—' }}
+Motivo: {{ friendly_message }}
+
+Passos:
+{% if suggested_cta == 'edit_clinic' -%}
+1. Aceda a Definições → Clínica e verifique o CIF/NIF.
+2. Volte a Definições → Verifactu → Fila de envio e clique em «Regenerar e reenviar».
+{% elif suggested_cta == 'edit_billing_party' -%}
+1. Abra a fatura {{ invoice_number }} e clique em «Editar os dados do cliente» na faixa de aviso.
+2. Depois de guardar, o registo é reenviado automaticamente.
+{% elif suggested_cta == 'edit_lines' -%}
+1. Verifique a correspondência do IVA e os montantes da fatura.
+2. Emita uma nota de crédito se a fatura já estava paga.
+{% else -%}
+1. Aceda a Definições → Verifactu → Fila de envio para ver os detalhes.
+2. Se a causa não for clara, contacte o suporte indicando o código de erro.
+{% endif %}
+
+{% if queue_url -%}
+Fila Verifactu: {{ queue_url }}
+{%- endif %}

--- a/backend/templates/email/pt/welcome.html
+++ b/backend/templates/email/pt/welcome.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Bem-vindo à {{ clinic_name }}{% endblock %}
+
+{% block content %}
+<h2>Bem-vindo, {{ patient_name }}!</h2>
+
+<p>Obrigado por se ter registado na {{ clinic_name }}. É um prazer poder ajudá-lo a cuidar da sua saúde oral.</p>
+
+<div class="alert alert-success">
+    A sua ficha de paciente foi criada com sucesso no nosso sistema.
+</div>
+
+<h3 style="margin-top: 24px; margin-bottom: 12px; font-size: 16px; font-weight: 600;">O que pode fazer agora?</h3>
+
+<ul style="padding-left: 20px; color: #3f3f46;">
+    <li style="margin-bottom: 8px;">Marcar a sua primeira consulta de avaliação</li>
+    <li style="margin-bottom: 8px;">Conhecer os nossos serviços e tratamentos</li>
+    <li style="margin-bottom: 8px;">Contactar-nos para qualquer questão</li>
+</ul>
+
+{% if clinic_phone %}
+<div class="button-container">
+    <a href="tel:{{ clinic_phone }}" class="button">Marcar a minha primeira consulta</a>
+</div>
+{% endif %}
+
+<div class="info-box">
+    <div class="label">Horário de funcionamento</div>
+    <div class="value">{{ clinic_hours | default('Segunda a sexta-feira: 9h00 - 20h00') }}</div>
+</div>
+
+<p>Não hesite em contactar-nos se tiver alguma dúvida. Estamos aqui para ajudar.</p>
+
+<p>Até breve!</p>
+{% endblock %}

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { fr, es, en } from '@nuxt/ui/locale'
+import { fr, es, en, pt } from '@nuxt/ui/locale'
 
 const { t, locale } = useI18n()
 
-const nuxtUILocales: Record<string, typeof en> = { en, fr, es }
+const nuxtUILocales: Record<string, typeof en> = { en, fr, es, pt }
 const nuxtUILocale = computed(() => nuxtUILocales[locale.value] || en)
 
 useHead(() => ({

--- a/frontend/app/constants/languages.ts
+++ b/frontend/app/constants/languages.ts
@@ -1,5 +1,6 @@
 export const SUPPORTED_LOCALES = [
   'en',
   'es',
-  'fr'
+  'fr',
+  'pt'
 ] as const

--- a/frontend/i18n/locales/pt.json
+++ b/frontend/i18n/locales/pt.json
@@ -1,0 +1,2948 @@
+{
+  "app": {
+    "name": "DentalPin",
+    "tagline": "Gestão de clínica dentária"
+  },
+  "demo": {
+    "bannerMessage": "Demonstração pública — não introduza dados reais de pacientes. A base de dados é reposta periodicamente.",
+    "bannerDismiss": "Dispensar",
+    "credentialsTitle": "Credenciais de demonstração",
+    "credentialsNote": "Apenas para avaliação — mostradas por se tratar de uma instância de demonstração pública.",
+    "copyEmail": "Copiar email",
+    "copyPassword": "Copiar palavra-passe",
+    "copied": "Copiado para a área de transferência"
+  },
+  "nav": {
+    "dashboard": "Início",
+    "patients": "Pacientes",
+    "appointments": "Agenda",
+    "recalls": "Reconvocações",
+    "treatmentPlans": "Planos de tratamento",
+    "budgets": "Orçamentos",
+    "invoices": "Faturas",
+    "reports": "Relatórios",
+    "settings": "Definições",
+    "defaultClinicName": "Clínica",
+    "catalog": "Catálogo",
+    "menu": "Menu",
+    "openMenu": "Abrir menu",
+    "close": "Fechar",
+    "toggleSidebar": "Alternar barra lateral"
+  },
+  "auth": {
+    "login": "Iniciar sessão",
+    "logout": "Terminar sessão",
+    "email": "Email",
+    "password": "Palavra-passe",
+    "loginButton": "Entrar",
+    "loginSuccess": "Sessão iniciada com sucesso",
+    "invalidCredentials": "Email ou palavra-passe incorretos",
+    "emailRequired": "Introduza o seu email",
+    "passwordRequired": "Introduza a sua palavra-passe",
+    "emailInvalid": "Endereço de email inválido",
+    "accountInactive": "A sua conta está inativa. Contacte o administrador",
+    "tooManyAttempts": "Demasiadas tentativas. Tente novamente dentro de alguns minutos",
+    "sessionExpired": "A sua sessão expirou",
+    "networkError": "Não foi possível ligar ao servidor",
+    "serverError": "O servidor está indisponível. Tente novamente dentro de alguns minutos",
+    "unknownError": "Erro inesperado. Tente novamente"
+  },
+  "setup": {
+    "title": "Configuração inicial",
+    "subtitle": "Crie a conta de administrador e a sua clínica para começar",
+    "stepAccount": "Conta de administrador",
+    "stepClinic": "Dados da clínica",
+    "firstName": "Nome",
+    "lastName": "Apelido",
+    "email": "Email",
+    "password": "Palavra-passe",
+    "passwordConfirm": "Confirmar palavra-passe",
+    "passwordHint": "Pelo menos 8 caracteres, com letras e números",
+    "clinicName": "Nome da clínica",
+    "taxId": "NIF",
+    "next": "Seguinte",
+    "back": "Voltar",
+    "submit": "Criar e começar",
+    "success": "Tudo pronto! Bem-vindo ao DentalPin",
+    "firstNameRequired": "Introduza o nome",
+    "lastNameRequired": "Introduza o apelido",
+    "emailRequired": "Introduza o email",
+    "emailInvalid": "O email não é válido",
+    "passwordRequired": "Introduza uma palavra-passe",
+    "passwordTooShort": "A palavra-passe deve ter pelo menos 8 caracteres",
+    "passwordWeak": "A palavra-passe deve incluir letras e números",
+    "passwordMismatch": "As palavras-passe não coincidem",
+    "clinicNameRequired": "Introduza o nome da clínica",
+    "taxIdRequired": "Introduza o NIF",
+    "alreadyInitialized": "O sistema já está configurado. Inicie sessão.",
+    "error": "Não foi possível concluir a configuração. Tente novamente"
+  },
+  "actions": {
+    "edit": "Editar",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "create": "Criar",
+    "delete": "Eliminar",
+    "close": "Fechar",
+    "remove": "Remover"
+  },
+  "patients": {
+    "title": "Pacientes",
+    "create": "Novo paciente",
+    "edit": "Editar paciente",
+    "search": "Procurar paciente...",
+    "searchPlaceholder": "Nome ou telefone",
+    "noResults": "Nenhum paciente encontrado",
+    "empty": "Nenhum paciente registado",
+    "emptyAction": "Criar primeiro paciente",
+    "name": "Nome",
+    "firstName": "Nome",
+    "lastName": "Apelido",
+    "phone": "Telefone",
+    "email": "Email",
+    "dateOfBirth": "Data de nascimento",
+    "notes": "Notas",
+    "created": "Paciente criado",
+    "updated": "Paciente atualizado",
+    "archived": "Paciente arquivado",
+    "notFound": "Paciente não encontrado",
+    "archiveConfirm": "Arquivar o paciente {name}?",
+    "archiveDescription": "Esta ação irá ocultar o paciente das pesquisas. As consultas existentes não serão eliminadas.",
+    "cancel": "Cancelar",
+    "archive": "Arquivar",
+    "dangerZone": {
+      "title": "Zona de perigo",
+      "archiveHelp": "Arquive o paciente para o ocultar das pesquisas. As consultas e o histórico são preservados."
+    },
+    "billingSection": "Dados de faturação",
+    "billingSectionHint": "Estes dados serão usados automaticamente ao criar faturas para este paciente.",
+    "editingBillingForInvoice": "A editar dados de faturação. As alterações serão refletidas na fatura.",
+    "returnToInvoice": "Voltar à fatura",
+    "billingName": "Nome de faturação",
+    "billingNamePlaceholder": "Nome ou empresa para as faturas",
+    "billingTaxId": "NIF",
+    "billingEmail": "Email de faturação",
+    "billingAddress": "Morada de faturação",
+    "billingComplete": "Completo",
+    "billingIncomplete": "Incompleto",
+    "demographics": "Dados demográficos",
+    "nationalId": "Documento de identificação",
+    "nationalIdType": "Tipo de documento",
+    "passport": "Passaporte",
+    "profession": "Profissão",
+    "workplace": "Local de trabalho",
+    "years": "anos",
+    "status": {
+      "active": "Ativo",
+      "archived": "Arquivado"
+    },
+    "filters": {
+      "status": "Estado",
+      "city": "Cidade",
+      "withDebt": "Com dívida",
+      "doNotContact": "Não contactar",
+      "doNotContactOnly": "Apenas não contactar",
+      "doNotContactOnlyContactable": "Apenas contactáveis"
+    },
+    "columns": {
+      "city": "Cidade",
+      "contact": "Contacto",
+      "debt": "Dívida"
+    },
+    "sort": {
+      "lastVisit": "Última visita",
+      "lastName": "Apelido",
+      "firstName": "Nome",
+      "createdAt": "Data de registo",
+      "updatedAt": "Editados recentemente"
+    },
+    "doNotContact": {
+      "label": "Não contactar",
+      "hint": "O paciente será excluído da lista de chamadas e das comunicações automáticas",
+      "badge": "Não contactar"
+    },
+    "gender": {
+      "label": "Género",
+      "select": "Selecionar género",
+      "male": "Masculino",
+      "female": "Feminino",
+      "other": "Outro",
+      "preferNotSay": "Prefiro não dizer"
+    },
+    "emergencyContact": {
+      "title": "Contacto de emergência",
+      "hasContact": "Tem contacto de emergência",
+      "noContact": "Nenhum contacto de emergência registado",
+      "name": "Nome completo",
+      "namePlaceholder": "Nome do contacto",
+      "relationship": "Relação",
+      "relationshipPlaceholder": "Selecionar relação",
+      "phone": "Telefone",
+      "phonePlaceholder": "Telefone do contacto",
+      "email": "Email",
+      "emailPlaceholder": "Email do contacto",
+      "isLegalGuardian": "É tutor legal",
+      "remove": "Remover contacto",
+      "relationships": {
+        "spouse": "Cônjuge",
+        "parent": "Pai/Mãe",
+        "child": "Filho/a",
+        "sibling": "Irmão/Irmã",
+        "friend": "Amigo/a",
+        "other": "Outro"
+      }
+    },
+    "medicalHistory": {
+      "title": "História clínica",
+      "save": "Guardar história",
+      "fetchError": "Erro ao carregar a história clínica",
+      "saveSuccess": "História clínica guardada",
+      "saveError": "Erro ao guardar a história clínica",
+      "allergies": "Alergias",
+      "allergiesCount": "{n} alergia | {n} alergias",
+      "onAnticoagulants": "Sob terapêutica anticoagulante",
+      "allergyName": "Nome da alergia",
+      "type": "Tipo",
+      "allergyTypes": {
+        "drug": "Medicamento",
+        "food": "Alimento",
+        "material": "Material",
+        "environmental": "Ambiental"
+      },
+      "severity": {
+        "low": "Baixa",
+        "medium": "Média",
+        "high": "Alta",
+        "critical": "Crítica"
+      },
+      "medications": "Medicação",
+      "medicationName": "Nome do medicamento",
+      "dosage": "Dosagem",
+      "frequency": "Frequência",
+      "systemicDiseases": "Doenças sistémicas",
+      "diseaseName": "Nome da doença",
+      "diseaseTypes": {
+        "cardiovascular": "Cardiovascular",
+        "respiratory": "Respiratória",
+        "endocrine": "Endócrina",
+        "neurological": "Neurológica",
+        "autoimmune": "Autoimune",
+        "other": "Outra"
+      },
+      "critical": "Crítica",
+      "controlled": "Controlada",
+      "notControlled": "Não controlada",
+      "specialConditions": "Condições especiais",
+      "pregnant": "Grávida",
+      "pregnancyWeek": "Semana de gestação",
+      "lactating": "A amamentar",
+      "anticoagulants": "Anticoagulantes",
+      "anticoagulantMedication": "Medicação anticoagulante",
+      "inrValue": "Valor de INR",
+      "anesthesiaReaction": "Reação à anestesia",
+      "anesthesiaReactionDetails": "Detalhes da reação",
+      "bruxism": "Bruxismo",
+      "lifestyle": "Estilo de vida",
+      "smoker": "Fumador",
+      "smokingFrequency": "Cigarros/dia",
+      "alcoholConsumption": "Consumo de álcool",
+      "alcohol": {
+        "none": "Nenhum",
+        "occasional": "Ocasional",
+        "moderate": "Moderado",
+        "heavy": "Elevado"
+      },
+      "surgicalHistory": "História cirúrgica",
+      "procedure": "Procedimento"
+    },
+    "timeline": {
+      "empty": "Ainda não há atividade registada",
+      "emptyFiltered": "Nenhum evento nesta categoria",
+      "clearFilter": "Mostrar toda a atividade",
+      "endOfTimeline": "Fim da cronologia",
+      "totalEntries": "{count} entrada | {count} entradas",
+      "groups": {
+        "today": "Hoje",
+        "yesterday": "Ontem",
+        "thisWeek": "Esta semana",
+        "thisMonth": "Este mês",
+        "earlier": "Anteriormente"
+      },
+      "author": "por {name}",
+      "meta": {
+        "cabinet": "Gabinete {name}",
+        "teeth": "Dentes: {list}",
+        "total": "Total: {amount}",
+        "number": "N.º {value}",
+        "via": "Via {channel}",
+        "template": "Modelo: {key}",
+        "docType": "Tipo: {type}"
+      },
+      "categories": {
+        "all": "Tudo",
+        "visit": "Visitas",
+        "treatment": "Tratamentos",
+        "financial": "Financeiro",
+        "communication": "Comunicações",
+        "medical": "História clínica",
+        "document": "Documentos",
+        "note": "Notas clínicas"
+      }
+    },
+    "alerts": {
+      "title": "{count} alerta | {count} alertas",
+      "label": "Alertas clínicos"
+    },
+    "editDemographics": "Editar dados demográficos",
+    "editEmergencyContact": "Editar contacto de emergência",
+    "editBilling": "Editar dados de faturação",
+    "editMedicalHistory": "Editar história clínica",
+    "medicalSnapshot": {
+      "title": "Informação clínica",
+      "allergiesLabel": "Alergias",
+      "allergiesEmpty": "Sem alergias conhecidas",
+      "allergiesNotReviewed": "História clínica não registada",
+      "completeHistory": "História completa",
+      "reviewedOn": "Revista a {date}",
+      "conditions": {
+        "pregnantWeek": "Grávida · sem. {week}",
+        "anticoagulantInr": "Anticoagulante · INR {inr}",
+        "smokerFreq": "Fumador · {freq}/dia"
+      }
+    },
+    "visitSummary": {
+      "title": "Resumo de visitas",
+      "lastVisit": "Última visita",
+      "nextAppointment": "Próxima consulta",
+      "noLastVisit": "Sem visitas anteriores",
+      "noNextAppointment": "Sem consulta agendada"
+    },
+    "personalInfo": {
+      "title": "Dados pessoais",
+      "ageLabel": "{age} anos",
+      "birthWithAge": "{date} ({age} anos)"
+    },
+    "contactInfo": {
+      "title": "Contacto",
+      "copyPhone": "Copiar telefone",
+      "copyEmail": "Copiar email",
+      "address": "Morada",
+      "addEmergency": "Adicionar contacto de emergência",
+      "addGuardian": "Adicionar tutor legal",
+      "guardianRequired": "Tutor legal obrigatório"
+    },
+    "administrative": {
+      "title": "Administrativo"
+    },
+    "header": {
+      "ariaLabel": "Cabeçalho do paciente"
+    },
+    "quickActions": {
+      "ariaLabel": "Ações rápidas do paciente"
+    }
+  },
+  "patientDetail": {
+    "tabs": {
+      "summary": "Resumo",
+      "info": "Informação",
+      "clinical": "Clínico",
+      "odontogram": "Odontograma",
+      "administration": "Administração",
+      "history": "Histórico",
+      "timeline": "Atividade",
+      "appointments": "Consultas",
+      "budgets": "Orçamentos",
+      "billing": "Faturação",
+      "payments": "Pagamentos",
+      "documents": "Documentos",
+      "gallery": "Galeria"
+    },
+    "historyPlaceholder": "Notas clínicas disponíveis numa versão futura",
+    "noAppointments": "Este paciente não tem consultas",
+    "scheduleAppointment": "Agendar consulta",
+    "noBudgets": "Este paciente não tem orçamentos",
+    "createBudget": "Criar orçamento",
+    "viewAllBudgets": "Ver todos os orçamentos",
+    "activePlan": "Plano ativo",
+    "noActivePlan": "Sem plano ativo",
+    "viewPlan": "Abrir plano",
+    "createPlan": "Criar plano",
+    "nextAppointment": "Próxima consulta",
+    "noUpcomingAppointments": "Sem consultas futuras",
+    "openAppointment": "Abrir consulta",
+    "reschedule": "Reagendar",
+    "balance": "Saldo",
+    "collect": "Cobrar",
+    "viewLedger": "Abrir conta corrente",
+    "noPayments": "Sem movimentos",
+    "diagnoses": "Diagnósticos",
+    "pending": "por tratar",
+    "noDiagnoses": "Sem achados pendentes",
+    "openOdontogram": "Abrir odontograma",
+    "medicalHistory": "História clínica",
+    "completeMedicalHistory": "Sem história clínica. Preencha-a para registar alergias, patologias e medicação.",
+    "editMedicalHistory": "Editar história clínica",
+    "quickActions": "Ações rápidas",
+    "edit": "Editar",
+    "editPatient": "Editar paciente",
+    "noSummaryCards": "Nenhum módulo registado no resumo.",
+    "actions": {
+      "label": "Ações",
+      "newAppointment": "Consulta",
+      "collect": "Cobrar",
+      "newNote": "Nota",
+      "newBudget": "Orçamento",
+      "uploadDocument": "Documento"
+    }
+  },
+  "patientBilling": {
+    "totalBudgeted": "Total orçamentado",
+    "workInProgress": "Trabalho em curso",
+    "workCompleted": "Trabalho concluído",
+    "totalInvoiced": "Total faturado",
+    "totalPaid": "Total pago",
+    "balancePending": "Saldo pendente",
+    "invoices": "Faturas",
+    "createInvoice": "Criar fatura",
+    "noInvoices": "Este paciente não tem faturas",
+    "pending": "Pendente"
+  },
+  "odontogram": {
+    "title": "Odontograma",
+    "tooth": "Dente",
+    "globals": {
+      "category": "Boca inteira",
+      "applied": "{name} adicionado ao plano",
+      "archPickerTitle": "Qual a arcada para \"{name}\"?",
+      "upperArch": "Arcada superior",
+      "lowerArch": "Arcada inferior"
+    },
+    "selectCondition": "Selecionar condição",
+    "readOnly": "Apenas visualização",
+    "legend": "Legenda",
+    "statusLegend": "Estado do tratamento",
+    "toothPosition": "Posição do dente",
+    "displaced": "Deslocado",
+    "rotated": "Rodado",
+    "dentition": {
+      "permanent": "Permanente",
+      "deciduous": "Decídua",
+      "toggle": "Alternar dentição"
+    },
+    "quadrants": {
+      "upper": "Arcada superior",
+      "lower": "Arcada inferior",
+      "upperRight": "Superior direito",
+      "upperLeft": "Superior esquerdo",
+      "lowerRight": "Inferior direito",
+      "lowerLeft": "Inferior esquerdo"
+    },
+    "surfaces": {
+      "M": "Mesial",
+      "D": "Distal",
+      "O": "Oclusal",
+      "V": "Vestibular",
+      "L": "Lingual"
+    },
+    "conditions": {
+      "healthy": "Saudável",
+      "caries": "Cárie",
+      "filling": "Restauração",
+      "crown": "Coroa",
+      "missing": "Ausente",
+      "root_canal": "Endodontia",
+      "implant": "Implante",
+      "bridge_pontic": "Pôntico de ponte",
+      "bridge_abutment": "Pilar de ponte",
+      "extraction_indicated": "Extração indicada",
+      "sealant": "Selante",
+      "fracture": "Fratura"
+    },
+    "history": {
+      "title": "Histórico de alterações",
+      "noChanges": "Nenhuma alteração registada",
+      "changedBy": "Alterado por",
+      "changeTypes": {
+        "created": "Criado",
+        "general_condition": "Condição geral",
+        "surface_update": "Atualização de face",
+        "note": "Nota"
+      }
+    },
+    "messages": {
+      "updated": "Odontograma atualizado",
+      "error": "Erro ao atualizar o odontograma",
+      "loadError": "Não foi possível carregar o odontograma"
+    },
+    "actions": {
+      "save": "Guardar",
+      "reset": "Repor",
+      "print": "Imprimir"
+    },
+    "status": {
+      "existing": "Existente",
+      "planned": "Planeado"
+    },
+    "treatments": {
+      "title": "Tratamentos",
+      "addTreatment": "Adicionar tratamento",
+      "selectStatus": "Selecionar estado",
+      "noTreatments": "Nenhum tratamento registado",
+      "markPerformed": "Marcar como realizado",
+      "categories": {
+        "common": "Comuns",
+        "restorative": "Dentisteria",
+        "diagnostic": "Diagnóstico",
+        "orthodontic": "Ortodontia",
+        "periodontic": "Periodontologia",
+        "position": "Posição",
+        "other": "Outros",
+        "diagnostico": "Diagnóstico",
+        "restauradora": "Dentisteria",
+        "cirugia": "Cirurgia",
+        "endodoncia": "Endodontia",
+        "ortodoncia": "Ortodontia"
+      },
+      "types": {
+        "pulpitis": "Pulpite",
+        "caries": "Cárie",
+        "incipient_caries": "Cárie incipiente",
+        "pigmentation": "Pigmentação",
+        "fracture": "Fratura",
+        "missing": "Ausente",
+        "periapical_small": "Periapical <2 mm",
+        "periapical_medium": "Periapical 2-4 mm",
+        "periapical_large": "Periapical >4 mm",
+        "rotated": "Rodado",
+        "displaced": "Deslocado",
+        "unerupted": "Não erupcionado",
+        "filling": "Restauração",
+        "filling_composite": "Restauração em compósito",
+        "filling_amalgam": "Restauração em amálgama",
+        "filling_temporary": "Restauração provisória",
+        "sealant": "Selante",
+        "veneer": "Faceta",
+        "inlay": "Inlay",
+        "overlay": "Overlay",
+        "crown": "Coroa",
+        "crown_on_implant": "Coroa sobre implante",
+        "provisional_crown_on_implant": "Coroa provisória sobre implante",
+        "pontic": "Pôntico",
+        "bridge_pontic": "Pôntico de ponte",
+        "bridge_abutment": "Pilar de ponte",
+        "extraction": "Extração",
+        "implant": "Implante",
+        "apicoectomy": "Apicectomia",
+        "root_canal": "Endodontia",
+        "root_canal_full": "Endodontia completa",
+        "root_canal_two_thirds": "Endodontia 2/3",
+        "root_canal_half": "Endodontia 1/2",
+        "root_canal_overfill": "Endodontia sobreobturada",
+        "post": "Espigão",
+        "bracket": "Bracket",
+        "tube": "Tubo",
+        "band": "Banda",
+        "attachment": "Attachment",
+        "retainer": "Contenção",
+        "rotate": "Rodado",
+        "displace": "Deslocado",
+        "splint": "Ferulização",
+        "migrated": "Tratamento geral"
+      },
+      "treatmentAdded": "Tratamento adicionado",
+      "treatmentPerformed": "Tratamento marcado como realizado",
+      "treatmentDeleted": "Tratamento eliminado",
+      "status": {
+        "existing": "Existente",
+        "planned": "Planeado"
+      }
+    },
+    "position": {
+      "displaced": "Deslocado",
+      "rotated": "Rodado",
+      "normal": "Normal"
+    },
+    "views": {
+      "occlusal": "Vista oclusal",
+      "lateral": "Vista lateral",
+      "dual": "Vista dupla"
+    },
+    "selectSurfaces": "Selecionar faces",
+    "selectedSurfaces": "Faces selecionadas",
+    "surfacesSelected": "face(s) selecionada(s)",
+    "instructions": {
+      "selectTreatment": "Selecione um tratamento para aplicar",
+      "clickTooth": "Clique no dente para aplicar"
+    },
+    "addToPlan": "Adicionar ao plano",
+    "noPlan": "Sem plano",
+    "createNewPlan": "Criar novo plano...",
+    "applyTo": "Aplicar a",
+    "oneTooth": "1 dente",
+    "multipleTeeth": "Vários dentes",
+    "surfacePricingHint": "Preço por face: {range}",
+    "toothNames": {
+      "centralIncisor": "Incisivo central",
+      "lateralIncisor": "Incisivo lateral",
+      "canine": "Canino",
+      "firstPremolar": "Primeiro pré-molar",
+      "secondPremolar": "Segundo pré-molar",
+      "firstMolar": "Primeiro molar",
+      "secondMolar": "Segundo molar",
+      "thirdMolar": "Terceiro molar"
+    },
+    "positions": {
+      "upper": "superior",
+      "lower": "inferior",
+      "left": "esquerdo",
+      "right": "direito"
+    },
+    "tooltip": {
+      "clickToEdit": "Clique para editar"
+    },
+    "planning": "Planeamento",
+    "diagnosisMode": "Diagnóstico",
+    "treatmentList": {
+      "title": "Lista de tratamentos",
+      "noTreatments": "Nenhum tratamento registado"
+    },
+    "changeHistory": {
+      "title": "Histórico de alterações",
+      "noChanges": "Nenhuma alteração registada",
+      "treatmentAdded": "Tratamento"
+    },
+    "timeline": {
+      "title": "Cronologia",
+      "viewingDate": "A visualizar: {date}",
+      "viewingHistory": "Está a visualizar o estado histórico do odontograma",
+      "returnToNow": "Voltar ao estado atual",
+      "noHistory": "Sem histórico anterior"
+    },
+    "multiTooth": {
+      "bridge": {
+        "label": "Ponte fixa"
+      },
+      "splint": {
+        "label": "Ferulização"
+      },
+      "veneers": {
+        "label": "Facetas múltiplas"
+      },
+      "crowns": {
+        "label": "Coroas múltiplas"
+      },
+      "pillar": "pilar",
+      "pontic": "pôntico",
+      "roleHint": "Clique num dente para alternar entre pilar e pôntico.",
+      "needPillar": "A ponte exige pelo menos um dente pilar.",
+      "confirmHint": "Está prestes a criar um grupo de tratamento com {n} dentes.",
+      "willBePlanned": "O grupo será marcado como planeado.",
+      "willBeExisting": "O grupo será registado como existente.",
+      "hints": {
+        "range": "Clique no primeiro dente e depois no último",
+        "free": "Clique para adicionar ou remover dentes"
+      },
+      "errors": {
+        "tooFew": "São necessários pelo menos {n} dentes",
+        "tooMany": "Máximo de {n} dentes permitidos",
+        "sameArchRequired": "Os dentes devem estar na mesma arcada dentária"
+      },
+      "sectionLabel": "Tratamentos multidentários"
+    }
+  },
+  "clinical": {
+    "modes": {
+      "history": "Histórico",
+      "diagnosis": "Diagnóstico",
+      "plans": "Planos de tratamento",
+      "appointments": "Consultas"
+    },
+    "history": {
+      "stateAt": "Estado em",
+      "changesOnDate": "Alterações nesta data",
+      "noChanges": "Nenhuma alteração registada"
+    },
+    "diagnosis": {
+      "registeredConditions": "Condições diagnosticadas",
+      "registerConditions": "Registar condições",
+      "noConditions": "Nenhuma condição registada",
+      "startDiagnosis": "Selecione um dente e adicione as condições existentes",
+      "generalConditions": "Condições gerais",
+      "readyToCreatePlan": "Diagnóstico concluído?",
+      "createPlan": "Criar plano de tratamento",
+      "continuePlan": "Continuar o plano \"{name}\"",
+      "selectPlan": "Selecionar plano",
+      "continue": "Continuar",
+      "odontogramTab": "Odontograma"
+    },
+    "plans": {
+      "title": "Planos de tratamento",
+      "create": "Novo plano",
+      "backToList": "Voltar aos planos",
+      "treatments": "Tratamentos do plano",
+      "addTreatment": "Adicionar tratamento",
+      "total": "Total",
+      "activate": "Ativar plano",
+      "generateBudget": "Gerar orçamento",
+      "empty": "Sem planos de tratamento",
+      "emptyDescription": "Crie um plano para organizar os tratamentos do paciente",
+      "createFirst": "Criar primeiro plano",
+      "active": "Planos ativos",
+      "drafts": "Rascunhos",
+      "completed": "Concluídos",
+      "closed": "Fechados",
+      "other": "Outros",
+      "noItems": "Sem tratamentos no plano",
+      "markComplete": "Marcar como concluído",
+      "removeItem": "Remover do plano",
+      "sessions": {
+        "progress": "{done}/{total} sessões",
+        "markDone": "Marcar sessão como realizada",
+        "cancel": "Cancelar sessão",
+        "markedDone": "Sessão marcada como realizada",
+        "cancelled": "Sessão cancelada",
+        "untitled": "Sessão {n}"
+      },
+      "unknownTreatment": "Tratamento",
+      "odontogram": "Odontograma",
+      "pending": "pendente",
+      "dragToReorder": "Arraste para reordenar",
+      "reorderHint": "Use Alt + setas para mover",
+      "emptyDraft": {
+        "title": "Planeie os tratamentos",
+        "step1": "Escolha um tratamento na barra abaixo",
+        "step2": "Clique num dente no odontograma",
+        "step3": "Confirme o plano para gerar o orçamento e as consultas"
+      },
+      "steps": {
+        "plan": "Planear",
+        "confirm": "Confirmar",
+        "inProgress": "Em curso"
+      },
+      "confirmCta": {
+        "titleWithItems": "Confirmar plano",
+        "subtitleWithItems": "Ao confirmar, desbloqueia a geração do orçamento e o agendamento de consultas.",
+        "empty": "Adicione pelo menos um tratamento para confirmar o plano"
+      },
+      "ghostHint": "Disponível após confirmar o plano",
+      "addedToPlan": "Adicionado ao plano",
+      "addingToPlan": "A adicionar a este plano",
+      "cancelPlan": "Cancelar plano",
+      "locked": {
+        "title": "Plano bloqueado",
+        "subtitle": "O orçamento {number} já foi emitido. Para editar os tratamentos, use Reabrir (se estiver pendente) ou Renegociar o orçamento.",
+        "viewBudget": "Ver orçamento"
+      }
+    },
+    "tooth": "Dente"
+  },
+  "appointments": {
+    "title": "Agenda",
+    "create": "Nova consulta",
+    "edit": "Editar consulta",
+    "today": "Hoje",
+    "tomorrow": "Amanhã",
+    "week": "Semana",
+    "prevWeek": "Semana anterior",
+    "nextWeek": "Semana seguinte",
+    "selectPatient": "Selecionar paciente",
+    "selectProfessional": "Selecionar profissional",
+    "openPatientFile": "Abrir ficha do paciente",
+    "patient": "Paciente",
+    "professional": "Profissional",
+    "cabinet": "Gabinete",
+    "date": "Data",
+    "time": "Hora",
+    "startTime": "Hora de início",
+    "duration": "Duração",
+    "treatmentType": "Tipo de tratamento",
+    "treatments": "Tratamentos",
+    "addTreatment": "Adicionar tratamento",
+    "selectTreatment": "Selecionar tratamento",
+    "estimatedDuration": "Duração estimada",
+    "notes": "Notas",
+    "hasNotes": "Tem notas",
+    "status": {
+      "label": "Estado",
+      "scheduled": "Agendada",
+      "confirmed": "Confirmada",
+      "checked_in": "Na sala de espera",
+      "in_treatment": "Na cadeira",
+      "completed": "Concluída",
+      "cancelled": "Cancelada",
+      "no_show": "Faltou"
+    },
+    "scheduled": "Agendada",
+    "confirmed": "Confirmada",
+    "inProgress": "Em curso",
+    "in_progress": "Em curso",
+    "completed": "Concluída",
+    "cancelled": "Cancelada",
+    "noShow": "Faltou",
+    "no_show": "Faltou",
+    "transitions": {
+      "confirmed": "Marcar como confirmada",
+      "checked_in": "Registar chegada",
+      "in_treatment": "Passar para a cadeira",
+      "completed": "Terminar consulta",
+      "cancelled": "Cancelar consulta",
+      "no_show": "Marcar falta"
+    },
+    "timer": {
+      "startsIn": "começa em {minutes} min",
+      "startsInOverdue": "{minutes} min de atraso",
+      "waiting": "à espera há {minutes} min",
+      "inTreatment": "{elapsed}/{planned} min",
+      "completedAt": "terminou às {time}",
+      "cancelledAt": "cancelada",
+      "noShowAt": "faltou"
+    },
+    "confirmTransitionTitle": "Confirmar alteração de estado",
+    "confirmCancelMessage": "Cancelar esta consulta? A alteração ficará registada.",
+    "confirmNoShowMessage": "Marcar este paciente como falta? A alteração ficará registada.",
+    "noteLabel": "Nota (opcional)",
+    "transitionFailed": "Não foi possível alterar o estado da consulta",
+    "when": "Quando",
+    "whereWho": "Gabinete e profissional",
+    "followup": {
+      "title": "Ações pós-consulta"
+    },
+    "created": "Consulta criada",
+    "saved": "Consulta guardada",
+    "updated": "Consulta atualizada",
+    "conflict": "Este horário já está ocupado",
+    "cancel": "Cancelar consulta",
+    "markCompleted": "Marcar como concluída",
+    "markNoShow": "Faltou",
+    "dailyView": "Dia",
+    "weeklyView": "Semana",
+    "kanbanView": "Kanban",
+    "kanban": {
+      "upcoming": "Próximas",
+      "waiting": "Sala de espera",
+      "inChair": "Na cadeira",
+      "done": "Concluídas",
+      "missed": "Faltas / Canceladas",
+      "free": "Livre",
+      "inactive": "Inativo",
+      "empty": "Sem consultas",
+      "nextIn": "Próxima às {time}",
+      "subtitleCount": "{count} consultas",
+      "subtitleEmpty": "Sem consultas",
+      "subtitleWaiting": "{count} à espera · média {avg} min",
+      "subtitleInChair": "{busy} ocupados · {free} livres"
+    },
+    "cabinetAssignment": {
+      "assignLater": "Atribuir mais tarde",
+      "unassigned": "Sem atribuição",
+      "assign": "Atribuir gabinete",
+      "reassign": "Reatribuir gabinete",
+      "unassign": "Remover gabinete",
+      "requiredForTreatment": "Atribua um gabinete antes de passar ao tratamento"
+    },
+    "professionals": {
+      "strip": "Profissionais",
+      "state": {
+        "free": "Livre",
+        "in_treatment": "Na cadeira",
+        "on_break": "Em pausa",
+        "off": "Indisponível"
+      }
+    },
+    "noProfessionals": "Nenhum profissional configurado",
+    "overlapWarning": "Sobreposições detetadas",
+    "overlapProfessional": "O profissional tem {count} consulta(s) a esta hora",
+    "overlapCabinet": "O gabinete tem {count} consulta(s) a esta hora",
+    "selectDuration": "Selecionar duração...",
+    "sendEmail": "Enviar email",
+    "sendConfirmationEmail": "Enviar confirmação",
+    "resendConfirmation": "Reenviar confirmação",
+    "sendReminderEmail": "Enviar lembrete",
+    "emailSent": "Email enviado com sucesso",
+    "automatic": "automático",
+    "selectPatientFirst": "Selecione um paciente para ver os tratamentos pendentes",
+    "noPendingTreatments": "Sem tratamentos pendentes",
+    "createPlanFirst": "Crie um plano de tratamento para este paciente",
+    "addTreatmentFromPlan": "Adicionar tratamento do plano",
+    "selectPendingTreatment": "Selecionar tratamento pendente",
+    "emptyDay": "Sem consultas para este dia",
+    "noPatient": "Sem paciente",
+    "freeSlots": {
+      "byProfessional": "Profissional",
+      "byCabinet": "Gabinete",
+      "freeSuffix": "livre",
+      "freeShort": "livre",
+      "noFreeTime": "Sem tempo livre",
+      "tapToBook": "Toque para agendar",
+      "tapToBookAria": "Vaga livre de {duration} às {time}",
+      "nextFreeAt": "Próxima às {time}",
+      "gapsAtLeast": "{count} intervalos ≥ {min} min",
+      "minDuration": "Mínimo",
+      "noFreeSlots": "Sem vagas livres hoje",
+      "clinicClosed": "Clínica encerrada",
+      "professionalOff": "Fora de serviço",
+      "onBreak": "Em pausa"
+    }
+  },
+  "dashboard": {
+    "greetings": {
+      "morning": "Bom dia",
+      "afternoon": "Boa tarde",
+      "evening": "Boa noite"
+    },
+    "welcome": "Bem-vindo ao DentalPin",
+    "welcomeMessage": "Comece por criar o seu primeiro paciente.",
+    "quickActions": {
+      "newAppointment": "Nova consulta",
+      "newPatient": "Novo paciente",
+      "search": "Procurar paciente",
+      "searchPlaceholder": "Procurar por nome, telefone ou email"
+    },
+    "timeline": {
+      "title": "Hoje",
+      "empty": "Sem consultas agendadas para hoje",
+      "now": "Agora",
+      "openSchedule": "Abrir agenda"
+    },
+    "todayKpi": {
+      "title": "Consultas de hoje",
+      "completed": "concluídas",
+      "inProgress": "em curso",
+      "upcoming": "por realizar",
+      "cancelled": "canceladas",
+      "noShow": "faltas",
+      "empty": "Sem consultas hoje"
+    },
+    "inClinic": {
+      "title": "Na clínica agora",
+      "inTreatment": "{n} na cadeira",
+      "waiting": "{n} à espera",
+      "empty": "Ninguém na clínica"
+    },
+    "unconfirmed": {
+      "title": "Por confirmar para amanhã",
+      "empty": "Todas as consultas de amanhã estão confirmadas",
+      "confirm": "Confirmar",
+      "confirmError": "Não foi possível confirmar"
+    },
+    "overdue": {
+      "title": "Pagamentos em atraso",
+      "daysOverdue": "{n} dia de atraso | {n} dias de atraso",
+      "viewAll": "Ver tudo",
+      "empty": "Sem faturas em atraso"
+    },
+    "recent": {
+      "title": "Pacientes recentes",
+      "empty": "Ainda não há pacientes"
+    },
+    "weekGlance": {
+      "title": "Resumo da semana",
+      "subtitle": "Últimos 7 dias vs. 7 anteriores",
+      "appointments": "Consultas",
+      "completed": "Concluídas",
+      "invoiced": "Faturado",
+      "empty": "Sem dados esta semana"
+    }
+  },
+  "settings": {
+    "title": "Definições",
+    "subtitle": "Faça a gestão da sua clínica, equipa e módulos.",
+    "allCategories": "Todas as categorias",
+    "navLabel": "Categorias de definições",
+    "attentionRequired": "Requer atenção",
+    "categories": {
+      "general": {
+        "label": "Geral",
+        "description": "Perfil da clínica, identidade visual e fuso horário."
+      },
+      "workspace": {
+        "label": "Espaço de trabalho",
+        "description": "Gabinetes, horários e disponibilidade."
+      },
+      "people": {
+        "label": "Pessoas",
+        "description": "Utilizadores, perfis e convites."
+      },
+      "clinical": {
+        "label": "Clínico",
+        "description": "Catálogo, predefinições de tratamento e modelos."
+      },
+      "billing": {
+        "label": "Faturação e impostos",
+        "description": "Séries de faturas, IVA e conformidade fiscal."
+      },
+      "communications": {
+        "label": "Comunicações",
+        "description": "Notificações, SMTP e modelos."
+      },
+      "integrations": {
+        "label": "Integrações",
+        "description": "Serviços e fornecedores externos."
+      },
+      "modules": {
+        "label": "Módulos",
+        "description": "Instalar, atualizar e desinstalar módulos."
+      },
+      "account": {
+        "label": "Conta",
+        "description": "O seu perfil, palavra-passe e idioma."
+      }
+    },
+    "search": {
+      "placeholder": "Procurar nas definições…",
+      "empty": "Sem resultados para essa pesquisa.",
+      "navigate": "navegar",
+      "open": "abrir"
+    },
+    "locked": {
+      "title": "Não tem acesso a esta secção",
+      "description": "Peça a um administrador da clínica que lhe conceda as permissões necessárias."
+    },
+    "emptyCategory": {
+      "title": "Sem opções disponíveis",
+      "description": "Quando módulos compatíveis forem ativados, as respetivas definições aparecerão aqui."
+    },
+    "loadError": {
+      "description": "Não foi possível carregar este editor. Tente novamente dentro de alguns segundos."
+    },
+    "comingSoon": {
+      "title": "Brevemente",
+      "subtitle": "Estamos a trabalhar nesta secção. Entretanto, pode gerir isto através da API."
+    },
+    "onboarding": {
+      "title": "Termine a configuração da sua clínica",
+      "subtitle": "Tem {count} passos pendentes para concluir a configuração inicial.",
+      "dismiss": "Dispensar",
+      "items": {
+        "clinicInfo": {
+          "label": "Complete o perfil da clínica",
+          "description": "O nome, o NIF e a morada aparecem nos orçamentos e nas faturas."
+        },
+        "cabinets": {
+          "label": "Crie pelo menos um gabinete",
+          "description": "Sem gabinetes não é possível agendar consultas."
+        }
+      }
+    },
+    "cabinetsDescription": "Salas ou boxes onde os pacientes são atendidos.",
+    "usersDescription": "Contas com acesso a esta clínica e respetivos perfis.",
+    "profileDescription": "A sua informação pessoal nesta clínica.",
+    "clinic": "Clínica",
+    "profile": "Perfil",
+    "clinicName": "Nome da clínica",
+    "clinicInfo": "Informação da clínica",
+    "clinicInfoDescription": "Estes dados aparecerão nos orçamentos e documentos",
+    "taxId": "NIF",
+    "legalName": "Denominação social",
+    "legalNameHelp": "Denominação social da entidade para faturação. Deixe em branco para usar o nome da clínica.",
+    "street": "Morada",
+    "city": "Cidade",
+    "postalCode": "Código postal",
+    "country": "País",
+    "countryPlaceholder": "Selecione um país",
+    "countrySearchPlaceholder": "Procurar país…",
+    "phone": "Telefone",
+    "timezone": "Fuso horário",
+    "timezoneHelp": "Todos os horários e consultas são interpretados neste fuso horário.",
+    "currency": "Moeda",
+    "currencyHelp": "Moeda da clínica usada nos orçamentos, faturas e catálogo.",
+    "editClinicInfo": "Editar informação",
+    "clinicUpdated": "Informação da clínica atualizada",
+    "clinicUpdateError": "Erro ao atualizar a informação",
+    "cabinets": "Gabinetes",
+    "language": "Idioma",
+    "languageDescription": "Selecione o seu idioma preferido",
+    "users": "Utilizadores da clínica",
+    "newUser": "Novo utilizador",
+    "createUser": "Criar utilizador",
+    "editUser": "Editar utilizador",
+    "deleteUser": "Eliminar utilizador",
+    "deleteUserConfirm": "Tem a certeza de que pretende remover",
+    "deleteUserNote": "O utilizador perderá o acesso a esta clínica, mas a sua conta não será eliminada.",
+    "noUsers": "Nenhum utilizador registado",
+    "youTag": "(você)",
+    "userActive": "Utilizador ativo",
+    "userInactiveNote": "(Não consegue iniciar sessão)",
+    "saveChanges": "Guardar alterações",
+    "noCabinets": "Nenhum gabinete configurado",
+    "addCabinet": "Adicionar",
+    "newCabinet": "Novo gabinete",
+    "editCabinet": "Editar gabinete",
+    "deleteCabinet": "Eliminar gabinete",
+    "deleteCabinetConfirm": "Tem a certeza de que pretende eliminar o gabinete",
+    "deleteCabinetNote": "As consultas existentes neste gabinete não serão afetadas.",
+    "createCabinet": "Criar gabinete",
+    "roles": {
+      "admin": "Administrador",
+      "dentist": "Médico dentista",
+      "hygienist": "Higienista",
+      "assistant": "Assistente",
+      "receptionist": "Rececionista"
+    },
+    "errors": {
+      "loadUsers": "Erro ao carregar os utilizadores",
+      "createUser": "Erro ao criar o utilizador",
+      "updateUser": "Erro ao atualizar o utilizador",
+      "deleteUser": "Erro ao eliminar o utilizador",
+      "emailExists": "O email já existe",
+      "userNotFound": "Utilizador não encontrado",
+      "operationNotAllowed": "Operação não permitida",
+      "invalidData": "Dados inválidos"
+    },
+    "messages": {
+      "userCreated": "Utilizador criado com sucesso",
+      "userUpdated": "Utilizador atualizado com sucesso",
+      "userDeleted": "Utilizador removido da clínica"
+    },
+    "modules": {
+      "title": "Módulos",
+      "subtitle": "Instale, desinstale e atualize os módulos da clínica.",
+      "description": "Faça a gestão dos módulos ativos na sua clínica.",
+      "deps": "Dependências",
+      "noDeps": "Sem dependências",
+      "state": {
+        "installed": "Instalado",
+        "uninstalled": "Não instalado",
+        "toInstall": "Instalação pendente",
+        "toUpgrade": "Atualização pendente",
+        "toRemove": "Remoção pendente",
+        "disabled": "Desativado",
+        "error": "Erro"
+      },
+      "category": {
+        "official": "Oficial",
+        "community": "Comunidade"
+      },
+      "actions": {
+        "install": "Instalar",
+        "uninstall": "Desinstalar",
+        "upgrade": "Atualizar",
+        "apply": "Aplicar alterações",
+        "viewDetails": "Detalhes",
+        "force": "Forçar desinstalação"
+      },
+      "confirmInstall": {
+        "title": "Instalar {name}?",
+        "message": "O módulo será agendado para instalação e ficará ativo depois de aplicar as alterações.",
+        "scheduled": "Estas dependências também serão instaladas:"
+      },
+      "confirmUninstall": {
+        "title": "Desinstalar {name}?",
+        "warning": "As tabelas do módulo serão removidas. É criada previamente uma cópia de segurança com pg_dump para permitir recuperar os dados.",
+        "forceHint": "Ignora os módulos dependentes. Use apenas se souber o que está a fazer."
+      },
+      "confirmUpgrade": {
+        "title": "Atualizar {name}?",
+        "message": "O módulo será atualizado para a versão do manifesto em disco quando as alterações forem aplicadas."
+      },
+      "confirmApply": {
+        "title": "Aplicar alterações",
+        "message": "O backend será reiniciado. A sessão poderá ser brevemente interrompida enquanto as operações pendentes são executadas."
+      },
+      "pending": {
+        "banner": "Alterações pendentes:",
+        "apply": "Aplicar alterações"
+      },
+      "doctor": {
+        "banner": "Foram detetados problemas no sistema de módulos.",
+        "orphans": "módulos órfãos",
+        "missingDeps": "dependências em falta",
+        "manifestErrors": "erros de manifesto",
+        "errored": "módulos com erro"
+      },
+      "detail": {
+        "state": "Estado",
+        "category": "Categoria",
+        "installedAt": "Instalado em",
+        "lastChange": "Última alteração",
+        "baseRevision": "Revisão base",
+        "appliedRevision": "Revisão aplicada",
+        "manifest": "Manifesto completo",
+        "errorMessage": "Mensagem de erro",
+        "operationLog": "Registo de operações",
+        "noOperations": "Nenhuma operação registada."
+      },
+      "restart": {
+        "inProgress": "A reiniciar o backend…",
+        "done": "Alterações aplicadas",
+        "failed": "Falha ao aplicar as alterações",
+        "timeout": "Tempo esgotado à espera do backend"
+      },
+      "toasts": {
+        "scheduled": "Operação agendada. Aplique as alterações para concluir.",
+        "applied": "Alterações aplicadas com sucesso."
+      }
+    }
+  },
+  "selector": {
+    "recentPatients": "Pacientes recentes",
+    "commonTreatments": "Tratamentos comuns",
+    "noRecentPatients": "Sem pacientes recentes",
+    "noCommonTreatments": "Sem tratamentos comuns",
+    "noMatches": "Sem correspondências",
+    "typeToSearch": "Escreva para procurar..."
+  },
+  "density": {
+    "switchToCompact": "Vista compacta",
+    "switchToComfortable": "Vista confortável"
+  },
+  "patientSelector": {
+    "createOption": "Criar o paciente \"{query}\"",
+    "createOptionEmpty": "Criar novo paciente",
+    "newBadge": "Novo",
+    "duplicateWarning": "Já existe {name} com este telefone",
+    "useExisting": "Usar este paciente",
+    "createForm": {
+      "title": "Novo paciente",
+      "back": "Voltar à pesquisa",
+      "firstName": "Nome",
+      "lastName": "Apelido",
+      "phone": "Telefone",
+      "phoneHint": "Pode adicioná-lo mais tarde na ficha do paciente.",
+      "submit": "Criar e selecionar",
+      "cancel": "Cancelar",
+      "errorGeneric": "Não foi possível criar o paciente. Tente novamente."
+    }
+  },
+  "common": {
+    "save": "Guardar",
+    "add": "Adicionar",
+    "cancel": "Cancelar",
+    "clear": "Limpar",
+    "close": "Fechar",
+    "delete": "Eliminar",
+    "comingSoon": "Brevemente",
+    "edit": "Editar",
+    "change": "alteração | alterações",
+    "back": "Voltar",
+    "loading": "A carregar...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "completed": "Concluído",
+    "retry": "Tentar novamente",
+    "refresh": "Atualizar",
+    "hide": "Ocultar",
+    "forbidden": "Acesso negado",
+    "confirm": "Confirmar",
+    "yes": "Sim",
+    "no": "Não",
+    "actions": "Ações",
+    "viewDetails": "Ver detalhes",
+    "previous": "Anterior",
+    "next": "Seguinte",
+    "previousYear": "Ano anterior",
+    "nextYear": "Ano seguinte",
+    "undo": "Anular",
+    "undone": "Anulado",
+    "added": "Adicionado",
+    "removed": "Removido",
+    "page": "Página {current} de {total}",
+    "noData": "Sem dados",
+    "noValue": "sem valor",
+    "noResults": "Sem resultados",
+    "search": "Procurar...",
+    "selectAll": "Todos",
+    "deselectAll": "Nenhum",
+    "all": "Todos",
+    "required": "Este campo é obrigatório",
+    "invalidEmail": "Email inválido",
+    "networkError": "Erro de ligação",
+    "serverError": "Erro do servidor",
+    "notFound": "Não encontrado",
+    "offline": "Sem ligação — os dados podem não estar atualizados",
+    "inactive": "Inativo",
+    "name": "Nome",
+    "color": "Cor",
+    "firstName": "Nome",
+    "lastName": "Apelido",
+    "email": "Email",
+    "password": "Palavra-passe",
+    "passwordPlaceholder": "Mínimo de 8 caracteres",
+    "role": "Perfil",
+    "readOnly": "Apenas leitura",
+    "createdBy": "Criado por",
+    "date": "Data",
+    "upload": "Carregar",
+    "uploading": "A carregar…",
+    "maxFileSize": "até 10 MB",
+    "durationMinutes": "{value} min",
+    "days": {
+      "sunday": "Domingo",
+      "monday": "Segunda-feira",
+      "tuesday": "Terça-feira",
+      "wednesday": "Quarta-feira",
+      "thursday": "Quinta-feira",
+      "friday": "Sexta-feira",
+      "saturday": "Sábado"
+    },
+    "now": "Agora",
+    "today": "Hoje",
+    "tomorrow": "Amanhã",
+    "yesterday": "Ontem",
+    "copied": "Copiado para a área de transferência",
+    "copy": "Copiar",
+    "copyFailed": "Não foi possível copiar"
+  },
+  "cabinet": {
+    "toast": {
+      "created": "Gabinete criado",
+      "updated": "Gabinete atualizado",
+      "deleted": "Gabinete eliminado",
+      "duplicateName": "Já existe um gabinete com este nome",
+      "notFound": "Gabinete não encontrado",
+      "createFailed": "Falha ao criar o gabinete",
+      "updateFailed": "Falha ao atualizar o gabinete",
+      "deleteFailed": "Falha ao eliminar o gabinete"
+    }
+  },
+  "professionals": {
+    "toast": {
+      "loadFailed": "Falha ao carregar os profissionais"
+    }
+  },
+  "lists": {
+    "empty": {
+      "title": "Sem resultados",
+      "description": "Ajuste os filtros ou limpe-os para ver todos os registos."
+    },
+    "resultCount": "{shown} de {total}",
+    "filter": {
+      "title": "Filtros",
+      "more": "Filtros",
+      "moreCount": "Filtros ({count})",
+      "clear": "Limpar",
+      "apply": "Aplicar",
+      "date": "Datas",
+      "dateFrom": "De",
+      "dateTo": "Até",
+      "searchPlaceholder": "Procurar...",
+      "noResults": "Sem correspondências",
+      "all": "Todos"
+    },
+    "sort": {
+      "label": "Ordenar",
+      "asc": "Ascendente",
+      "desc": "Descendente"
+    },
+    "datePreset": {
+      "today": "Hoje",
+      "last7": "Últimos 7 dias",
+      "last30": "Últimos 30 dias",
+      "thisMonth": "Este mês",
+      "thisQuarter": "Trimestre",
+      "thisYear": "Ano",
+      "custom": "Personalizado"
+    },
+    "truncatedWarning": "Resultados truncados (>1000). Refine os filtros."
+  },
+  "shared": {
+    "totals": "Totais",
+    "info": "Detalhes",
+    "moreActions": "Mais ações",
+    "criticalBanner": {
+      "dismiss": "Dispensar alerta"
+    },
+    "collect": {
+      "amountLabel": "Montante a cobrar",
+      "methodLabel": "Método de pagamento",
+      "dateLabel": "Data do pagamento",
+      "today": "Hoje",
+      "quickFull": "Total",
+      "optionalDetails": "Adicionar referência ou notas (opcional)",
+      "referenceLabel": "Referência",
+      "referencePlaceholder": "Ex.: número da transação no TPA",
+      "notesLabel": "Notas internas",
+      "submit": "Cobrar",
+      "cancel": "Cancelar"
+    }
+  },
+  "validation": {
+    "required": "Este campo é obrigatório",
+    "email": "Introduza um email válido",
+    "minLength": "Mínimo de {min} caracteres",
+    "maxLength": "Máximo de {max} caracteres",
+    "phone": "Introduza um número de telefone válido"
+  },
+  "time": {
+    "minutes": "{n} min",
+    "hours": "{n} hora | {n} horas"
+  },
+  "calendar": {
+    "today": "Hoje",
+    "prevWeek": "Semana anterior",
+    "nextWeek": "Semana seguinte",
+    "monday": "Segunda-feira",
+    "tuesday": "Terça-feira",
+    "wednesday": "Quarta-feira",
+    "thursday": "Quinta-feira",
+    "friday": "Sexta-feira",
+    "saturday": "Sábado",
+    "sunday": "Domingo"
+  },
+  "catalog": {
+    "title": "Catálogo de tratamentos",
+    "description": "Faça a gestão de tratamentos, preços e configuração de impostos",
+    "items": "Tratamentos",
+    "categories": "Categorias",
+    "noItems": "Sem tratamentos no catálogo",
+    "searchPlaceholder": "Procurar por código ou nome...",
+    "code": "Código",
+    "name": "Nome",
+    "category": "Categoria",
+    "price": "Preço",
+    "defaultPrice": "Preço base",
+    "costPrice": "Preço de custo",
+    "currency": "Moeda",
+    "vatType": "Tipo de IVA",
+    "vatRate": "IVA %",
+    "duration": "Duração",
+    "system": "Sistema",
+    "newItem": "Novo tratamento",
+    "editItem": "Editar tratamento",
+    "deleteItem": "Eliminar tratamento",
+    "deleteItemConfirm": "Tem a certeza de que pretende eliminar o tratamento \"{name}\"?",
+    "deleteItemNote": "Esta ação não pode ser anulada.",
+    "pricing": "Preços",
+    "scheduling": "Agendamento",
+    "characteristics": "Características",
+    "scope": "Âmbito",
+    "requiresAppointment": "Requer consulta",
+    "isDiagnostic": "É de diagnóstico",
+    "requiresSurfaces": "Requer faces",
+    "materialNotes": "Notas de materiais",
+    "materialNotesPlaceholder": "Materiais ou consumíveis necessários...",
+    "active": "Ativo",
+    "vatTypes": {
+      "exempt": "Isento",
+      "reduced": "Reduzida",
+      "standard": "Normal"
+    },
+    "scopeTypes": {
+      "tooth": "Dente",
+      "multi_tooth": "Multidentário",
+      "global_mouth": "Boca inteira",
+      "global_arch": "Por arcada"
+    },
+    "pricingStrategy": {
+      "label": "Estratégia de preço",
+      "help": "Como é calculado o preço do tratamento quando aplicado",
+      "flat": "Fixo (preço único)",
+      "per_tooth": "Por dente (× número de dentes)",
+      "per_surface": "Por face (por escalões)",
+      "per_role": "Por função (ponte: pilar/pôntico)"
+    },
+    "surfacePrices": {
+      "title": "Preços por número de faces",
+      "help": "Defina o preço para 1 a 5 faces. Quando são selecionadas faces num dente, é usado o escalão correspondente. Os escalões em falta recorrem ao escalão inferior mais próximo com valor definido.",
+      "tier": "{n} faces"
+    },
+    "sessions": {
+      "title": "Sessões (faturação fracionada)",
+      "help": "Defina as etapas com nome ao longo das quais este tratamento é realizado e faturado (ex.: coroa: 'Impressões' + 'Colocação'). A soma deve ser igual ao preço base.",
+      "label": "Designação",
+      "labelPlaceholder": "Ex.: Impressões",
+      "price": "Montante",
+      "add": "Adicionar sessão",
+      "sumStatus": "Soma {sum} € · Total {total} €"
+    },
+    "categoryCreated": "Categoria criada",
+    "categoryUpdated": "Categoria atualizada",
+    "categoryDeleted": "Categoria eliminada",
+    "categoryKeyExists": "Já existe uma categoria com esta chave",
+    "categoryCreateFailed": "Erro ao criar a categoria",
+    "categoryUpdateFailed": "Erro ao atualizar a categoria",
+    "categoryDeleteFailed": "Erro ao eliminar a categoria",
+    "cannotModifySystemCategory": "Não é possível modificar uma categoria de sistema",
+    "cannotDeleteSystemCategory": "Não é possível eliminar uma categoria de sistema",
+    "itemCreated": "Tratamento criado",
+    "itemUpdated": "Tratamento atualizado",
+    "itemDeleted": "Tratamento eliminado",
+    "itemCodeExists": "Já existe um tratamento com este código",
+    "categoryNotFound": "Categoria não encontrada",
+    "itemCreateFailed": "Erro ao criar o tratamento",
+    "itemUpdateFailed": "Erro ao atualizar o tratamento",
+    "itemDeleteFailed": "Erro ao eliminar o tratamento",
+    "cannotModifySystemItem": "Não é possível modificar um tratamento de sistema",
+    "cannotDeleteSystemItem": "Não é possível eliminar um tratamento de sistema",
+    "odontogramMapping": "Visualização no odontograma",
+    "odontogramMappingDescription": "Associe este tratamento a um tipo de visualização no odontograma para que apareça na ficha do paciente.",
+    "odontogramType": "Tipo de tratamento",
+    "clinicalCategory": "Categoria clínica",
+    "noOdontogramMapping": "Sem associação",
+    "odontogramMappingHint": "As características do tratamento serão ajustadas automaticamente com base no tipo selecionado.",
+    "selectCategory": "Selecionar categoria...",
+    "selectVatType": "Selecionar tipo de IVA...",
+    "selectScope": "Selecionar âmbito...",
+    "selectOdontogramType": "Selecionar tipo...",
+    "selectClinicalCategory": "Selecionar categoria...",
+    "expandAll": "Expandir tudo",
+    "collapseAll": "Recolher tudo",
+    "unnamed": "Sem título",
+    "activeHint": "Disponível para orçamentos e planos",
+    "tabs": {
+      "general": "Geral",
+      "pricing": "Preços",
+      "scheduling": "Agendamento",
+      "clinical": "Clínico"
+    }
+  },
+  "placeholders": {
+    "selectRole": "Selecionar perfil..."
+  },
+  "vatTypes": {
+    "title": "Tipos de IVA",
+    "description": "Faça a gestão dos tipos de IVA disponíveis para os tratamentos",
+    "name": "Nome",
+    "rate": "Taxa",
+    "default": "Predefinido",
+    "system": "Sistema",
+    "active": "Ativo",
+    "new": "Novo tipo de IVA",
+    "edit": "Editar tipo de IVA",
+    "delete": "Eliminar tipo de IVA",
+    "setAsDefault": "Definir como predefinido",
+    "showInactive": "Mostrar inativos",
+    "noItems": "Nenhum tipo de IVA configurado",
+    "namePlaceholder": "Ex.: Reduzida (10%)",
+    "systemNote": "Nos tipos de IVA de sistema só é possível alterar o estado de predefinido.",
+    "deleteConfirm": "Tem a certeza de que pretende eliminar o tipo de IVA",
+    "deleteNote": "Os tratamentos que usam este tipo de IVA não serão afetados.",
+    "created": "Tipo de IVA criado",
+    "updated": "Tipo de IVA atualizado",
+    "deleted": "Tipo de IVA eliminado",
+    "loadError": "Erro ao carregar os tipos de IVA",
+    "createError": "Erro ao criar o tipo de IVA",
+    "updateError": "Erro ao atualizar o tipo de IVA",
+    "deleteError": "Erro ao eliminar o tipo de IVA"
+  },
+  "treatmentPlans": {
+    "title": "Planos de tratamento",
+    "description": "Faça a gestão dos planos de tratamento dos pacientes",
+    "new": "Novo plano",
+    "create": "Criar plano de tratamento",
+    "edit": "Editar plano",
+    "view": "Ver plano",
+    "delete": "Eliminar plano",
+    "noItems": "Este plano não tem tratamentos",
+    "noPlans": "Este paciente não tem planos de tratamento",
+    "noPlansHint": "Marque os tratamentos no odontograma e crie um plano para os organizar",
+    "createFirst": "Criar primeiro plano",
+    "empty": "Nenhum plano de tratamento registado",
+    "emptyAction": "Criar primeiro plano",
+    "searchPlaceholder": "Procurar por número, paciente ou título...",
+    "planNumber": "Número",
+    "patient": "Paciente",
+    "untitled": "Sem título",
+    "untitledPlan": "Plano sem título",
+    "itemCount": "{count} tratamento | {count} tratamentos",
+    "treatments": "tratamentos",
+    "progress": "Progresso",
+    "pendingTreatments": "Tratamentos pendentes",
+    "completedTreatments": "Tratamentos concluídos",
+    "linkedBudget": "Orçamento associado",
+    "unknownTreatment": "Tratamento desconhecido",
+    "globalTreatment": "Tratamento geral",
+    "activePlan": "Plano ativo",
+    "otherPlans": "Outros planos",
+    "viewAllPlans": "Ver histórico de planos",
+    "activate": "Ativar",
+    "generateBudget": "Gerar orçamento",
+    "scheduleAppointment": "Agendar consulta",
+    "status": {
+      "draft": "Rascunho",
+      "pending": "Pendente",
+      "active": "Ativo",
+      "completed": "Concluído",
+      "closed": "Fechado",
+      "archived": "Arquivado"
+    },
+    "fields": {
+      "title": "Título",
+      "titlePlaceholder": "Ex.: Reabilitação oral completa",
+      "assignedProfessional": "Profissional responsável",
+      "selectProfessional": "Selecionar profissional",
+      "diagnosisNotes": "Notas de diagnóstico",
+      "diagnosisNotesPlaceholder": "Diagnóstico e observações clínicas...",
+      "internalNotes": "Notas internas",
+      "internalNotesPlaceholder": "Notas visíveis apenas para a equipa..."
+    },
+    "modal": {
+      "subtitle": "Organize os tratamentos do paciente",
+      "titleHint": "Opcional - ajuda a identificar o plano",
+      "additionalNotes": "Notas adicionais",
+      "quickTip": "Depois de criar o plano pode adicionar tratamentos a partir do odontograma ou do catálogo.",
+      "createButton": "Criar plano"
+    },
+    "actions": {
+      "activate": "Ativar plano",
+      "confirm": "Confirmar plano",
+      "complete": "Marcar como concluído",
+      "generateBudget": "Gerar orçamento",
+      "linkBudget": "Associar orçamento",
+      "syncBudget": "Sincronizar orçamento",
+      "cancelPlan": "Cancelar plano",
+      "reopen": "Reabrir",
+      "close": "Fechar plano",
+      "reactivate": "Reativar plano",
+      "logContact": "Registar contacto"
+    },
+    "items": {
+      "title": "Tratamentos",
+      "add": "Adicionar tratamento",
+      "addSelected": "Adicionar {count} tratamento | Adicionar {count} tratamentos",
+      "remove": "Remover tratamento",
+      "empty": "Sem tratamentos neste plano",
+      "assignedProfessional": "Médico dentista responsável",
+      "assignedProfessionalAriaLabel": "Alterar o médico dentista responsável por este tratamento",
+      "useUsersPlanDoctor": "Usar o médico dentista do plano",
+      "noProfessional": "Sem médico dentista atribuído",
+      "inactiveProfessional": "Profissional inativo",
+      "cascadeReassign": {
+        "title": "Reatribuir os tratamentos pendentes?",
+        "body": "Alterou o médico dentista do plano. {count} tratamento(s) pendente(s) estavam atribuídos a {previousName}. Pretende reatribuí-los também ao novo médico dentista?",
+        "confirm": "Sim, reatribuir os pendentes",
+        "cancel": "Não, manter como estão"
+      }
+    },
+    "filters": {
+      "allStatuses": "Todos os estados"
+    },
+    "confirmations": {
+      "delete": "Eliminar este plano de tratamento?",
+      "completeItem": "Marcar o tratamento como concluído?",
+      "completeItemDescription": "Esta ação não pode ser anulada.",
+      "activateTitle": "Confirmar o plano de tratamento?",
+      "activateDescription": "Ao confirmar, desbloqueia a geração do orçamento e o agendamento de consultas. Pode continuar a adicionar ou concluir tratamentos depois.",
+      "unlockTitle": "Modificar o plano?",
+      "unlockIntro": "Este plano tem o orçamento {number} já emitido. Para o modificar, o orçamento atual tem de ser anulado.",
+      "unlockConsequence1": "O orçamento {number} será anulado e deixará de ser válido para o paciente.",
+      "unlockConsequence2": "Poderá adicionar, editar ou remover tratamentos do plano.",
+      "unlockConsequence3": "Terá de gerar um novo orçamento quando terminar as alterações.",
+      "unlockConsequence4": "O orçamento anulado é mantido no histórico para rastreabilidade.",
+      "cancelTitle": "Cancelar o plano de tratamento?",
+      "cancelDescription": "O plano passará ao estado cancelado e os tratamentos planeados não realizados serão removidos do odontograma. O histórico do plano é mantido."
+    },
+    "messages": {
+      "created": "Plano de tratamento criado",
+      "updated": "Plano de tratamento atualizado",
+      "deleted": "Plano de tratamento eliminado",
+      "itemsAdded": "Tratamentos adicionados ao plano"
+    },
+    "itemCompleted": "Tratamento concluído",
+    "budgetGenerated": "Orçamento gerado",
+    "created": "Plano de tratamento criado",
+    "updated": "Plano de tratamento atualizado",
+    "statusUpdated": "Estado do plano atualizado",
+    "deleted": "Plano de tratamento eliminado",
+    "budgetLinked": "Orçamento associado ao plano",
+    "budgetSynced": "Orçamento sincronizado",
+    "errors": {
+      "load": "Erro ao carregar os planos de tratamento",
+      "create": "Erro ao criar o plano de tratamento",
+      "update": "Erro ao atualizar o plano de tratamento",
+      "delete": "Erro ao eliminar o plano de tratamento"
+    },
+    "notes": {
+      "title": "Notas clínicas",
+      "empty": "Ainda não há notas clínicas",
+      "addNote": "Adicionar nota",
+      "edit": "Editar nota",
+      "delete": "Eliminar nota",
+      "attachments": "Anexos",
+      "author": "Autor",
+      "createdAt": "Criada",
+      "templatePicker": "Modelos",
+      "bodyPlaceholder": "Escreva a nota clínica…",
+      "saved": "Nota guardada",
+      "deleted": "Nota eliminada"
+    },
+    "completionNudge": {
+      "title": "Concluir tratamento",
+      "description": "Adicione uma nota clínica a descrever o que aconteceu nesta visita antes de a marcar como concluída.",
+      "completeWithNote": "Concluir com nota",
+      "skip": "Ignorar nota",
+      "skipConfirm": "Concluir sem nota clínica?"
+    },
+    "visitNote": {
+      "title": "Nota clínica da visita",
+      "save": "Guardar nota",
+      "empty": "Ainda não há nota de visita",
+      "saved": "Nota guardada"
+    },
+    "clinicalNotesTab": "Notas clínicas",
+    "filterBy": {
+      "plan": "Plano",
+      "item": "Tratamento",
+      "visit": "Visita",
+      "all": "Todas"
+    },
+    "byPlan": {
+      "empty": "Este paciente não tem notas clínicas em nenhum plano de tratamento",
+      "planNotesLabel": "Notas do plano",
+      "noNotesForTreatment": "Sem notas para este tratamento",
+      "noNotesForPlan": "Sem notas neste plano"
+    },
+    "noteTemplates": {
+      "endo": {
+        "singleVisit": "Endodontia — sessão única",
+        "multiVisit": "Endodontia — várias sessões"
+      },
+      "perio": {
+        "scaling": "Destartarização / alisamento radicular"
+      },
+      "implant": {
+        "placement": "Colocação de implante"
+      },
+      "general": {
+        "followUp": "Seguimento geral"
+      }
+    },
+    "closureReason": {
+      "rejected_by_patient": "Recusado pelo paciente",
+      "expired": "Expirado",
+      "cancelled_by_clinic": "Cancelado pela clínica",
+      "patient_abandoned": "Paciente desistiu",
+      "other": "Outro motivo"
+    },
+    "confirmed": "Plano confirmado",
+    "reopened": "Plano reaberto",
+    "closed": "Plano fechado",
+    "reactivated": "Plano reativado",
+    "contactLogged": "Contacto registado",
+    "modals": {
+      "confirm": {
+        "title": "Confirmar plano",
+        "description": "O plano passará a Pendente e será criado automaticamente um orçamento em rascunho. Depois de confirmados, os tratamentos ficam apenas de leitura.",
+        "submit": "Confirmar plano"
+      },
+      "reopen": {
+        "title": "Reabrir o plano para edição",
+        "description": "Isto irá anular o orçamento atual. O plano volta a Rascunho para poder editar os tratamentos.",
+        "submit": "Reabrir"
+      },
+      "close": {
+        "title": "Fechar plano",
+        "description": "Escolha o motivo do fecho. Os tratamentos pendentes serão arquivados.",
+        "reasonLabel": "Motivo",
+        "noteLabel": "Nota (opcional)",
+        "submit": "Fechar plano"
+      },
+      "reactivate": {
+        "title": "Reativar plano fechado",
+        "description": "Isto irá reativar um plano fechado a {date} como «{reason}». Continuar?",
+        "submit": "Reativar"
+      },
+      "contactLog": {
+        "title": "Registar contacto",
+        "description": "Regista o contacto sem alterar o estado do plano.",
+        "channelLabel": "Canal",
+        "noteLabel": "Nota (opcional)",
+        "submit": "Registar"
+      }
+    }
+  },
+  "pipeline": {
+    "title": "Pipeline de planos",
+    "description": "Faça a gestão do pipeline de tratamentos.",
+    "tabs": {
+      "por_presupuestar": "Por orçamentar",
+      "esperando_paciente": "A aguardar o paciente",
+      "sin_cita": "Sem consulta",
+      "sin_proxima_cita": "Sem próxima consulta",
+      "cerrados": "Fechados",
+      "listado": "Lista"
+    },
+    "row": {
+      "patient": "Paciente",
+      "plan": "Plano",
+      "budget": "Orçamento",
+      "items": "Tratamentos",
+      "daysIn": "{n} dias neste estado",
+      "nextAppt": "Próxima consulta",
+      "noNextAppt": "Sem consulta",
+      "noBudget": "Sem orçamento"
+    },
+    "actions": {
+      "open": "Abrir",
+      "send": "Enviar",
+      "remind": "Reenviar",
+      "schedule": "Agendar",
+      "scheduleNext": "Agendar a próxima",
+      "reactivate": "Reativar",
+      "call": "Telefonar",
+      "whatsapp": "WhatsApp",
+      "markContacted": "Marcar como contactado",
+      "acceptInClinic": "Aceitar na clínica"
+    },
+    "search": "Procurar por nome ou número…",
+    "empty": "Sem registos neste separador.",
+    "loading": "A carregar…"
+  },
+  "budget": {
+    "title": "Orçamentos",
+    "description": "Faça a gestão dos orçamentos de tratamento dos pacientes",
+    "new": "Novo orçamento",
+    "edit": "Editar orçamento",
+    "view": "Ver orçamento",
+    "delete": "Eliminar orçamento",
+    "duplicate": "Criar nova versão",
+    "noItems": "Sem orçamentos",
+    "empty": "Nenhum orçamento registado",
+    "emptyAction": "Criar primeiro orçamento",
+    "linkedToPlan": "Associado ao plano",
+    "searchPlaceholder": "Procurar por número ou paciente...",
+    "budgetNumber": "Número",
+    "version": "Versão",
+    "treatmentPlan": "Plano de tratamento",
+    "patient": "Paciente",
+    "selectPatient": "Selecionar paciente",
+    "selectPatientHint": "Procure e selecione o paciente para este orçamento",
+    "professional": "Profissional",
+    "validFrom": "Válido desde",
+    "validUntil": "Válido até",
+    "validUntilHint": "Deixe vazio para um orçamento sem data de validade",
+    "noExpiry": "Sem data de validade",
+    "createAndAddItems": "Criar e adicionar tratamentos",
+    "subtotal": "Subtotal",
+    "totalDiscount": "Desconto total",
+    "totalTax": "Total de IVA",
+    "total": "Total",
+    "globalDiscount": "Desconto global",
+    "discountType": "Tipo de desconto",
+    "discountValue": "Valor do desconto",
+    "percentage": "Percentagem",
+    "absolute": "Absoluto",
+    "internalNotes": "Notas internas",
+    "internalNotesPlaceholder": "Notas visíveis apenas para a equipa...",
+    "patientNotes": "Notas para o paciente",
+    "patientNotesPlaceholder": "Notas visíveis no orçamento...",
+    "status": {
+      "title": "Estado",
+      "draft": "Rascunho",
+      "sent": "Enviado",
+      "partially_accepted": "Parcialmente aceite",
+      "accepted": "Aceite",
+      "in_progress": "Em curso",
+      "completed": "Concluído",
+      "invoiced": "Faturado",
+      "rejected": "Recusado",
+      "expired": "Expirado",
+      "cancelled": "Anulado"
+    },
+    "itemStatus": {
+      "pending": "Pendente",
+      "accepted": "Aceite",
+      "rejected": "Recusado",
+      "in_progress": "Em curso",
+      "completed": "Concluído"
+    },
+    "actions": {
+      "send": "Enviar ao paciente",
+      "accept": "Aceitar orçamento",
+      "acceptPartial": "Aceitar selecionados",
+      "reject": "Recusar",
+      "cancel": "Anular orçamento",
+      "duplicate": "Criar nova versão",
+      "downloadPdf": "Descarregar PDF",
+      "previewPdf": "Pré-visualizar PDF",
+      "startTreatment": "Iniciar tratamento",
+      "completeTreatment": "Concluir tratamento",
+      "renegotiate": "Renegociar",
+      "acceptInClinic": "Aceitar na clínica",
+      "resend": "Reenviar",
+      "sendReminder": "Enviar lembrete",
+      "setPublicCode": "Definir código de acesso",
+      "unlockPublic": "Desbloquear acesso"
+    },
+    "items": {
+      "title": "Tratamentos",
+      "add": "Adicionar tratamento",
+      "remove": "Remover tratamento",
+      "edit": "Editar tratamento",
+      "empty": "Sem tratamentos neste orçamento",
+      "singular": "tratamento",
+      "plural": "tratamentos",
+      "addFromCatalog": "Adicionar do catálogo",
+      "addFromOdontogram": "Adicionar do odontograma",
+      "treatment": "Tratamento",
+      "searchCatalog": "Procurar no catálogo de tratamentos...",
+      "unitPrice": "Preço unitário",
+      "quantity": "Quantidade",
+      "discount": "Desconto",
+      "lineTotal": "Total da linha",
+      "tooth": "Dente",
+      "toothNumber": "Número do dente",
+      "toothNumberPlaceholder": "Ex.: 11, 21, 36...",
+      "surfaces": "Faces",
+      "notes": "Notas",
+      "notesPlaceholder": "Notas sobre este tratamento..."
+    },
+    "signature": {
+      "title": "Assinatura digital",
+      "viewAction": "Ver assinatura",
+      "signedBy": "Assinado por",
+      "signedAt": "Assinado a",
+      "methodLabel": "Método",
+      "relationshipLabel": "Relação",
+      "documentHash": "Hash do documento (SHA-256)",
+      "hashHint": "Hash {short} — associa a assinatura a este PDF exato. Qualquer alteração invalidá-la-ia.",
+      "downloadSignedPdf": "Descarregar PDF assinado",
+      "downloadError": "Não foi possível descarregar o PDF assinado.",
+      "notSigned": "Ainda não foi recolhida qualquer assinatura para este orçamento.",
+      "method": {
+        "drawn": "Assinatura manuscrita",
+        "clickAccept": "Aceitação por clique",
+        "external": "Fornecedor externo"
+      },
+      "email": "Email",
+      "relationship": "Relação com o paciente",
+      "patient": "Paciente",
+      "guardian": "Tutor legal",
+      "representative": "Representante",
+      "accept": "Aceito as condições do orçamento",
+      "signHere": "Assine aqui",
+      "clear": "Limpar assinatura"
+    },
+    "history": {
+      "title": "Histórico de alterações",
+      "noChanges": "Nenhuma alteração registada",
+      "actions": {
+        "created": "Orçamento criado",
+        "updated": "Orçamento atualizado",
+        "status_changed": "Estado alterado",
+        "item_added": "Tratamento adicionado",
+        "item_removed": "Tratamento removido",
+        "signed": "Orçamento assinado",
+        "sent": "Orçamento enviado",
+        "duplicated": "Nova versão criada",
+        "deleted": "Orçamento eliminado",
+        "item_treatment_started": "Tratamento iniciado",
+        "item_treatment_completed": "Tratamento concluído"
+      }
+    },
+    "versions": {
+      "title": "Versões",
+      "current": "Atual",
+      "viewVersion": "Ver versão"
+    },
+    "confirmations": {
+      "send": "Enviar o orçamento ao paciente?",
+      "sendDescription": "O orçamento será marcado como enviado.",
+      "reject": "Recusar o orçamento?",
+      "rejectDescription": "Esta ação não pode ser anulada.",
+      "cancel": "Anular o orçamento?",
+      "cancelDescription": "Esta ação não pode ser anulada.",
+      "delete": "Eliminar o orçamento?",
+      "deleteDescription": "Esta ação não pode ser anulada."
+    },
+    "send": {
+      "description": "Pode enviar o orçamento por email ou marcá-lo como enviado manualmente (impresso ou entregue em mão).",
+      "sendByEmail": "Enviar por email",
+      "willSendTo": "Será enviado para",
+      "noPatientEmail": "O paciente não tem email registado",
+      "customMessage": "Mensagem personalizada (opcional)",
+      "customMessagePlaceholder": "Adicione uma mensagem para o paciente...",
+      "manualNote": "O orçamento será marcado como enviado sem enviar qualquer email.",
+      "sendEmail": "Enviar email",
+      "markAsSent": "Marcar como enviado"
+    },
+    "messages": {
+      "created": "Orçamento criado",
+      "updated": "Orçamento atualizado",
+      "deleted": "Orçamento eliminado",
+      "sent": "Orçamento enviado",
+      "sentByEmail": "Orçamento enviado por email",
+      "sentManually": "Orçamento marcado como enviado",
+      "accepted": "Orçamento aceite",
+      "rejected": "Orçamento recusado",
+      "cancelled": "Orçamento anulado",
+      "duplicated": "Nova versão criada",
+      "itemAdded": "Tratamento adicionado",
+      "itemUpdated": "Tratamento atualizado",
+      "itemRemoved": "Tratamento removido",
+      "treatmentStarted": "Tratamento iniciado",
+      "treatmentCompleted": "Tratamento concluído"
+    },
+    "errors": {
+      "load": "Erro ao carregar os orçamentos",
+      "create": "Erro ao criar o orçamento",
+      "update": "Erro ao atualizar o orçamento",
+      "delete": "Erro ao eliminar o orçamento",
+      "send": "Erro ao enviar o orçamento",
+      "accept": "Erro ao aceitar o orçamento",
+      "reject": "Erro ao recusar o orçamento",
+      "notFound": "Orçamento não encontrado",
+      "onlyDraft": "Só é possível editar orçamentos em rascunho"
+    },
+    "filters": {
+      "allStatuses": "Todos os estados",
+      "status": "Estado",
+      "paymentStatus": "Estado",
+      "professional": "Profissional",
+      "validity": "Validade",
+      "validityValid": "Válido",
+      "validityExpiringSoon": "Expira em 7 dias",
+      "validityExpired": "Expirado",
+      "dateFrom": "De",
+      "dateTo": "Até",
+      "showExpired": "Mostrar expirados",
+      "advanced": "Filtros avançados",
+      "clear": "Limpar filtros"
+    },
+    "sortFields": {
+      "createdAt": "Criado",
+      "validUntil": "Válido até",
+      "total": "Total",
+      "status": "Estado",
+      "budgetNumber": "Número"
+    },
+    "validity": {
+      "expired": "Expirado",
+      "expiresIn": "Expira em {days}d"
+    },
+    "pdf": {
+      "generating": "A gerar o PDF...",
+      "downloadError": "Erro ao descarregar o PDF"
+    },
+    "modals": {
+      "renegotiate": {
+        "title": "Renegociar orçamento",
+        "description": "Isto irá anular o orçamento atual e reabrir o plano em Rascunho para poder ajustar os tratamentos.",
+        "submit": "Renegociar"
+      },
+      "acceptInClinic": {
+        "title": "Aceitar o orçamento na clínica",
+        "description": "Registe a aceitação do paciente. Pode recolher uma assinatura em tablet (opcional).",
+        "signerLabel": "Nome completo do signatário",
+        "captureSignature": "Recolher assinatura",
+        "submit": "Marcar como aceite"
+      },
+      "setPublicCode": {
+        "title": "Definir código de acesso",
+        "description": "Este paciente não tem telefone nem data de nascimento registados. Defina um código de 4 a 6 dígitos e comunique-o verbalmente ao paciente. NÃO inclua o código no email.",
+        "codeLabel": "Código (4-6 dígitos)",
+        "submit": "Guardar código"
+      }
+    },
+    "publicLink": {
+      "action": "Partilhar ligação",
+      "title": "Ligação para o paciente",
+      "help": "Copie esta ligação e partilhe-a com o paciente por WhatsApp, SMS ou email. Ser-lhe-á pedido um dado de verificação antes de ver o orçamento.",
+      "copy": "Copiar ligação",
+      "copied": "Copiado!",
+      "whatsapp": "Enviar por WhatsApp",
+      "whatsappNoPhone": "O paciente não tem telefone registado",
+      "whatsappGreeting": "Olá {name}, aqui está o seu orçamento:",
+      "whatsappGreetingFallback": "Olá, aqui está o seu orçamento:",
+      "preview": "Pré-visualizar",
+      "statusSent": "Enviado",
+      "statusAccepted": "Aceite",
+      "statusRejected": "Recusado",
+      "statusExpired": "Expirado"
+    },
+    "public": {
+      "title": "O seu orçamento",
+      "intro": "A {clinic} enviou-lhe este orçamento. Reveja os tratamentos e escolha uma opção.",
+      "greeting": "Olá, {name}",
+      "subtitle": "O seu plano de tratamento personalizado",
+      "budgetNumber": "Orçamento",
+      "issuedOn": "Emitido a {date}",
+      "items": "Tratamentos incluídos",
+      "tooth": "Dente {number}",
+      "subtotal": "Subtotal",
+      "discount": "Desconto",
+      "tax": "IVA",
+      "total": "Total",
+      "validUntil": "Válido até {date}",
+      "trustSecure": "Ligação segura",
+      "trustEncrypted": "Dados encriptados",
+      "trustSignature": "Assinatura com valor legal",
+      "needHelp": "Precisa de ajuda? Telefone à clínica",
+      "noteFromClinic": "Mensagem da clínica",
+      "callClinic": "Telefonar à clínica",
+      "emailClinic": "Enviar email",
+      "cta_accept": "Aceitar e assinar",
+      "cta_reject": "Não tenho interesse",
+      "expired": "Este orçamento expirou. Por favor, contacte a clínica.",
+      "locked": "Acesso bloqueado após demasiadas tentativas. Por favor, telefone à clínica.",
+      "already_accepted": "Já aceitou este orçamento. A clínica entrará em contacto para agendar a sua primeira consulta.",
+      "already_rejected": "Recusou este orçamento. Se mudar de ideias, telefone à clínica.",
+      "download": {
+        "signedPdf": "Descarregar PDF assinado",
+        "notSigned": "Este orçamento ainda não tem assinatura associada.",
+        "error": "Não foi possível descarregar o PDF. Tente novamente.",
+        "reauthIntro": "Por segurança, verifique novamente a sua identidade para descarregar o PDF assinado."
+      },
+      "verify": {
+        "title": "Verifique a sua identidade",
+        "intro": "Para proteger a sua informação, confirme um dado antes de ver o seu orçamento.",
+        "phone_last4_label": "Últimos 4 dígitos do seu telefone",
+        "dob_label": "A sua data de nascimento",
+        "manual_code_label": "Código fornecido pela clínica",
+        "submit": "Continuar",
+        "invalid": "Dado incorreto. Tente novamente.",
+        "locked": "Acesso bloqueado após demasiadas tentativas. Por favor, telefone à clínica.",
+        "rate_limited": "Demasiadas tentativas. Aguarde 15 minutos."
+      },
+      "accept": {
+        "title": "Aceitar e assinar",
+        "signerLabel": "O seu nome completo",
+        "signatureLabel": "Assine aqui (opcional)",
+        "signatureClear": "Limpar",
+        "consent": "Aceito este orçamento e autorizo o tratamento descrito.",
+        "submit": "Confirmar aceitação",
+        "success": "Feito! A clínica entrará em contacto para agendar a sua primeira consulta."
+      },
+      "reject": {
+        "title": "Não tenho interesse",
+        "intro": "Porque é que este orçamento não é para si?",
+        "reasonLabel": "Motivo",
+        "noteLabel": "Comentário (opcional)",
+        "submit": "Confirmar recusa",
+        "success": "Informámos a clínica.",
+        "reasons": {
+          "price": "Preço",
+          "time": "Falta de tempo",
+          "second_opinion": "Segunda opinião",
+          "other": "Outro motivo"
+        }
+      }
+    },
+    "settings": {
+      "title": "Definições de orçamentos",
+      "description": "Configure a validade, os lembretes e a verificação da ligação pública.",
+      "cards": {
+        "expiry": {
+          "title": "Validade e fecho automático",
+          "description": "Durante quanto tempo um orçamento é válido antes de expirar e quando fechar automaticamente os planos pendentes."
+        },
+        "reminders": {
+          "title": "Lembretes automáticos",
+          "description": "Ative ou desative os lembretes por email aos 7 e 14 dias para pacientes sem resposta."
+        },
+        "publicLink": {
+          "title": "Ligação pública e verificação",
+          "description": "Configure a proteção da ligação do orçamento destinada ao paciente."
+        }
+      },
+      "expiry": {
+        "validityDays": "Validade do orçamento (dias)",
+        "validityHelp": "Ao fim deste número de dias sem resposta, o orçamento passa a Expirado (intervalo 7-180).",
+        "autoCloseDays": "Dias antes de fechar automaticamente o plano",
+        "autoCloseHelp": "Os planos com orçamento expirado e sem ação durante este número de dias passam a Fechados (intervalo 7-180).",
+        "save": "Guardar"
+      },
+      "reminders": {
+        "enabled": "Enviar lembretes automáticos aos 7 e 14 dias",
+        "enabledHelp": "Quando ativo, o sistema envia email ao paciente sobre orçamentos pendentes. Quando inativo, a receção faz o seguimento manualmente.",
+        "save": "Guardar"
+      },
+      "publicLink": {
+        "authDisabled": "Desativar a verificação da ligação pública",
+        "authDisabledHelp": "Quando ativo, o paciente vê o orçamento apenas com a ligação — sem pedido de telefone ou data de nascimento. Aceite o risco caso a ligação seja partilhada.",
+        "save": "Guardar"
+      },
+      "saved": "Definições guardadas"
+    }
+  },
+  "notifications": {
+    "communications": {
+      "language": {
+        "cardTitle": "Idioma das comunicações",
+        "cardDescription": "Idioma usado na vista do orçamento destinada ao paciente, nos emails e nos SMS.",
+        "title": "Idioma das comunicações com o paciente",
+        "label": "Idioma",
+        "help": "Aplica-se à vista do orçamento destinada ao paciente e aos modelos automáticos de email/SMS. A interface da equipa mantém a preferência de idioma de cada utilizador.",
+        "save": "Guardar",
+        "saved": "Idioma guardado"
+      }
+    },
+    "title": "Notificações",
+    "description": "Configure as notificações por email da clínica",
+    "pageDescription": "Configure que notificações são enviadas automaticamente e quais exigem envio manual.",
+    "autoVsManual": "Notificações automáticas vs. manuais",
+    "autoVsManualDescription": "Defina que notificações são enviadas automaticamente quando ocorre um evento e quais exigem que o utilizador as envie manualmente.",
+    "notificationType": "Tipo de notificação",
+    "enabled": "Ativada",
+    "autoSend": "Envio automático",
+    "options": "Opções",
+    "hoursBefore": "h antes",
+    "testConnection": "Testar ligação",
+    "testEmailTitle": "Enviar email de teste",
+    "testEmailDescription": "Vamos enviar um email de teste para verificar se a configuração funciona corretamente.",
+    "sendTestEmail": "Enviar teste",
+    "test_email_sent": "Email de teste enviado com sucesso",
+    "settings_saved": "Definições guardadas",
+    "emailProvider": "Fornecedor de email",
+    "providerConfigured": "Fornecedor de email configurado",
+    "providerNote": "A configuração do servidor de email é feita nas variáveis de ambiente do servidor.",
+    "infoTitle": "Informação",
+    "infoAutoSend": "Envio automático: a notificação é enviada quando o evento ocorre (por exemplo, ao criar uma consulta).",
+    "infoManualSend": "Envio manual: aparecerá um botão para enviar a notificação quando desejar.",
+    "infoDisabled": "Desativada: a notificação não será enviada e a opção de envio não aparecerá.",
+    "types": {
+      "appointment_confirmation": "Confirmação de consulta",
+      "appointment_confirmation_desc": "Email de confirmação quando uma consulta é agendada",
+      "appointment_cancelled": "Cancelamento de consulta",
+      "appointment_cancelled_desc": "Email de aviso quando uma consulta é cancelada",
+      "appointment_reminder": "Lembrete de consulta",
+      "appointment_reminder_desc": "Email de lembrete antes da consulta",
+      "budget_sent": "Envio de orçamento",
+      "budget_sent_desc": "Email com os detalhes do orçamento",
+      "budget_accepted": "Orçamento aceite",
+      "budget_accepted_desc": "Email de confirmação quando um orçamento é aceite",
+      "welcome": "Boas-vindas",
+      "welcome_desc": "Email de boas-vindas para novos pacientes"
+    },
+    "sendConfirmation": "Enviar confirmação",
+    "sendReminder": "Enviar lembrete",
+    "sendCancellation": "Enviar cancelamento",
+    "sendBudget": "Enviar por email",
+    "sendAcceptance": "Enviar confirmação",
+    "sendWelcome": "Enviar boas-vindas",
+    "sendEmail": "Enviar email",
+    "errors": {
+      "fetch_failed": "Erro ao carregar as definições",
+      "save_failed": "Erro ao guardar as definições",
+      "test_failed": "Erro ao enviar o email de teste",
+      "send_failed": "Erro ao enviar a notificação"
+    },
+    "smtp": {
+      "title": "Configuração do servidor de email",
+      "description": "Configure o servidor SMTP para enviar emails a partir da sua clínica. Cada clínica pode ter a sua própria configuração.",
+      "configure": "Configurar",
+      "provider": "Fornecedor",
+      "host": "Servidor",
+      "port": "Porta",
+      "username": "Nome de utilizador",
+      "password": "Palavra-passe",
+      "passwordHint": "Deixe vazio para manter a palavra-passe atual",
+      "useTls": "Usar TLS",
+      "useSsl": "Usar SSL",
+      "fromEmail": "Email do remetente",
+      "fromName": "Nome do remetente",
+      "security": "Segurança",
+      "testConnection": "Testar ligação",
+      "testConnectionTitle": "Testar a configuração antes de guardar",
+      "testEmailPlaceholder": "Endereço de email de teste",
+      "test_success": "Ligação SMTP bem-sucedida. Email de teste enviado.",
+      "test_failed": "Erro na ligação SMTP",
+      "settings_saved": "Definições SMTP guardadas",
+      "consoleNote": "No modo consola, os emails são apresentados na consola do servidor em vez de serem enviados. Útil para desenvolvimento.",
+      "disabledNote": "Com o email desativado, não serão enviadas notificações por email a partir desta clínica.",
+      "status": {
+        "not_configured": "Não configurado",
+        "verified": "Verificado e a funcionar",
+        "not_verified": "Configurado mas não verificado",
+        "disabled": "Email desativado",
+        "console": "Modo consola (desenvolvimento)"
+      },
+      "errors": {
+        "fetch_failed": "Erro ao carregar as definições SMTP",
+        "save_failed": "Erro ao guardar as definições SMTP",
+        "test_failed": "Erro ao testar a ligação SMTP"
+      }
+    }
+  },
+  "invoice": {
+    "title": "Faturas",
+    "description": "Faça a gestão das faturas e da faturação",
+    "new": "Nova fatura",
+    "edit": "Editar fatura",
+    "view": "Ver fatura",
+    "delete": "Eliminar fatura",
+    "noItems": "Sem faturas",
+    "empty": "Nenhuma fatura registada",
+    "emptyAction": "Criar primeira fatura",
+    "searchPlaceholder": "Procurar por número ou paciente...",
+    "notFound": "Fatura não encontrada",
+    "draftNoNumber": "Rascunho",
+    "details": "Detalhes",
+    "invoiceNumber": "Número da fatura",
+    "patient": "Paciente",
+    "searchPatient": "Procurar paciente",
+    "searchPatientPlaceholder": "Procurar por nome...",
+    "professional": "Profissional",
+    "billingData": "Dados de faturação",
+    "billingName": "Nome de faturação",
+    "taxId": "NIF",
+    "billingEmail": "Email de faturação",
+    "billingAddress": "Morada de faturação",
+    "billingDataComplete": "Completos",
+    "billingDataIncomplete": "Incompletos",
+    "billingDataIncompleteHint": "Faltam alguns dados de faturação do paciente.",
+    "editPatientBilling": "Editar dados do paciente",
+    "fromPatient": "Do paciente",
+    "editInPatient": "Editar no perfil",
+    "billingFromPatientHint": "Estes dados provêm da ficha do paciente. Para os alterar, edite os dados de faturação do paciente.",
+    "paymentTerms": "Condições de pagamento",
+    "linkedToBudget": "Associada ao orçamento",
+    "selectPatient": "Selecionar paciente",
+    "noBillingData": "Sem dados de faturação",
+    "street": "Rua",
+    "city": "Cidade",
+    "postalCode": "Código postal",
+    "province": "Distrito",
+    "country": "País",
+    "linkedBudget": "Orçamento associado",
+    "creditNoteFor": "Nota de crédito de",
+    "paymentTermDays": "Prazo de pagamento (dias)",
+    "dueDate": "Data de vencimento",
+    "issueDate": "Data de emissão",
+    "subtotal": "Subtotal",
+    "discount": "Desconto",
+    "totalDiscount": "Desconto total",
+    "tax": "Imposto",
+    "total": "Total",
+    "paid": "Pago",
+    "totalPaid": "Total pago",
+    "balance": "Saldo",
+    "balanceDue": "Saldo em dívida",
+    "overdue": "Em atraso",
+    "overdueDays": "Em atraso há {n}d",
+    "info": {
+      "issueDate": "Data de emissão",
+      "dueDate": "Data de vencimento",
+      "issuedBy": "Emitida por",
+      "createdBy": "Criada por",
+      "createdAt": "Criada",
+      "budget": "Orçamento",
+      "creditNoteFor": "Nota de crédito de"
+    },
+    "criticalBanner": {
+      "aeatRejected": {
+        "title": "A AEAT recusou esta fatura",
+        "cta": "Corrigir e reenviar"
+      },
+      "billingIncomplete": {
+        "title": "Dados de faturação incompletos",
+        "cta": "Completar dados"
+      }
+    },
+    "collect": {
+      "title": "Cobrar fatura",
+      "submit": "Cobrar",
+      "noteAppliedToInvoice": "aplicados a esta fatura.",
+      "notePendingAfter": "Saldo restante",
+      "noteFullySettled": "Este pagamento liquida totalmente a fatura.",
+      "noteToInvoice": "aplicados a esta fatura e",
+      "noteExcessToOnAccount": "creditados na conta corrente do paciente.",
+      "noteInvoiceSettled": "Esta fatura já está paga.",
+      "noteToOnAccount": "serão creditados na conta corrente do paciente."
+    },
+    "tooth": "Dente",
+    "vat": "IVA",
+    "currency": "Moeda",
+    "internalNotes": "Notas internas",
+    "internalNotesPlaceholder": "Notas visíveis apenas para a equipa...",
+    "publicNotes": "Notas públicas",
+    "publicNotesPlaceholder": "Notas visíveis na fatura...",
+    "items": "Linhas",
+    "addItem": "Adicionar linha",
+    "editItem": "Editar linha",
+    "selectTreatment": "Tratamento",
+    "searchCatalog": "Procurar tratamento no catálogo...",
+    "itemDescription": "Descrição",
+    "itemPrice": "Preço unitário",
+    "itemQuantity": "Quantidade",
+    "selectVatType": "Selecionar tipo de IVA",
+    "summary": "Resumo",
+    "createDraft": "Criar rascunho",
+    "createFromBudget": "Criar fatura a partir do orçamento",
+    "notes": "Notas",
+    "status": {
+      "draft": "Rascunho",
+      "issued": "Emitida",
+      "partial": "Parcialmente paga",
+      "paid": "Paga",
+      "cancelled": "Cancelada",
+      "voided": "Anulada"
+    },
+    "actions": {
+      "issue": "Emitir fatura",
+      "void": "Anular",
+      "recordPayment": "Registar pagamento",
+      "createCreditNote": "Criar nota de crédito",
+      "downloadPdf": "Descarregar PDF",
+      "previewPdf": "Pré-visualizar PDF",
+      "sendEmail": "Enviar por email"
+    },
+    "recordPayment": "Registar pagamento",
+    "paymentAmount": "Montante",
+    "paymentMethod": "Método de pagamento",
+    "paymentDate": "Data do pagamento",
+    "paymentReference": "Referência",
+    "paymentReferencePlaceholder": "Número da transação, recibo...",
+    "paymentNotes": "Notas do pagamento",
+    "paymentVoided": "Pagamento anulado",
+    "createCreditNote": "Criar nota de crédito",
+    "creditNoteReason": "Motivo da nota de crédito",
+    "creditNoteReasonPlaceholder": "Descreva o motivo da nota de crédito...",
+    "creditNoteInfo": "Será criada uma nota de crédito pelo valor total da fatura.",
+    "prompts": {
+      "voidPaymentReason": "Introduza o motivo da anulação deste pagamento"
+    },
+    "payments": {
+      "title": "Pagamentos",
+      "record": "Registar pagamento",
+      "void": "Anular pagamento",
+      "amount": "Montante",
+      "method": "Método de pagamento",
+      "date": "Data",
+      "reference": "Referência",
+      "notes": "Notas",
+      "noPayments": "Nenhum pagamento registado",
+      "recorded": "Pagamento registado",
+      "voided": "Pagamento anulado",
+      "voidReason": "Motivo da anulação",
+      "voidReasonPlaceholder": "Motivo para anular este pagamento...",
+      "methods": {
+        "cash": "Numerário",
+        "card": "Cartão",
+        "bank_transfer": "Transferência bancária",
+        "direct_debit": "Débito direto",
+        "insurance": "Seguro",
+        "other": "Outro"
+      }
+    },
+    "creditNote": {
+      "title": "Nota de crédito",
+      "create": "Criar nota de crédito",
+      "reason": "Motivo",
+      "reasonPlaceholder": "Motivo da nota de crédito...",
+      "selectItems": "Selecionar as linhas a retificar",
+      "fullCreditNote": "Nota de crédito total (todas as linhas)",
+      "partialCreditNote": "Nota de crédito parcial (linhas selecionadas)",
+      "originalInvoice": "Fatura original",
+      "created": "Nota de crédito criada"
+    },
+    "history": {
+      "title": "Histórico",
+      "noChanges": "Nenhuma alteração registada",
+      "actions": {
+        "created": "Fatura criada",
+        "updated": "Fatura atualizada",
+        "issued": "Fatura emitida",
+        "voided": "Fatura anulada",
+        "payment_recorded": "Pagamento registado",
+        "payment_voided": "Pagamento anulado",
+        "credit_note_created": "Nota de crédito criada"
+      }
+    },
+    "fromBudget": "Criar fatura a partir do orçamento",
+    "selectItems": "Selecionar as linhas a faturar",
+    "selectItemsHint": "Selecione as linhas do orçamento que pretende faturar",
+    "availableQuantity": "Disponível",
+    "quantityToInvoice": "Qtd. a faturar",
+    "alreadyInvoiced": "Já faturado",
+    "remaining": "Restante",
+    "noItemsAvailable": "Não há linhas disponíveis para faturar",
+    "allItemsInvoiced": "Todas as linhas já foram faturadas",
+    "series": {
+      "title": "Séries de faturação",
+      "prefix": "Prefixo",
+      "type": "Tipo",
+      "currentNumber": "Número atual",
+      "resetYearly": "Reiniciar anualmente",
+      "default": "Predefinida",
+      "active": "Ativa",
+      "invoice": "Fatura",
+      "credit_note": "Nota de crédito"
+    },
+    "filters": {
+      "allStatuses": "Estado",
+      "overdueOnly": "Em atraso",
+      "dateFrom": "De",
+      "dateTo": "Até"
+    },
+    "sortFields": {
+      "created": "Criada",
+      "issueDate": "Data de emissão",
+      "dueDate": "Data de vencimento",
+      "total": "Total"
+    },
+    "overdueByDays": "Em atraso há {days}d",
+    "pdf": {
+      "generating": "A gerar o PDF...",
+      "downloadError": "Erro ao descarregar o PDF"
+    },
+    "reports": {
+      "title": "Relatórios de faturação",
+      "summary": "Resumo",
+      "overdue": "Em atraso",
+      "overdueInvoices": "Faturas em atraso",
+      "byPaymentMethod": "Por método de pagamento",
+      "byProfessional": "Por profissional",
+      "vatSummary": "Resumo de IVA",
+      "gaps": "Falhas na numeração",
+      "period": "Período",
+      "from": "De",
+      "to": "Até",
+      "refresh": "Atualizar",
+      "totalInvoiced": "Total faturado",
+      "totalCollected": "Total cobrado",
+      "totalPaid": "Total pago",
+      "totalPending": "Total pendente",
+      "pending": "Saldo em dívida",
+      "invoices": "faturas",
+      "paid": "pagas",
+      "payments": "pagamentos",
+      "noGaps": "Sem falhas na numeração",
+      "gapsFound": "Encontrada(s) {count} falha(s) na numeração",
+      "gapsDetected": "Detetadas falhas na numeração",
+      "missingNumbers": "Números em falta:",
+      "noData": "Sem dados para o período selecionado",
+      "noOverdue": "Sem faturas em atraso",
+      "daysOverdue": "dias de atraso",
+      "vatType": "Tipo de IVA",
+      "base": "Base",
+      "tax": "Imposto",
+      "thisMonth": "Este mês",
+      "thisQuarter": "Este trimestre",
+      "thisYear": "Este ano",
+      "lastMonth": "Mês anterior",
+      "lastQuarter": "Trimestre anterior",
+      "lastYear": "Ano anterior"
+    },
+    "confirmations": {
+      "issue": "Emitir a fatura?",
+      "issueDescription": "Depois de emitida, a fatura não pode ser editada. Só é possível registar pagamentos ou criar notas de crédito.",
+      "void": "Anular a fatura?",
+      "voidDescription": "Esta ação não pode ser anulada.",
+      "delete": "Eliminar a fatura?",
+      "deleteDescription": "Esta ação não pode ser anulada."
+    },
+    "messages": {
+      "created": "Fatura criada",
+      "updated": "Fatura atualizada",
+      "deleted": "Fatura eliminada",
+      "issued": "Fatura emitida",
+      "voided": "Fatura anulada",
+      "itemAdded": "Linha adicionada",
+      "itemUpdated": "Linha atualizada",
+      "sentByEmail": "Fatura enviada por email",
+      "sentManually": "Fatura marcada como enviada"
+    },
+    "send": {
+      "title": "Enviar fatura",
+      "description": "Pode enviar a fatura por email ou marcá-la como enviada manualmente (impressa ou entregue em mão).",
+      "sendByEmail": "Enviar por email",
+      "willSendTo": "Será enviada para",
+      "noPatientEmail": "O paciente não tem endereço de email",
+      "customMessage": "Mensagem personalizada (opcional)",
+      "customMessagePlaceholder": "Adicione uma mensagem para o paciente...",
+      "manualNote": "A fatura será marcada como enviada sem enviar qualquer email.",
+      "sendEmail": "Enviar email",
+      "markAsSent": "Marcar como enviada"
+    },
+    "errors": {
+      "load": "Erro ao carregar as faturas",
+      "create": "Erro ao criar a fatura",
+      "update": "Erro ao atualizar a fatura",
+      "delete": "Erro ao eliminar a fatura",
+      "issue": "Erro ao emitir a fatura",
+      "void": "Erro ao anular a fatura",
+      "recordPayment": "Erro ao registar o pagamento",
+      "voidPayment": "Erro ao anular o pagamento",
+      "createCreditNote": "Erro ao criar a nota de crédito",
+      "send": "Erro ao enviar a fatura",
+      "creditNoteReasonRequired": "O motivo da nota de crédito é obrigatório",
+      "notFound": "Fatura não encontrada",
+      "onlyDraft": "Só é possível editar faturas em rascunho",
+      "canOnlyDeleteDraft": "Só é possível eliminar faturas em rascunho",
+      "patientRequired": "O paciente é obrigatório",
+      "itemsRequired": "É necessária pelo menos uma linha",
+      "itemRequired": "A descrição e o preço são obrigatórios",
+      "selectCatalogItem": "Selecione um tratamento do catálogo",
+      "cannotEdit": "Só é possível editar faturas em rascunho",
+      "billingIncomplete": "A fatura não pode ser emitida porque os dados de faturação estão incompletos. Preencha os dados de faturação do paciente para continuar."
+    },
+    "newItemsPending": "Novas linhas por guardar"
+  },
+  "reports": {
+    "title": "Relatórios",
+    "subtitle": "Análises e estatísticas da clínica",
+    "viewReports": "Ver relatórios",
+    "noAccess": "Não tem acesso a nenhum relatório",
+    "dashboard": {
+      "title": "Painel",
+      "subtitle": "A sua clínica num relance",
+      "period": "Período",
+      "snapshotBadge": "Hoje",
+      "snapshotTooltip": "Não é afetado pelo intervalo de datas",
+      "vsPrev": "vs. período anterior",
+      "empty": {
+        "noData": "Sem dados neste intervalo"
+      },
+      "drilldown": {
+        "title": "Detalhar",
+        "payments": "Pagamentos"
+      },
+      "kpi": {
+        "cashCollected": "Valor cobrado",
+        "cashCollectedHint": "{count} pagamentos",
+        "patientAdvance": "Crédito do paciente",
+        "patientAdvanceHint": "Adiantamentos por afetar",
+        "production": "Produção",
+        "productionHint": "{count} tratamentos",
+        "byMethod": "Por método de pagamento",
+        "methodCount": "{count} pagamentos",
+        "total": "Total",
+        "newPatients": "Novos pacientes",
+        "newPatientsHint": "{rate}% do total de consultas",
+        "appointmentFunnel": "Taxa de faltas",
+        "funnelHint": "{completed}% concluídas",
+        "avgCollectedTicket": "Ticket médio cobrado",
+        "avgTicketHint": "Sobre {count} pagamentos",
+        "aging": "Antiguidade de saldos"
+      },
+      "charts": {
+        "cashOverTime": "Cobranças ao longo do tempo",
+        "productionByDoctor": "Produção por médico dentista",
+        "refunded": "Reembolsos"
+      },
+      "production": {
+        "unassigned": "Sem atribuição",
+        "others": "Outros",
+        "treatmentCount": "{count} tratamentos"
+      },
+      "aging": {
+        "bucket0_30": "0-30 dias",
+        "bucket31_60": "31-60 dias",
+        "bucket61_90": "61-90 dias",
+        "bucket90plus": "Mais de 90 dias",
+        "empty": "Sem saldos em dívida",
+        "patientCount": "{count} pacientes"
+      }
+    },
+    "billing": {
+      "title": "Faturação",
+      "description": "Receitas, pagamentos, IVA e faturas em atraso",
+      "summary": "Resumo",
+      "overdue": "Em atraso",
+      "overdueInvoices": "Faturas em atraso",
+      "byPaymentMethod": "Por método de pagamento",
+      "byProfessional": "Por profissional",
+      "vatSummary": "Resumo de IVA",
+      "gaps": "Falhas na numeração",
+      "period": "Período",
+      "from": "De",
+      "to": "Até",
+      "refresh": "Atualizar",
+      "totalInvoiced": "Total faturado",
+      "totalCollected": "Total cobrado",
+      "pending": "Saldo em dívida",
+      "invoices": "faturas",
+      "paid": "pagas",
+      "payments": "pagamentos",
+      "gapsDetected": "Detetadas falhas na numeração",
+      "missingNumbers": "Números em falta:",
+      "noData": "Sem dados para o período selecionado",
+      "noOverdue": "Sem faturas em atraso",
+      "daysOverdue": "dias de atraso",
+      "vatType": "Tipo de IVA",
+      "base": "Base",
+      "tax": "Imposto",
+      "thisMonth": "Este mês",
+      "thisQuarter": "Este trimestre",
+      "thisYear": "Este ano",
+      "lastMonth": "Mês anterior",
+      "lastQuarter": "Trimestre anterior",
+      "lastYear": "Ano anterior"
+    },
+    "budgets": {
+      "title": "Orçamentos",
+      "description": "Taxas de aceitação, análise por profissional e tratamentos",
+      "comingSoonDescription": "Os relatórios de orçamentos estarão disponíveis em breve. Poderá analisar taxas de aceitação, orçamentos por profissional e os tratamentos mais pedidos.",
+      "features": {
+        "acceptanceRate": "Taxa de aceitação",
+        "acceptanceRateDesc": "Percentagem de orçamentos aceites vs. recusados",
+        "byProfessional": "Por profissional",
+        "byProfessionalDesc": "Orçamentos criados por cada profissional",
+        "byTreatment": "Por tratamento",
+        "byTreatmentDesc": "Tratamentos mais orçamentados",
+        "averageValue": "Valor médio",
+        "averageValueDesc": "Montante médio dos orçamentos"
+      },
+      "labels": {
+        "totalCreated": "Total criados",
+        "accepted": "Aceites",
+        "rejected": "recusados",
+        "pending": "pendentes",
+        "completed": "Concluídos",
+        "acceptanceRate": "Taxa de aceitação",
+        "averageValue": "Valor médio",
+        "byStatus": "Por estado",
+        "topTreatments": "Tratamentos mais orçamentados",
+        "treatment": "Tratamento",
+        "occurrences": "Ocorrências",
+        "quantity": "Quantidade"
+      }
+    },
+    "scheduling": {
+      "title": "Agenda",
+      "description": "Primeiras consultas, horas trabalhadas e ocupação",
+      "comingSoonDescription": "Os relatórios da agenda estarão disponíveis em breve. Poderá analisar primeiras consultas, horas por profissional e taxas de cancelamento.",
+      "features": {
+        "firstVisits": "Primeiras consultas",
+        "firstVisitsDesc": "Novos pacientes por período",
+        "hoursWorked": "Horas trabalhadas",
+        "hoursWorkedDesc": "Tempo por profissional",
+        "cancellations": "Cancelamentos",
+        "cancellationsDesc": "Taxas de cancelamento e de faltas",
+        "cabinetUtilization": "Ocupação dos gabinetes",
+        "cabinetUtilizationDesc": "Utilização de cada gabinete"
+      },
+      "labels": {
+        "totalAppointments": "Total de consultas",
+        "completionRate": "Taxa de conclusão",
+        "completed": "concluídas",
+        "cancellationRate": "Taxa de cancelamento",
+        "cancelled": "canceladas",
+        "noShowRate": "Taxa de faltas",
+        "noShows": "faltas",
+        "newPatients": "novos pacientes",
+        "firstVisitRate": "Taxa de primeiras consultas",
+        "ofTotalAppointments": "do total de consultas",
+        "appointmentsInPeriod": "Consultas no período",
+        "excludingCancelled": "excluindo canceladas",
+        "appointments": "consultas",
+        "byDayOfWeek": "Por dia da semana",
+        "statusBreakdown": "Distribuição por estado",
+        "pending": "pendentes"
+      },
+      "analytics": {
+        "funnel": "Funil de estados",
+        "funnelDesc": "Distribuição das consultas por estado no período",
+        "waitingTimes": "Tempos de espera",
+        "waitingTimesDesc": "Minutos entre a chegada do paciente e a entrada na cadeira",
+        "punctuality": "Pontualidade dos pacientes",
+        "punctualityDesc": "Diferença entre a hora agendada e a chegada efetiva",
+        "durationVariance": "Duração prevista vs. real",
+        "durationVarianceDesc": "Comparação entre a duração prevista e o tempo real na cadeira",
+        "samples": "Amostras",
+        "average": "Média",
+        "median": "Mediana",
+        "p90": "P90",
+        "avgDelta": "Desvio médio",
+        "medianDelta": "Desvio mediano",
+        "onTime": "% pontuais",
+        "avgOverrun": "Excesso médio",
+        "overrunCount": "Consultas com excesso",
+        "underCount": "Consultas abaixo do previsto",
+        "completionRate": "Conclusão",
+        "noShowRate": "Faltas",
+        "cancellationRate": "Cancelamento",
+        "punctuality_early": "Adiantados (<-5)",
+        "punctuality_on_time": "Pontuais (±5)",
+        "punctuality_late_short": "Atrasados (5-15)",
+        "punctuality_late_long": "Atrasados (>15)"
+      },
+      "tabs": {
+        "overview": "Visão geral",
+        "activity": "Atividade",
+        "quality": "Qualidade"
+      },
+      "hero": {
+        "inPeriod": "no período"
+      },
+      "filters": {
+        "cabinet": "Gabinete",
+        "professional": "Profissional",
+        "custom": "Intervalo personalizado",
+        "all": "Todos",
+        "clear": "Limpar filtros"
+      },
+      "empty": {
+        "title": "Sem dados para este período",
+        "desc": "Experimente um intervalo de datas mais amplo ou remova os filtros."
+      }
+    }
+  },
+  "invoiceSeries": {
+    "title": "Séries de faturação",
+    "description": "Configure os prefixos e a numeração das faturas",
+    "regularInvoices": "Faturas",
+    "creditNotes": "Notas de crédito",
+    "new": "Nova série",
+    "newTitle": "Nova série de {type}",
+    "editTitle": "Editar série",
+    "prefix": "Prefixo",
+    "prefixHint": "Ex.: FT, NC. O ano será acrescentado automaticamente.",
+    "descriptionLabel": "Descrição",
+    "descriptionPlaceholder": "Descrição opcional da série...",
+    "nextNumber": "Próximo número",
+    "preview": "Pré-visualização",
+    "resetYearly": "Reinício anual",
+    "resetYearlyLabel": "Reiniciar a numeração todos os anos",
+    "setAsDefault": "Definir como predefinida",
+    "activeLabel": "Série ativa",
+    "showInactive": "Mostrar inativas",
+    "noItems": "Nenhuma série configurada",
+    "resetCounter": "Reiniciar contador",
+    "currentNumber": "Número atual",
+    "seriesPrefix": "Prefixo da série",
+    "newNumber": "Novo número",
+    "newNumberHint": "O número tem de ser superior ao número mais alto existente nesta série.",
+    "resetWarningTitle": "Aviso",
+    "resetWarning": "Esta ação ficará registada no registo de auditoria e não pode ser anulada.",
+    "confirmReset": "Reiniciar contador",
+    "created": "Série criada com sucesso",
+    "saved": "Série atualizada com sucesso",
+    "resetSuccess": "Contador reiniciado com sucesso"
+  },
+  "documents": {
+    "title": "Documentos",
+    "add": "Adicionar",
+    "edit": "Editar documento",
+    "upload": "Carregar documento",
+    "uploading": "A carregar...",
+    "empty": "Ainda não há documentos",
+    "uploadFirst": "Carregar o primeiro documento",
+    "types": {
+      "consent": "Consentimento",
+      "id_scan": "Documento de identificação",
+      "insurance": "Seguro",
+      "report": "Relatório",
+      "referral": "Referenciação",
+      "other": "Outro"
+    },
+    "fields": {
+      "type": "Tipo",
+      "title": "Título",
+      "titlePlaceholder": "Título do documento",
+      "description": "Descrição",
+      "descriptionPlaceholder": "Notas opcionais"
+    },
+    "dropzone": {
+      "hint": "Arraste um ficheiro para aqui ou clique para selecionar"
+    },
+    "filter": {
+      "allTypes": "Todos os tipos"
+    },
+    "deleteConfirm": {
+      "title": "Eliminar documento",
+      "message": "Tem a certeza de que pretende eliminar este documento? Esta ação não pode ser anulada."
+    },
+    "fetchError": "Erro ao carregar os documentos",
+    "uploadSuccess": "Documento carregado com sucesso",
+    "uploadError": "Erro ao carregar o documento",
+    "downloadError": "Erro ao descarregar o documento",
+    "deleteSuccess": "Documento eliminado",
+    "deleteError": "Erro ao eliminar o documento",
+    "updateSuccess": "Documento atualizado",
+    "updateError": "Erro ao atualizar o documento",
+    "viewer": {
+      "loading": "A carregar o documento...",
+      "error": "Não foi possível carregar o documento",
+      "downloadInstead": "Descarregar em alternativa",
+      "unsupported": "Pré-visualização não disponível para este tipo de ficheiro",
+      "zoomOut": "Reduzir",
+      "zoomIn": "Ampliar",
+      "resetZoom": "Repor a 100%",
+      "zoomHint": "Ctrl + scroll para ampliar"
+    },
+    "typeDesc": {
+      "consent": "Documento assinado",
+      "id_scan": "Cartão de cidadão / passaporte",
+      "insurance": "Apólice ou cartão",
+      "report": "Relatório clínico",
+      "referral": "Carta de referenciação",
+      "other": "Não classificado"
+    },
+    "errors": {
+      "mime": "Tipo de ficheiro não permitido. Apenas PDF, JPG ou PNG.",
+      "size": "O ficheiro excede 10 MB."
+    },
+    "pdfPreviewHint": "Pré-visualização disponível após o carregamento",
+    "uploadHelp": "Classifique o ficheiro para que apareça na categoria correta."
+  },
+  "photoGallery": {
+    "title": "Galeria do paciente",
+    "add": "Adicionar fotografia",
+    "empty": "Ainda não há fotografias",
+    "uploadFirst": "Carregar a primeira",
+    "showingOf": "A mostrar {count} de {total}",
+    "upload": "Carregar fotografia",
+    "uploadHelp": "Classifique para que apareça na categoria correta",
+    "dropHere": "Arraste uma fotografia para aqui ou clique",
+    "category": "Tipo",
+    "subtype": "Vista",
+    "titlePlaceholder": "Intraoral frontal — 02/05",
+    "capturedAt": "Data",
+    "exifHint": "Automático a partir do EXIF",
+    "cat": {
+      "all": "Todas",
+      "intraoral": "Intraoral",
+      "extraoral": "Extraoral",
+      "xray": "Radiografia",
+      "clinical": "Antes/Depois",
+      "other": "Outra"
+    },
+    "catDesc": {
+      "intraoral": "Dentro da boca",
+      "extraoral": "Rosto e perfil",
+      "xray": "Imagem radiológica",
+      "clinical": "Comparação de tratamento",
+      "other": "Não classificada"
+    },
+    "sub": {
+      "frontal": "Frontal",
+      "lateral_left": "Lateral esquerda",
+      "lateral_right": "Lateral direita",
+      "occlusal_upper": "Oclusal superior",
+      "occlusal_lower": "Oclusal inferior",
+      "palatal": "Palatina",
+      "lingual": "Lingual",
+      "smile": "Sorriso",
+      "rest": "Repouso",
+      "frontal_face": "Frontal",
+      "profile_left": "Perfil esquerdo",
+      "profile_right": "Perfil direito",
+      "three_quarter_left": "3/4 esquerdo",
+      "three_quarter_right": "3/4 direito",
+      "panoramic": "Panorâmica",
+      "periapical": "Periapical",
+      "bitewing": "Bitewing",
+      "ceph_lat": "Telerradiografia de perfil",
+      "ceph_pa": "Telerradiografia PA",
+      "cbct": "CBCT",
+      "occlusal_xray": "Radiografia oclusal",
+      "before": "Antes",
+      "after": "Depois",
+      "progress": "Progresso",
+      "reference": "Referência",
+      "portrait": "Retrato",
+      "document_scan": "Documento",
+      "model_photo": "Modelo"
+    },
+    "compare": {
+      "before": "Antes",
+      "after": "Depois"
+    },
+    "pair": {
+      "pickHint": "Escolha a fotografia a emparelhar:",
+      "noCandidates": "Não há fotografias disponíveis. Carregue outra primeiro.",
+      "paired": "Emparelhada",
+      "exitCompare": "Sair da comparação",
+      "compare": "Comparar",
+      "unpair": "Remover",
+      "pair": "Emparelhar antes/depois"
+    }
+  },
+  "help": {
+    "label": "Ajuda",
+    "openHelp": "Abrir ajuda",
+    "drawerTitle": "Ajuda para esta página",
+    "unavailable": "Ainda não há ajuda contextual disponível para esta página.",
+    "openFullManual": "Abrir o manual completo"
+  },
+  "charts": {
+    "trend": {
+      "ariaLabel": "Tendência ao longo de {count} pontos"
+    },
+    "donut": {
+      "ariaLabel": "Gráfico de anel, {count} segmentos"
+    }
+  }
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -116,7 +116,8 @@ export default defineNuxtConfig({
     locales: [
       { code: 'en', name: 'English', file: 'en.json' },
       { code: 'es', name: 'Español', file: 'es.json' },
-      { code: 'fr', name: 'Français', file: 'fr.json' }
+      { code: 'fr', name: 'Français', file: 'fr.json' },
+      { code: 'pt', name: 'Português', file: 'pt.json' }
     ],
     defaultLocale: 'en',
     lazy: true,


### PR DESCRIPTION
Fourth UI language after Spanish, English and French, following the same shape as #103.

## What's in it

**UI locale.** `frontend/i18n/locales/pt.json` (2,336 keys) plus a `pt.json` for each of the eleven module layers, registered in the host and per-module nuxt configs. Key and placeholder parity against `en.json` is exact for every file — verified by script, including plural-pipe forms and `{named}` interpolations.

European Portuguese (pt-PT), with clinical terminology matching the domain: *odontograma*, *cárie*, *restauração*, *endodontia*, *pôntico / pilar de ponte*, *reconvocações*, *orçamento*, *fatura*, *nota de crédito*.

**Nuxt UI locale.** Wired `pt` into `UApp` so date pickers and built-in component strings follow the UI language rather than falling back to English.

**Patient communications.** The clinic-wide communications language now accepts `pt` and offers it in the picker, and all eleven transactional email templates are translated (appointment confirmation / reminder / cancellation, quote sent / accepted, welcome, morning digest, Verifactu certificate expiry and record rejection, incl. the `.txt` parts). These were not optional: `EmailService._render_template` tries `{locale}/ → default/ → root` and there is no `default/`, so a `pt` clinic with untranslated templates would fail to render rather than fall back.

## One bug found along the way

`CatalogItemModal.vue` writes catalog names under the **active** locale (`names[locale.value]`). A treatment created while the UI is in Portuguese is therefore stored as `names.pt`. The backend resolvers only tried `es → en → fr`, so those names would silently degrade to the internal code on invoices, treatment plans, the patient timeline and the copilot tools. Added `pt` to each chain (`billing`, `catalog`, `treatment_plan`, `clinical_notes`, `patient_timeline`) — the same fix #103 applied for French.

## Deliberately not included

Matching how French shipped: the user manual (`docs/user-manual/{en,es}`) and the demo seed data (`--lang es|en|fr`) stay as they are. `demo_data.t()` falls back to English, so `--lang pt` is simply not offered rather than half-working.

## Verification

| Check | Result |
|---|---|
| Backend suite | 834 passed |
| Alembic round-trip | 8 passed |
| Frontend unit tests | 62 passed |
| `ruff check` / `ruff format --check` | clean |
| `eslint` | clean |
| `nuxi prepare` with empty `modules.json` | clean |
| Catalog freshness, docs coverage `--strict`, docs layout | pass |
| Locale parity script (12 files) | 0 missing, 0 extra, 0 placeholder mismatches |

A production build **inside the container**, where the module layers are actually mounted, emits the same 8 `pt-*` chunks as `fr-*` (305,698 vs 308,560 bytes), confirming the per-module locales merge into the `pt` bundle rather than silently dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aeB9zvPvmii3KpWHRzUc4