### PR TITLE
fix(ui): surface the server's message on every failed action

### DIFF
--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the appointment modal and the kanban board (transition, cabinet assign) plus the unconfirmed panel.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - feat(agents): two new copilot tools — `reschedule_appointment` (WRITE,
   wraps `AppointmentService.update_appointment`, surfaces `slot_conflict`
   as a structured error) and `update_appointment_status` (WRITE, wraps

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentKanbanView.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentKanbanView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Appointment, AppointmentStatus } from '~~/app/types'
+import { errorDetail } from '~~/app/utils/error'
 
 interface Cabinet {
   id?: string
@@ -297,16 +298,16 @@ async function onDrop(col: ColumnDef, e: DragEvent, cabinetName?: string) {
     if (target === 'completed') {
       completionFollowup.trigger(apt)
     }
-  } catch {
-    toast.add({ title: t('appointments.transitionFailed'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('appointments.transitionFailed'), description: errorDetail(e), color: 'error' })
   }
 }
 
 async function safeAssign(aptId: string, cabinetId: string | null) {
   try {
     await assignCabinet(aptId, cabinetId)
-  } catch {
-    toast.add({ title: t('appointments.conflict'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('appointments.conflict'), description: errorDetail(e), color: 'error' })
     throw new Error('cabinet_assign_failed')
   }
 }

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
@@ -8,6 +8,7 @@ import type {
 } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { formatLocalDate, isoPartsToDateKey, parseIsoParts } from '../../utils/date'
+import { errorMessage } from '~~/app/utils/error'
 
 const props = defineProps<{
   open: boolean
@@ -589,10 +590,10 @@ async function handleCancel() {
     })
     emit('cancelled', props.appointment.id)
     emit('update:open', false)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('common.serverError'),
+      description: errorMessage(e, t('common.serverError')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/agenda/frontend/components/home/UnconfirmedPanel.vue
+++ b/backend/app/modules/agenda/frontend/components/home/UnconfirmedPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Appointment } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorDetail } from '~~/app/utils/error'
 
 defineProps<{ ctx?: unknown }>()
 
@@ -34,9 +35,10 @@ async function confirm(a: Appointment) {
   try {
     await transition(a.id, 'confirmed')
     removeTomorrowUnconfirmed(a.id)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('dashboard.unconfirmed.confirmError'),
+      description: errorDetail(e),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the invoice pages (issue, void, credit note, send, delete, edit, create) and both PDF downloads.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add `pt` fallback to invoice description resolution in
   service layer so Portuguese-localized treatment names appear on invoices.
 

--- a/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
+++ b/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { InvoiceItem, InvoiceItemCreate, TreatmentCatalogItem, VatType } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const props = defineProps<{
   invoiceId: string
@@ -173,10 +174,10 @@ async function handleSubmit() {
     emit('saved')
     open.value = false
     resetForm()
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: isEditing.value ? t('invoice.errors.update') : t('invoice.errors.create'),
+      description: errorMessage(e, isEditing.value ? t('invoice.errors.update') : t('invoice.errors.create')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/billing/frontend/composables/useInvoices.ts
+++ b/backend/app/modules/billing/frontend/composables/useInvoices.ts
@@ -455,7 +455,10 @@ export function useInvoices() {
     )
 
     if (!response.ok) {
-      throw new Error('Failed to download PDF')
+      // Raw fetch (blob response) bypasses useApi's error shaping — read
+      // the server's message instead of a hardcoded English string.
+      const body = await response.json().catch(() => null)
+      throw new Error(body?.message || body?.detail || 'Failed to download PDF')
     }
 
     const blob = await response.blob()

--- a/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { InvoiceItem, Patient } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const route = useRoute()
 const router = useRouter()
@@ -192,10 +193,10 @@ async function handleSave() {
     })
 
     router.push(`/invoices/${invoiceId.value}`)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.errors.update'),
+      description: errorMessage(e, t('invoice.errors.update')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/billing/frontend/pages/invoices/[id]/index.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/[id]/index.vue
@@ -169,10 +169,10 @@ async function handleVoid() {
       color: 'success'
     })
     await fetchInvoice(invoiceId.value)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.errors.void'),
+      description: errorMessage(e, t('invoice.errors.void')),
       color: 'error'
     })
   } finally {
@@ -222,10 +222,10 @@ async function handleCreateCreditNote() {
     showCreditNoteModal.value = false
     // Navigate to the new credit note
     router.push(`/invoices/${creditNote.id}`)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.errors.createCreditNote'),
+      description: errorMessage(e, t('invoice.errors.createCreditNote')),
       color: 'error'
     })
   } finally {
@@ -261,10 +261,10 @@ async function handleSend() {
       color: 'success'
     })
     showSendModal.value = false
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.errors.send'),
+      description: errorMessage(e, t('invoice.errors.send')),
       color: 'error'
     })
   } finally {
@@ -278,10 +278,10 @@ async function handleDownloadPDF() {
   isDownloadingPdf.value = true
   try {
     await downloadPDF(invoiceId.value, locale.value)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.pdf.downloadError'),
+      description: errorMessage(e, t('invoice.pdf.downloadError')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { BudgetDetail, BudgetItem, InvoiceItemFromBudget, VatType } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -195,10 +196,10 @@ async function handleSubmit() {
     })
 
     router.push(`/invoices/${invoice.id}`)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.errors.create'),
+      description: errorMessage(e, t('invoice.errors.create')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/billing/frontend/pages/invoices/index.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/index.vue
@@ -2,6 +2,7 @@
 import type { InvoiceListItem, InvoiceStatus, PaginatedResponse } from '~~/app/types'
 import { INVOICE_STATUS_ROLE, roleToUiColor } from '~~/app/config/severity'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorMessage } from '~~/app/utils/error'
 
 /**
  * /invoices — list page.
@@ -176,8 +177,8 @@ async function handleDelete(inv: InvoiceListItem, ev: Event) {
   try {
     await deleteInvoice(inv.id)
     toast.add({ title: t('common.success'), description: t('invoice.messages.deleted'), color: 'success' })
-  } catch {
-    toast.add({ title: t('common.error'), description: t('invoice.errors.delete'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorMessage(e, t('invoice.errors.delete')), color: 'error' })
   }
 }
 </script>

--- a/backend/app/modules/billing/frontend/pages/invoices/new.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/new.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { InvoiceItemCreate, Patient, VatType } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -173,10 +174,10 @@ async function handleSubmit() {
       ? `?from=patient&patientId=${route.query.patient_id}`
       : ''
     router.push(`/invoices/${invoice.id}${queryParams}`)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('invoice.errors.create'),
+      description: errorMessage(e, t('invoice.errors.create')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
-- fix(ui): the budget detail page swallowed the API error and always
-  toasted a generic "Error" — every `catch {}` now surfaces the server's
-  message via `errorMessage()`. Reported by users who saw *Error* on
-  *Mark as sent* / *Send email* / *Accept quote* with no way to tell
-  that the real cause was an empty budget or a patient without email.
+- fix(ui): surface the API error instead of a generic toast, across the
+  detail page, the item modal, the new-budget page and the list (delete,
+  PDF). `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Reported by users who saw
+  *Error* on *Mark as sent* / *Send email* / *Accept quote* when the real
+  cause was an empty budget or a patient without email. `downloadPDFAt`
+  also stops throwing a hardcoded English string and reads the response
+  body instead.
 
 - refactor(scheduler): declare the budget cron jobs (`expire_budgets`,
   `send_budget_reminders`, `purge_budget_access_logs`) via

--- a/backend/app/modules/budget/frontend/components/budget/BudgetItemModal.vue
+++ b/backend/app/modules/budget/frontend/components/budget/BudgetItemModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { BudgetItemCreate, TreatmentCatalogItem } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const props = defineProps<{
   open: boolean
@@ -93,10 +94,10 @@ async function handleSubmit() {
 
     emit('added')
     close()
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('budget.errors.create'),
+      description: errorMessage(e, t('budget.errors.create')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/budget/frontend/composables/useBudgets.ts
+++ b/backend/app/modules/budget/frontend/composables/useBudgets.ts
@@ -343,7 +343,11 @@ export function useBudgets() {
     })
 
     if (!response.ok) {
-      throw new Error('Failed to download PDF')
+      // This path uses raw fetch (blob response), so it bypasses useApi
+      // and its error shaping. Read the server's message rather than
+      // throwing a hardcoded English string the UI would then show.
+      const body = await response.json().catch(() => null)
+      throw new Error(body?.message || body?.detail || 'Failed to download PDF')
     }
 
     const blob = await response.blob()

--- a/backend/app/modules/budget/frontend/pages/budgets/[id].vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/[id].vue
@@ -320,10 +320,10 @@ async function handleDownloadPDF() {
 
   try {
     await downloadPDF(currentBudget.value.id, locale.value)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('budget.pdf.downloadError'),
+      description: errorMessage(e, t('budget.pdf.downloadError')),
       color: 'error'
     })
   }

--- a/backend/app/modules/budget/frontend/pages/budgets/index.vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { BudgetListItem, BudgetStatus, ApiResponse, PaginatedResponse } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorMessage } from '~~/app/utils/error'
 
 /**
  * /budgets — list page.
@@ -278,10 +279,10 @@ async function handleDownloadPDF(b: BudgetListItem, ev: Event) {
   ev.stopPropagation()
   try {
     await downloadPDF(b.id, locale.value)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('budget.pdf.downloadError'),
+      description: errorMessage(e, t('budget.pdf.downloadError')),
       color: 'error',
     })
   }
@@ -295,8 +296,8 @@ async function handleDelete(b: BudgetListItem, ev: Event) {
     await deleteBudget(b.id)
     toast.add({ title: t('common.success'), description: t('budget.messages.deleted'), color: 'success' })
     await refresh()
-  } catch {
-    toast.add({ title: t('common.error'), description: t('budget.errors.delete'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorMessage(e, t('budget.errors.delete')), color: 'error' })
   }
 }
 </script>

--- a/backend/app/modules/budget/frontend/pages/budgets/new.vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/new.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Patient, BudgetCreate } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorMessage } from '~~/app/utils/error'
 
 const route = useRoute()
 const router = useRouter()
@@ -67,10 +68,10 @@ async function handleCreate() {
       ? `?from=patient&patientId=${route.query.patient_id}`
       : ''
     router.push(`/budgets/${budget.id}${queryParams}`)
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('budget.errors.create'),
+      description: errorMessage(e, t('budget.errors.create')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the VAT-type composable (load, create, update, delete).
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add `pt` fallback to the agent-tool catalog name resolver so
   Portuguese-localized treatment names resolve.
 

--- a/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
+++ b/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
@@ -4,6 +4,7 @@
  * Handles CRUD operations for VAT types and provides computed helpers.
  */
 import type { VatType, VatTypeCreate, VatTypeUpdate, ApiResponse } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 export function useVatTypes() {
   const api = useApi()
@@ -49,10 +50,10 @@ export function useVatTypes() {
       const params = includeInactive ? '?include_inactive=true' : ''
       const response = await api.get<ApiResponse<VatType[]>>(`/api/v1/catalog/vat-types${params}`)
       vatTypes.value = response.data
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('vatTypes.loadError'),
+        description: errorMessage(e, t('vatTypes.loadError')),
         color: 'red'
       })
     } finally {
@@ -75,10 +76,10 @@ export function useVatTypes() {
         color: 'green'
       })
       return response.data
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('vatTypes.createError'),
+        description: errorMessage(e, t('vatTypes.createError')),
         color: 'red'
       })
       return null
