### PR TITLE
fix: i18n(clinical_notes): add Italian locale to module i18n config

### DIFF
--- a/backend/app/modules/clinical_notes/frontend/nuxt.config.ts
+++ b/backend/app/modules/clinical_notes/frontend/nuxt.config.ts
@@ -13,6 +13,7 @@ export default defineNuxtConfig({
       { code: 'en', file: 'en.json' },
       { code: 'es', file: 'es.json' },
       { code: 'fr', file: 'fr.json' },
+      { code: 'it', file: 'it.json' },
       { code: 'pt', file: 'pt.json' },
       { code: 'ta', file: 'ta.json' }
     ],


### PR DESCRIPTION
Fixes #132

Add Italian locale to clinical_notes module i18n config (partial fix — core frontend files and other module configs not shown in provided CODE)

No local test suite detected.

---
This change was prepared with AI assistance under human direction and review.