### PR TITLE
fix(frontend): bake every module layer into the prod build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,19 @@ jobs:
       - name: Seed demo data
         run: ./scripts/seed-demo.sh --lang es
 
+      - name: Install optional modules covered by e2e
+        # `periodontogram` ships `auto_install=False`; its spec assumes an
+        # operator installed it. Pending installs apply on backend boot.
+        run: |
+          docker compose exec -T backend python -m app.cli modules install periodontogram
+          docker compose restart backend
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8000/health > /dev/null; then
+              echo "backend ready"; break
+            fi
+            sleep 2
+          done
+
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -12,6 +12,16 @@ COPY backend/app/modules /module_layers
 
 COPY frontend/ ./
 
+# Bake every module layer. The committed modules.json only mirrors the
+# dev checkout's installed set; a prod image can't rebuild when a module
+# is installed later, so ship all layers and let the backend's
+# `/modules/-/active` decide what is visible at runtime.
+RUN node -e 'const fs=require("fs");\
+  const names=fs.readdirSync("/module_layers").filter(n=>fs.existsSync(`/module_layers/${n}/frontend/nuxt.config.ts`)).sort();\
+  const modules=names.map(name=>({name,path:`/module_layers/${name}/frontend`}));\
+  fs.writeFileSync("modules.json",JSON.stringify({layers:modules.map(m=>m.path),modules,version:1},null,2));\
+  console.log("modules.json:",names.join(", "))'
+
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 

--- a/frontend/app/composables/usePermissions.ts
+++ b/frontend/app/composables/usePermissions.ts
@@ -4,16 +4,30 @@ export function usePermissions() {
   const auth = useAuth()
   const permissions = computed<string[]>(() => auth.permissions.value ?? [])
 
+  // Layers baked into this build vs modules the backend reports as
+  // installed. `/me` grants permissions for every *registered* module
+  // (installed or not), so gate here: a baked layer whose module isn't
+  // active contributes no permission → its pages/slots/settings hide.
+  // Unknown until the active list loads (null) → no gate.
+  const builtLayers = new Set(useRuntimeConfig().public.moduleLayers as string[])
+  const active = useActiveModulesState()
+
+  function moduleActive(permission: string): boolean {
+    const ns = permission.split('.')[0] ?? ''
+    if (!builtLayers.has(ns) || !active.value) return true
+    return active.value.some(m => m.name === ns)
+  }
+
   function can(permission: string): boolean {
-    return permissions.value.includes(permission)
+    return moduleActive(permission) && permissions.value.includes(permission)
   }
 
   function canAny(perms: string[]): boolean {
-    return perms.some(p => permissions.value.includes(p))
+    return perms.some(can)
   }
 
   function canAll(perms: string[]): boolean {
-    return perms.every(p => permissions.value.includes(p))
+    return perms.every(can)
   }
 
   const isAdmin = computed(() => can(PERMISSIONS.users.write))

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -9,22 +9,25 @@ import { resolve } from 'node:path'
  * `manifest.frontend.layer_path` is installed. When absent (fresh
  * checkout, no community modules yet), returns an empty array.
  */
-function loadModuleLayers(): string[] {
+function loadModuleLayers(): { layers: string[], names: string[] } {
   const path = resolve(__dirname, 'modules.json')
   try {
     const raw = readFileSync(path, 'utf-8')
-    const payload = JSON.parse(raw) as { layers?: string[] }
-    return Array.isArray(payload.layers) ? payload.layers : []
+    const payload = JSON.parse(raw) as { layers?: string[], modules?: { name: string }[] }
+    return {
+      layers: Array.isArray(payload.layers) ? payload.layers : [],
+      names: Array.isArray(payload.modules) ? payload.modules.map(m => m.name) : []
+    }
   } catch (err: unknown) {
     const code = (err as { code?: string }).code
     if (code !== 'ENOENT') {
       console.warn('[nuxt.config] modules.json is malformed, using empty layers:', err)
     }
-    return []
+    return { layers: [], names: [] }
   }
 }
 
-const moduleLayers = loadModuleLayers()
+const { layers: moduleLayers, names: moduleLayerNames } = loadModuleLayers()
 const modulesJsonPath = resolve(__dirname, 'modules.json')
 
 export default defineNuxtConfig({
@@ -75,7 +78,11 @@ export default defineNuxtConfig({
       demoMode: process.env.NUXT_PUBLIC_DEMO_MODE === 'true',
       // Documentation portal origin used by the in-app help drawer
       // (Fase 5 of issue #75). Empty disables the help button.
-      docsUrl: process.env.NUXT_PUBLIC_DOCS_URL || 'https://docs.dentalpin.com'
+      docsUrl: process.env.NUXT_PUBLIC_DOCS_URL || 'https://docs.dentalpin.com',
+      // Module layers baked into this build. `usePermissions().can()`
+      // hides their permissions while the backend reports the module as
+      // not installed (prod bakes every layer — see Dockerfile.prod).
+      moduleLayers: moduleLayerNames
     }
   },
   srcDir: 'app',


### PR DESCRIPTION
## Problem
The demo sidebar showed a raw `nav.accountingExport` label and `/accounting-export` returned 404. `accounting_export` is installed on the demo backend, but the prod frontend image was built with the committed `frontend/modules.json` — a snapshot of the dev checkout's installed set — so the module's Nuxt layer (page + i18n) never shipped. Any module installed after the image is built hits the same wall.

## Fix
- `frontend/Dockerfile.prod`: generate `modules.json` from every `backend/app/modules/*/frontend` before `npm run build`. Prod always ships all layers; the backend's `/modules/-/active` decides what is visible.
- `frontend/nuxt.config.ts`: expose baked layer names via `runtimeConfig.public.moduleLayers`.
- `usePermissions().can()`: returns `false` for a permission whose namespace is a baked layer the backend does not report as active. Needed because `/me` grants permissions for every *registered* module (installed or not) — otherwise admins would see settings cards/slots for uninstalled modules (gap noted in `docs/technical/audit-2026-07-03.md`).

## Verified locally
- 22 layers baked + modules uninstalled → "Kapso WhatsApp" / "Data migration" settings cards hidden; disabling the gate makes them reappear.
- Installing `accounting_export` → sidebar shows the translated label and `/accounting-export` renders.
- eslint OK, vitest composables OK, `nuxi typecheck` adds no new errors.

Deploy: merging triggers the Coolify rebuild (`docker-compose.coolify.yml` → `frontend/Dockerfile.prod`), which fixes the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)