### PR TITLE
fix(budget): honour explicit null when updating a budget item

### DIFF
--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -9,6 +9,12 @@
   `net_line_amount` are the single proration formula; `BudgetDetailResponse`
   exposes `items[].global_discount_share` for the invoice wizard.
 
+- fix(items): `PUT /budgets/{id}/items/{item_id}` now honours an explicit
+  `null` on nullable fields (`discount_type`, `discount_value`,
+  `tooth_number`, `surfaces`, `notes`) — clearing a line discount was
+  silently ignored and totals stayed wrong. `null` on NOT NULL fields is
+  still ignored.
+
 - fix(workflow): plan ↔ budget lifecycle desync (issue #162).
   `cancel_budget` now publishes `budget.cancelled` (with `plan_id`) so a
   directly-cancelled quote reopens its pending plan instead of leaving it

--- a/backend/app/modules/budget/service.py
+++ b/backend/app/modules/budget/service.py
@@ -85,6 +85,12 @@ class BudgetNumberService:
         return f"{year_prefix}{sequence:04d}"
 
 
+# BudgetItem columns that may be cleared with an explicit ``null`` on update.
+_CLEARABLE_ITEM_FIELDS = frozenset(
+    {"discount_type", "discount_value", "tooth_number", "surfaces", "notes"}
+)
+
+
 class BudgetItemService:
     """Service for budget item operations."""
 
@@ -150,10 +156,19 @@ class BudgetItemService:
         item: BudgetItem,
         data: dict,
     ) -> BudgetItem:
-        """Update a budget item."""
+        """Update a budget item.
+
+        ``data`` comes from ``model_dump(exclude_unset=True)``: a key present
+        with ``None`` is an explicit clear. Honoured only for nullable
+        columns — ``None`` on a NOT NULL field (quantity, unit_price,
+        display_order) is ignored rather than turned into a DB error.
+        """
         for key, value in data.items():
-            if value is not None and hasattr(item, key):
-                setattr(item, key, value)
+            if not hasattr(item, key):
+                continue
+            if value is None and key not in _CLEARABLE_ITEM_FIELDS:
+                continue
+            setattr(item, key, value)
 
         # Recalculate line totals
         BudgetItemService._calculate_line_totals(item)

--- a/backend/tests/test_budget.py
+++ b/backend/tests/test_budget.py
@@ -391,6 +391,49 @@ async def test_item_with_discount(
     assert float(data["line_total"]) == 90.00
 
 
+@pytest.mark.asyncio
+async def test_update_item_explicit_null_clears_discount(
+    client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
+):
+    """PUT with ``discount_*: null`` clears the line discount and totals follow;
+    ``null`` on a NOT NULL field (quantity) is ignored, not applied."""
+    create_response = await client.post(
+        "/api/v1/budget/budgets",
+        json={"patient_id": budget_clinic_setup["patient_id"], "valid_from": "2024-01-01"},
+        headers=auth_headers,
+    )
+    budget_id = create_response.json()["data"]["id"]
+    item = await client.post(
+        f"/api/v1/budget/budgets/{budget_id}/items",
+        json={
+            "catalog_item_id": budget_clinic_setup["catalog_item_id"],
+            "quantity": 1,
+            "discount_type": "percentage",
+            "discount_value": 10,
+            "notes": "keep me",
+        },
+        headers=auth_headers,
+    )
+    item_id = item.json()["data"]["id"]
+
+    r = await client.put(
+        f"/api/v1/budget/budgets/{budget_id}/items/{item_id}",
+        json={"discount_type": None, "discount_value": None, "quantity": None},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+    assert data["discount_type"] is None
+    assert data["discount_value"] is None
+    assert float(data["line_discount"]) == 0.00
+    assert float(data["line_total"]) == 100.00
+    assert data["quantity"] == 1  # null on NOT NULL field ignored
+    assert data["notes"] == "keep me"  # omitted field untouched
+
+    budget = await client.get(f"/api/v1/budget/budgets/{budget_id}", headers=auth_headers)
+    assert float(budget.json()["data"]["total"]) == 100.00
+
+
 # ============================================================================
 # Workflow Tests
 # ============================================================================


### PR DESCRIPTION
Follow-up surfaced while working on #167 / #171.

`BudgetItemService.update_item` skipped every `None` in the payload, but the router sends `model_dump(exclude_unset=True)`, so an explicit `"discount_value": null` (or clearing `notes`, `tooth_number`, `surfaces`) was silently ignored — the line kept its discount and the budget totals stayed wrong. Not user-visible today (the UI has no line edit), API-only.

- Explicit `null` now clears the nullable columns (`discount_type`, `discount_value`, `tooth_number`, `surfaces`, `notes`).
- `null` on NOT NULL fields (`quantity`, `unit_price`, `display_order`) is still ignored instead of becoming a DB error.
- Test: clear a 10 % line discount → `line_discount 0`, `line_total 100`, budget total 100; `quantity: null` ignored; omitted fields untouched.
- `tests/test_budget.py` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)