@@ -107,10 +108,10 @@ export function useVatTypes() {
         color: 'green'
       })
       return response.data
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('vatTypes.updateError'),
+        description: errorMessage(e, t('vatTypes.updateError')),
         color: 'red'
       })
       return null
@@ -132,10 +133,10 @@ export function useVatTypes() {
         color: 'green'
       })
       return true
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('vatTypes.deleteError'),
+        description: errorMessage(e, t('vatTypes.deleteError')),
         color: 'red'
       })
       return false

--- a/backend/app/modules/copilot/CHANGELOG.md
+++ b/backend/app/modules/copilot/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the settings panel save.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add Portuguese locale (`pt.json`) with full UI coverage.
 
 - i18n: add French locale (`fr.json`) with full UI coverage.

--- a/backend/app/modules/copilot/frontend/components/CopilotSettingsPanel.vue
+++ b/backend/app/modules/copilot/frontend/components/CopilotSettingsPanel.vue
@@ -2,6 +2,7 @@
 // Copilot settings: morning digest opt-in (+ redaction visibility).
 // Mounted at /settings/integrations/copilot via the settings registry.
 import type { ApiResponse } from '~~/app/types'
+import { errorDetail } from '~~/app/utils/error'
 
 interface CopilotSettings {
   provider: string
@@ -98,8 +99,8 @@ async function save() {
     })
     settings.value = res.data
     toast.add({ title: t('copilot.settings.saved'), color: 'success' })
