### PR TITLE
fix: i18n: add Polish locale to schedules and periodontogram module…

### DIFF
--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Polish locale (`pl.json`) with full UI coverage.
+
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/periodontogram/frontend/nuxt.config.ts
+++ b/backend/app/modules/periodontogram/frontend/nuxt.config.ts
@@ -13,7 +13,8 @@ export default defineNuxtConfig({
       { code: 'es', file: 'es.json' },
       { code: 'fr', file: 'fr.json' },
       { code: 'pt', file: 'pt.json' },
-      { code: 'ta', file: 'ta.json' }
+      { code: 'ta', file: 'ta.json' },
+      { code: 'pl', file: 'pl.json' }
     ],
     langDir: 'locales'
   }

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- i18n: add Polish locale (`pl.json`) with full UI coverage.leased
+
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/schedules/frontend/nuxt.config.ts
+++ b/backend/app/modules/schedules/frontend/nuxt.config.ts
@@ -14,7 +14,8 @@ export default defineNuxtConfig({
       { code: 'es', file: 'es.json' },
       { code: 'fr', file: 'fr.json' },
       { code: 'pt', file: 'pt.json' },
-      { code: 'ta', file: 'ta.json' }
+      { code: 'ta', file: 'ta.json' },
+      { code: 'pl', file: 'pl.json' }
     ],
     langDir: 'locales'
   }


### PR DESCRIPTION
Fixes #144

Add Polish (pl) locale to schedules and periodontogram module layer i18n config and update changelogs

No local test suite detected.

---
This change was prepared with AI assistance under human direction and review.