-  } catch {
-    toast.add({ title: t('common.error'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorDetail(e), color: 'error' })
   } finally {
     isSaving.value = false
   }

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the settings, SMTP and manual-send composables.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add Portuguese locale (`notifications-pt.json`) with full UI coverage.
 
 - i18n: add French locale (`fr.json`) with full UI coverage.

--- a/backend/app/modules/notifications/frontend/composables/useCommunicationsSettings.ts
+++ b/backend/app/modules/notifications/frontend/composables/useCommunicationsSettings.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '~~/app/types'
+import { errorDetail } from '~~/app/utils/error'
 
 export interface CommunicationsSettings {
   language: string
@@ -40,8 +41,8 @@ export function useCommunicationsSettings() {
         color: 'success',
       })
       return true
-    } catch {
-      toast.add({ title: t('errors.updateFailed'), color: 'error' })
+    } catch (e) {
+      toast.add({ title: t('errors.updateFailed'), description: errorDetail(e), color: 'error' })
       return false
     } finally {
       saving.value = false

--- a/backend/app/modules/notifications/frontend/composables/useNotificationSend.ts
+++ b/backend/app/modules/notifications/frontend/composables/useNotificationSend.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ApiResponse, ManualSendResponse } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 export type AppointmentNotificationType
   = 'appointment_confirmation'
@@ -51,10 +52,10 @@ export function useNotificationSend() {
         })
         return false
       }
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.errors.send_failed'),
+        description: errorMessage(e, t('notifications.errors.send_failed')),
         color: 'error'
       })
       return false

--- a/backend/app/modules/notifications/frontend/composables/useNotificationSettings.ts
+++ b/backend/app/modules/notifications/frontend/composables/useNotificationSettings.ts
@@ -4,6 +4,7 @@
  * Provides methods to fetch, update, and test notification configuration.
  */
 
+import { errorMessage } from '~~/app/utils/error'
 import type {
   ApiResponse,
   ClinicNotificationSettings,
@@ -82,10 +83,10 @@ export function useNotificationSettings() {
         '/api/v1/notifications/settings'
       )
       settings.value = response.data
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.errors.fetch_failed'),
+        description: errorMessage(e, t('notifications.errors.fetch_failed')),
         color: 'error'
       })
     } finally {
@@ -110,10 +111,10 @@ export function useNotificationSettings() {
         color: 'success'
       })
       return true
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.errors.save_failed'),
+        description: errorMessage(e, t('notifications.errors.save_failed')),
         color: 'error'
       })
       return false
@@ -147,10 +148,10 @@ export function useNotificationSettings() {
         })
         return false
       }
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.errors.test_failed'),
+        description: errorMessage(e, t('notifications.errors.test_failed')),
         color: 'error'
       })
       return false
@@ -183,10 +184,10 @@ export function useNotificationSettings() {
         })
         return false
       }
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.errors.send_failed'),
+        description: errorMessage(e, t('notifications.errors.send_failed')),
         color: 'error'
       })
       return false
@@ -257,10 +258,10 @@ export function useNotificationSettings() {
         '/api/v1/notifications/smtp-settings'
       )
       smtpSettings.value = response.data
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.smtp.errors.fetch_failed'),
+        description: errorMessage(e, t('notifications.smtp.errors.fetch_failed')),
         color: 'error'
       })
     } finally {
@@ -285,10 +286,10 @@ export function useNotificationSettings() {
         color: 'success'
       })
       return true
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.smtp.errors.save_failed'),
+        description: errorMessage(e, t('notifications.smtp.errors.save_failed')),
         color: 'error'
       })
       return false
@@ -324,10 +325,10 @@ export function useNotificationSettings() {
         })
         return false
       }
-    } catch {
+    } catch (e) {
       toast.add({
         title: t('common.error'),
-        description: t('notifications.smtp.errors.test_failed'),
+        description: errorMessage(e, t('notifications.smtp.errors.test_failed')),
         color: 'error'
       })
       return false

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the recall row (no-answer, snooze), the settings panel and the attempt form.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add Portuguese locale (`pt.json`) with full UI coverage.
 
 - i18n: correct French wording in seed note (Contrôle mensuel).

--- a/backend/app/modules/recalls/frontend/components/LogAttemptForm.vue
+++ b/backend/app/modules/recalls/frontend/components/LogAttemptForm.vue
@@ -5,6 +5,7 @@ import type {
   RecallOutcome,
   RecallContactAttempt
 } from '../composables/useRecalls'
+import { errorDetail } from '~~/app/utils/error'
 
 interface Props {
   recallId: string
@@ -55,8 +56,8 @@ async function submit() {
       note: note.value || null
     })
     emit('logged', res.data)
-  } catch {
-    toast.add({ title: t('common.error'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorDetail(e), color: 'error' })
   } finally {
     isSubmitting.value = false
   }

--- a/backend/app/modules/recalls/frontend/components/RecallRow.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { Recall } from '../composables/useRecalls'
+import { errorDetail } from '~~/app/utils/error'
 
 interface Props { recall: Recall }
 const props = defineProps<Props>()
@@ -50,8 +51,8 @@ async function quickNoAnswer() {
     })
     const updated = await recallsApi.get(props.recall.id)
     emit('changed', updated.data)
-  } catch {
-    toast.add({ title: t('common.error'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorDetail(e), color: 'error' })
   } finally {
     isBusy.value = false
   }
@@ -70,8 +71,8 @@ async function snooze() {
     const res = await recallsApi.snooze(props.recall.id, snoozeMonths.value)
     snoozeOpen.value = false
     emit('changed', res.data)
-  } catch {
-    toast.add({ title: t('common.error'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorDetail(e), color: 'error' })
   } finally {
     isBusy.value = false
   }

--- a/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
 import type { RecallSettings } from '../composables/useRecalls'
+import { errorDetail } from '~~/app/utils/error'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -47,8 +48,8 @@ async function save() {
     })
     settings.value = res.data
     toast.add({ title: t('recalls.settings.saved'), color: 'success' })
-  } catch {
-    toast.add({ title: t('common.error'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorDetail(e), color: 'error' })
   } finally {
     isSaving.value = false
   }

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the clinic-hours and professional-hours settings pages.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add Portuguese locale (`pt.json`) with full UI coverage.
 
 - i18n: add French locale (`fr.json`) with full UI coverage.

--- a/backend/app/modules/schedules/frontend/components/settings/ClinicHoursPage.vue
+++ b/backend/app/modules/schedules/frontend/components/settings/ClinicHoursPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ClinicHours, ClinicOverride, ClinicOverridePayload, WeekdayShifts } from '../../composables/useClinicHours'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorDetail } from '~~/app/utils/error'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -60,8 +61,8 @@ async function save() {
     hours.value = updated
     days.value = updated.days
     toast.add({ title: t('schedules.clinicHours.saved'), color: 'success' })
-  } catch {
-    toast.add({ title: t('schedules.clinicHours.savedError'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('schedules.clinicHours.savedError'), description: errorDetail(e), color: 'error' })
   } finally {
     isSaving.value = false
   }

--- a/backend/app/modules/schedules/frontend/components/settings/ProfessionalSchedulesPage.vue
+++ b/backend/app/modules/schedules/frontend/components/settings/ProfessionalSchedulesPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ProfessionalHours, ProfessionalOverride, ProfessionalOverridePayload, WeekdayShifts } from '../../composables/useProfessionalHours'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorDetail } from '~~/app/utils/error'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -79,8 +80,8 @@ async function save() {
     hours.value = updated
     days.value = updated.days
     toast.add({ title: t('schedules.professionalHours.saved'), color: 'success' })
-  } catch {
-    toast.add({ title: t('common.error'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('common.error'), description: errorDetail(e), color: 'error' })
   } finally {
     isSaving.value = false
   }

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the plans list delete.
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add `pt` fallback to plan item name resolution in service
   layer so Portuguese-localized treatment names display correctly.
 

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/PlansListPanel.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/PlansListPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TreatmentPlan, TreatmentPlanStatus } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorMessage } from '~~/app/utils/error'
 
 const props = defineProps<{
   q: string
@@ -73,10 +74,10 @@ async function handleDelete(plan: TreatmentPlan, event: Event) {
       description: t('treatmentPlans.messages.deleted'),
       color: 'success',
     })
-  } catch {
+  } catch (e) {
     toast.add({
       title: t('common.error'),
-      description: t('treatmentPlans.errors.delete'),
+      description: errorMessage(e, t('treatmentPlans.errors.delete')),
       color: 'error',
     })
   }

--- a/backend/app/modules/whatsapp_kapso/CHANGELOG.md
+++ b/backend/app/modules/whatsapp_kapso/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(ui): surface the API error instead of a generic toast in the settings page (save, sync, map, test).
+  `catch {}` discarded the server's message, so any failure read as
+  "Error" with no way to tell what went wrong. Now via
+  `errorMessage()` / `errorDetail()`.
+
 - i18n: add Portuguese locale (`pt.json`) with full UI coverage.
 
 - i18n: add French locale (`fr.json`) with full UI coverage.

--- a/backend/app/modules/whatsapp_kapso/frontend/components/KapsoSettingsPage.vue
+++ b/backend/app/modules/whatsapp_kapso/frontend/components/KapsoSettingsPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useKapso } from '../composables/useKapso'
+import { errorDetail } from '~~/app/utils/error'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -55,8 +56,8 @@ async function onSave() {
     form.api_key = ''
     form.webhook_secret = ''
     toast.add({ title: t('whatsapp_kapso.saved'), color: 'success' })
-  } catch {
-    toast.add({ title: t('whatsapp_kapso.saveError'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('whatsapp_kapso.saveError'), description: errorDetail(e), color: 'error' })
   }
 }
 
@@ -64,8 +65,8 @@ async function onSync() {
   try {
     const list = await syncTemplates()
     toast.add({ title: t('whatsapp_kapso.synced', { n: list.length }), color: 'success' })
-  } catch {
-    toast.add({ title: t('whatsapp_kapso.syncError'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('whatsapp_kapso.syncError'), description: errorDetail(e), color: 'error' })
   }
 }
 
@@ -74,8 +75,8 @@ async function onMap() {
   try {
     await mapTemplate(mapping.notification_type, mapping.locale, mapping.template_name)
     toast.add({ title: t('whatsapp_kapso.mapped'), color: 'success' })
-  } catch {
-    toast.add({ title: t('whatsapp_kapso.mapError'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('whatsapp_kapso.mapError'), description: errorDetail(e), color: 'error' })
   }
 }
 
@@ -85,8 +86,8 @@ async function onTest() {
     const res = await testConnection(test.to_number, test.template_name, test.language)
     if (res.success) toast.add({ title: t('whatsapp_kapso.testOk'), color: 'success' })
     else toast.add({ title: t('whatsapp_kapso.testFail'), description: res.error ?? '', color: 'error' })
-  } catch {
-    toast.add({ title: t('whatsapp_kapso.testFail'), color: 'error' })
+  } catch (e) {
+    toast.add({ title: t('whatsapp_kapso.testFail'), description: errorDetail(e), color: 'error' })
   }
 }
 

--- a/frontend/app/utils/error.ts
+++ b/frontend/app/utils/error.ts
@@ -9,11 +9,24 @@
  */
 export function errorMessage(e: unknown, fallback: string): string {
   if (typeof e === 'object' && e !== null) {
-    const obj = e as { data?: { detail?: unknown, message?: string }, message?: string }
-    if (typeof obj.data?.detail === 'string') return obj.data.detail
-    return obj.data?.message ?? obj.message ?? fallback
+    return errorDetail(e) ?? (e as { message?: string }).message ?? fallback
   }
   return fallback
+}
+
+/**
+ * The server's own explanation, or `undefined` when the failure carries
+ * none (network drop, thrown `Error`). Use it as a toast `description`
+ * under an already-localized `title`: passing `undefined` leaves the
+ * toast exactly as it was before, so a generic title never gains an
+ * empty second line.
+ */
+export function errorDetail(e: unknown): string | undefined {
+  if (typeof e !== 'object' || e === null) return undefined
+  const obj = e as { data?: { detail?: unknown, message?: unknown } }
+  if (typeof obj.data?.detail === 'string') return obj.data.detail
+  if (typeof obj.data?.message === 'string') return obj.data.message
+  return undefined
 }
 
 export function errorStatus(e: unknown): number | undefined {

--- a/frontend/tests/utils/error.test.ts
+++ b/frontend/tests/utils/error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { errorMessage } from '~/utils/error'
+import { errorDetail, errorMessage } from '~/utils/error'
 
 describe('errorMessage', () => {
   it('surfaces the backend message from an ErrorResponse body', () => {
@@ -21,5 +21,20 @@ describe('errorMessage', () => {
   it('falls back for network errors and non-objects', () => {
     expect(errorMessage(new TypeError('Failed to fetch'), 'fallback')).toBe('Failed to fetch')
     expect(errorMessage(undefined, 'fallback')).toBe('fallback')
+  })
+})
+
+describe('errorDetail', () => {
+  it('returns the server message', () => {
+    expect(errorDetail({ data: { message: 'Cannot send empty budget' } })).toBe('Cannot send empty budget')
+    expect(errorDetail({ data: { detail: 'Patient has no email address' } })).toBe('Patient has no email address')
+  })
+
+  it('returns undefined when the failure carries no server message', () => {
+    // Used as a toast `description`, so undefined must stay undefined:
+    // an empty string would render a blank second line under the title.
+    expect(errorDetail(new TypeError('Failed to fetch'))).toBeUndefined()
+    expect(errorDetail({ statusCode: 422, data: { detail: [{ msg: 'field required' }] } })).toBeUndefined()
+    expect(errorDetail(undefined)).toBeUndefined()
   })
 })


### PR DESCRIPTION
Reopened continuation of #149 (auto-closed when its stacked base branch was deleted on merging #148). Same content, rebased onto main.

#148 fixed the 6 error-swallowing handlers on the budget detail page. This does the other **43**, found by grepping every `catch {}` whose next line opens a `toast.add` — invoices, appointments, recalls, schedules, VAT types, notifications, treatment plans, WhatsApp settings.

- Toasts that already had a `description` wrap it in `errorMessage(e, <old fallback>)`.
- Title-only toasts gain `description: errorDetail(e)` — a new extractor that returns the server's message or `undefined`, so they stay byte-identical when the failure carries no server message.
- Both raw-fetch PDF download paths (`useBudgets`, `useInvoices`) read the response body instead of throwing a hardcoded English string.
- Left alone: `EntityInfoCard` (clipboard) and `OdontogramChart` (local validation).

⚠️ Found while doing this (fixed in the follow-up PR): eslint never sees `backend/app/modules/*/frontend/**` — outside its base path, exits 0. Two broken imports passed `npm run lint`; caught by parsing every touched script with the TS compiler.

Tests: `errorMessage`/`errorDetail` covered in `frontend/tests/utils/error.test.ts` (68 total pass). CHANGELOG updated in all 10 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)